### PR TITLE
incus/remote: Add "get-client-certificate" and "get-client-token"

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -757,15 +757,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr "<alter Alias> <neuer Alias>"
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr "<Ziel>"
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr "Ein Client Zertifikat ist bereits erstellt worden"
 
@@ -839,12 +839,12 @@ msgstr "APP"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "Authentifizierungstyp"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "Akzeptiere das Zertifikat"
 
@@ -915,11 +915,11 @@ msgstr "Mitglied zu einer Gruppe hinzufügen"
 msgid "Add new aliases"
 msgstr "Erstelle neue Aliasse"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Alle Projekte"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr "Alle Server Adressen sind nicht erreichbar"
 
@@ -1165,7 +1165,7 @@ msgstr ""
 "interagieren,\n"
 "sowie bereits vorhandene Protokolleinträge (logs) einzusehen."
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Authentifizierungstyp '%s' wird nicht vom Server unterstützt"
@@ -1189,7 +1189,7 @@ msgstr "automatisches Update: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr "Automatischer Modus (nicht-interaktiv)"
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr "Verfügbare Projekte:"
 
@@ -1394,7 +1394,7 @@ msgstr "Kann nicht aus der Umgebungsdatei lesen: %w"
 msgid "Can't read from stdin: %w"
 msgstr "Kann nicht von stdin lesen: %w"
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1502,7 +1502,7 @@ msgstr "\"Zertifikat-Token für %s gelöscht\""
 msgid "Certificate description"
 msgstr "Fingerprint des Zertifikats: %s"
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1514,7 +1514,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerprint des Zertifikats: %s"
@@ -1538,7 +1538,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr "Client-Zertifikat wird nun vom Server als vertrauenswürdig behandelt:"
 
@@ -1648,7 +1648,7 @@ msgstr "Clustering aktiviert"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1851,12 +1851,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1885,7 +1885,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -2380,10 +2380,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2820,7 +2820,7 @@ msgstr "Alternatives config Verzeichnis."
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3293,7 +3293,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -3312,7 +3312,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3342,7 +3342,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -3357,7 +3357,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to create backup: %v"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3387,7 +3387,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3510,7 +3510,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3638,7 +3638,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3689,7 +3689,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3701,16 +3701,31 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "Akzeptiere Zertifikat"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -4243,7 +4258,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid URL %q: %w"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -4364,7 +4379,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid peer type"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -5280,11 +5295,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5713,7 +5728,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5726,7 +5741,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr "Veröffentliche Abbild"
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -6123,7 +6138,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -6158,7 +6173,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -6222,7 +6237,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -6540,7 +6555,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -6640,11 +6655,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6697,7 +6712,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
@@ -6707,7 +6722,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Please provide join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6780,6 +6795,11 @@ msgstr ""
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr ""
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "Ein Client Zertifikat ist bereits erstellt worden"
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -6904,7 +6924,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Project description"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6931,7 +6951,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -7055,37 +7075,37 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -7178,7 +7198,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -7257,7 +7277,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -7444,7 +7464,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -7504,15 +7524,15 @@ msgstr ""
 msgid "Serial: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -7523,7 +7543,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7779,7 +7799,7 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -8092,7 +8112,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -8382,7 +8402,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8820,7 +8840,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -8864,7 +8884,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8909,7 +8929,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
@@ -8932,7 +8952,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -9458,7 +9478,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -10837,7 +10857,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -10859,7 +10879,7 @@ msgstr ""
 msgid "application"
 msgstr "Eigenschaften:\n"
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -11593,7 +11613,7 @@ msgstr ""
 msgid "info"
 msgstr "Info"
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr "n"
 
@@ -11606,7 +11626,7 @@ msgstr "Name"
 msgid "no"
 msgstr "nein"
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 #, fuzzy
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (j/n/[fingerprint])?"
@@ -11640,7 +11660,7 @@ msgstr "nicht erreichbar"
 msgid "used by"
 msgstr "wird benutzt von"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr "j"
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -754,15 +754,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -790,7 +790,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -828,11 +828,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
@@ -901,11 +901,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1115,7 +1115,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1138,7 +1138,7 @@ msgstr "Auto actualización: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr ""
 
@@ -1345,7 +1345,7 @@ msgstr "No se peude leer desde stdin: %s"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1440,7 +1440,7 @@ msgstr "Perfil %s eliminado"
 msgid "Certificate description"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1452,7 +1452,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1476,7 +1476,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1587,7 +1587,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1779,12 +1779,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1813,7 +1813,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -2293,10 +2293,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2710,7 +2710,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3122,7 +3122,7 @@ msgstr "Acepta certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -3171,7 +3171,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -3186,7 +3186,7 @@ msgstr "Acepta certificado"
 msgid "Failed to create backup: %v"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
@@ -3216,7 +3216,7 @@ msgstr "Acepta certificado"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3339,7 +3339,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -3464,7 +3464,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3515,7 +3515,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3527,16 +3527,31 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "Acepta certificado"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -4060,7 +4075,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid URL %q: %w"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -4178,7 +4193,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -5086,11 +5101,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5494,7 +5509,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5506,7 +5521,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5896,7 +5911,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5931,7 +5946,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5993,7 +6008,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -6304,7 +6319,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -6401,11 +6416,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6457,7 +6472,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6466,7 +6481,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6539,6 +6554,11 @@ msgstr ""
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr ""
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "Certificado del cliente almacenado en el servidor: "
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -6662,7 +6682,7 @@ msgstr ""
 msgid "Project description"
 msgstr "Descripción"
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6688,7 +6708,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6808,37 +6828,37 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6925,7 +6945,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -7001,7 +7021,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -7186,7 +7206,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -7242,15 +7262,15 @@ msgstr "Dispositivo: %s"
 msgid "Serial: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -7259,7 +7279,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7504,7 +7524,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7801,7 +7821,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -8082,7 +8102,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8513,7 +8533,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Contraseña admin para %s: "
@@ -8558,7 +8578,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8601,7 +8621,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8623,7 +8643,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -9129,7 +9149,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9993,7 +10013,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -10007,7 +10027,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -10600,7 +10620,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr ""
 
@@ -10613,7 +10633,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -10646,7 +10666,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -757,15 +757,15 @@ msgstr "<local|global> <requête>"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr "<serveur_distant>"
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr "<serveur_distant> <URL>"
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr "<serveur distant> <nouveau nom>"
 
@@ -793,7 +793,7 @@ msgstr "<cible>"
 msgid "=> Query %d:"
 msgstr "=> Requête %d:"
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr "Un certificat client est déjà présent"
 
@@ -830,11 +830,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr "TYPE D'AUTHENTIFICATION"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -901,11 +901,11 @@ msgstr "Ajoutez des membres à un groupe"
 msgid "Add new aliases"
 msgstr "Ajouter de nouveaux alias"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1056,7 +1056,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Tous les projets"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr "Toutes les adresses serveurs sont indisponibles"
 
@@ -1138,7 +1138,7 @@ msgstr ""
 "instance\n"
 "ainsi qu'a récupérer les logs précédents"
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1162,7 +1162,7 @@ msgstr "Mise à jour auto : %s"
 msgid "Automatic (non-interactive) mode"
 msgstr "Mode automatique (non-interactif)"
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr "Projets disponibles :"
 
@@ -1370,7 +1370,7 @@ msgstr "Impossible de lire depuis le fichier d'environnement : %w"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %w"
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr "Impossible de supprimer le serveur distant par défaut"
 
@@ -1473,7 +1473,7 @@ msgstr "Jeton d'ajout du certificat pour %s supprimé"
 msgid "Certificate description"
 msgstr "Empreinte du certificat : %s"
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1488,7 +1488,7 @@ msgstr ""
 "Incompatibilité d'empreinte de certificat entre le jeton et le membre du "
 "cluster %q"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1512,7 +1512,7 @@ msgstr "Choisir %s:"
 msgid "Client %s certificate add token:"
 msgstr "Jeton d'ajout du certificat pour le client %s  :"
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client approuvé par le serveur :"
 
@@ -1622,7 +1622,7 @@ msgstr "Clustering activé"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1836,12 +1836,12 @@ msgstr "Coeur %d"
 msgid "Cores:"
 msgstr "Cœurs : %v"
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de fermer le fichier de certificat serveur %q: %w"
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1872,7 +1872,7 @@ msgstr ""
 "Impossible d'écrire un nouveau certificat pour le serveur distant '%s' suite "
 "à l'erreur : %v"
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible d'écrire le fichier de certificat serveur %q: %w"
@@ -2392,10 +2392,10 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2825,7 +2825,7 @@ msgstr "Clé de configuration invalide"
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3325,7 +3325,7 @@ msgstr "Échec du démarrage de sshfs : %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec de l'acceptation de la connexion entrante : %w"
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr "Échec de l'ajout d'un serveur distant"
 
@@ -3344,7 +3344,7 @@ msgstr "Impossible de vérifier que le démon est prêt (tentative %d): %v"
 msgid "Failed to close export file: %w"
 msgstr "Échec de la fermeture du fichier d'exportation : %w"
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec de la fermeture du fichier de certificat du serveur %q : %w"
@@ -3375,7 +3375,7 @@ msgstr "Échec de la connexion au démon local : %w"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Échec de la connexion au nœud de cluster cible %q : %w"
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec de la création de %q : %w"
@@ -3390,7 +3390,7 @@ msgstr "Échec de la création de l'alias %s : %w"
 msgid "Failed to create backup: %v"
 msgstr "Échec de la création de la sauvegarde : %v"
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec de la création du certificat : %w"
@@ -3422,7 +3422,7 @@ msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 "Échec de la récupération du fichier de sauvegarde du volume de stockage : %w"
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec de la recherche du projet : %w"
@@ -3548,7 +3548,7 @@ msgstr "Échec de la mise à jour de l'état du membre du cluster : %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "Échec du parcours des fichiers du répertoire %s : %s"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec de l'écriture du fichier de certificat serveur %q : %w"
@@ -3700,7 +3700,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3755,7 +3755,7 @@ msgstr "Fréquence : %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "Fréquence : %vMhz (min : %vMhz, max : %vMhz)"
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -3767,16 +3767,31 @@ msgstr "GPU :"
 msgid "GPUs:"
 msgstr "GPUs :"
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "Ajouter de nouveaux certificat pour des clients de confiance"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr "Générer les pages de manuel pour toutes les commandes"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Ajouter de nouveaux certificat pour des clients de confiance"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -4338,7 +4353,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Invalid URL %q: %w"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schéma d'URL invalide \"%s\" in \"%s\""
@@ -4464,7 +4479,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid peer type"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -5437,11 +5452,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5864,7 +5879,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5877,7 +5892,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -6278,7 +6293,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -6313,7 +6328,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr "NON"
 
@@ -6378,7 +6393,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -6701,7 +6716,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 #, fuzzy
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
@@ -6807,11 +6822,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -6865,7 +6880,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
@@ -6874,7 +6889,7 @@ msgstr "Chemin vers un dossier de configuration serveur alternatif"
 msgid "Please provide join token:"
 msgstr "Veuillez fournir le jeton de connexion :"
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "Veuillez entrer 'o', 'n' ou l'empreinte :"
 
@@ -6948,6 +6963,11 @@ msgstr ""
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr ""
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "Un certificat client est déjà présent"
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -7072,7 +7092,7 @@ msgstr "Profil %s ajouté à %s"
 msgid "Project description"
 msgstr "Description"
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -7098,7 +7118,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -7225,37 +7245,37 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Ajouter de nouveaux clients de confiance"
@@ -7349,7 +7369,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -7428,7 +7448,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -7632,7 +7652,7 @@ msgstr "ÉTAT"
 msgid "STATEFUL"
 msgstr "ÉTAT"
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -7691,15 +7711,15 @@ msgstr "Serveur distant : %s"
 msgid "Serial: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -7710,7 +7730,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 #, fuzzy
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
@@ -7964,7 +7984,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -8281,7 +8301,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -8574,7 +8594,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -9023,7 +9043,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -9068,7 +9088,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr "URL"
 
@@ -9113,7 +9133,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
@@ -9136,7 +9156,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -9661,7 +9681,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr "OUI"
 
@@ -11114,7 +11134,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -11139,7 +11159,7 @@ msgstr ""
 msgid "application"
 msgstr "Propriétés :"
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -11756,7 +11776,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -11770,7 +11790,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (o/n/[empreinte]) ?"
 
@@ -11803,7 +11823,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr "o"
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -495,15 +495,15 @@ msgstr "<lokal|global> <query>"
 msgid "<old alias> <new alias>"
 msgstr "<alias lama> <alias baru>"
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr "<remote>"
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr "<remote> <nama-baru>"
 
@@ -530,7 +530,7 @@ msgstr "<target>"
 msgid "=> Query %d:"
 msgstr "=> Query %d:"
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr ""
 
@@ -567,11 +567,11 @@ msgstr "APP"
 msgid "ARCHITECTURE"
 msgstr "ARSITEKTUR"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr "TIPE AUTH"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "Terima sertifikat"
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Semua proyek"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -868,7 +868,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr ""
 
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Certificate description"
 msgstr "deskripsi"
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1176,7 +1176,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1200,7 +1200,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1310,7 +1310,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1495,12 +1495,12 @@ msgstr "Core %d"
 msgid "Cores:"
 msgstr "Core:"
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1988,10 +1988,10 @@ msgstr "Hapus peringatan"
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2386,7 +2386,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -2791,7 +2791,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2840,7 +2840,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2855,7 +2855,7 @@ msgstr ""
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2885,7 +2885,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -3132,7 +3132,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3183,7 +3183,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3195,15 +3195,29 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+msgid "Generate a client token derived from the client certificate"
+msgstr ""
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3694,7 +3708,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3810,7 +3824,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -4697,11 +4711,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5088,7 +5102,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5100,7 +5114,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5469,7 +5483,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5504,7 +5518,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5566,7 +5580,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5876,7 +5890,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -5972,11 +5986,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6028,7 +6042,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6036,7 +6050,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6108,6 +6122,10 @@ msgstr ""
 
 #: cmd/incus/main.go:118
 msgid "Print help"
+msgstr ""
+
+#: cmd/incus/remote.go:716
+msgid "Print the client certificate used by this Incus client"
 msgstr ""
 
 #: cmd/incus/query.go:44
@@ -6228,7 +6246,7 @@ msgstr ""
 msgid "Project description"
 msgstr "deskripsi"
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6254,7 +6272,7 @@ msgstr ""
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6372,37 +6390,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6484,7 +6502,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -6554,7 +6572,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -6730,7 +6748,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -6786,15 +6804,15 @@ msgstr ""
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -6803,7 +6821,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7039,7 +7057,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7314,7 +7332,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr "Tampilkan proyek saat ini"
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr "Tampilkan remote baku"
 
@@ -7590,7 +7608,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8020,7 +8038,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -8063,7 +8081,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8105,7 +8123,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8127,7 +8145,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -8607,7 +8625,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9324,7 +9342,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -9336,7 +9354,7 @@ msgstr ""
 msgid "application"
 msgstr "aplikasi"
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -9929,7 +9947,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr ""
 
@@ -9942,7 +9960,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9975,7 +9993,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr "y"
 

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2025-05-07 00:48-0400\n"
+        "POT-Creation-Date: 2025-05-07 02:33-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -467,15 +467,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid   "<remote>"
 msgstr  ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -500,7 +500,7 @@ msgstr  ""
 msgid   "=> Query %d:"
 msgstr  ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid   "A client certificate is already present"
 msgstr  ""
 
@@ -536,11 +536,11 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -606,11 +606,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -729,7 +729,7 @@ msgstr  ""
 msgid   "All projects"
 msgstr  ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -803,7 +803,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -826,7 +826,7 @@ msgstr  ""
 msgid   "Automatic (non-interactive) mode"
 msgstr  ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid   "Available projects:"
 msgstr  ""
 
@@ -1018,7 +1018,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -1108,7 +1108,7 @@ msgstr  ""
 msgid   "Certificate description"
 msgstr  ""
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
@@ -1118,7 +1118,7 @@ msgstr  ""
 msgid   "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr  ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -1142,7 +1142,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1208,7 +1208,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433 cmd/incus/config_trust.go:636 cmd/incus/image.go:1114 cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1136 cmd/incus/network.go:1351 cmd/incus/network_allocations.go:64 cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439 cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114 cmd/incus/network_zone.go:118 cmd/incus/operation.go:144 cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751 cmd/incus/snapshot.go:323 cmd/incus/storage.go:707 cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968 cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776 cmd/incus/top.go:64 cmd/incus/warning.go:97
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433 cmd/incus/config_trust.go:636 cmd/incus/image.go:1114 cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1136 cmd/incus/network.go:1351 cmd/incus/network_allocations.go:64 cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439 cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114 cmd/incus/network_zone.go:118 cmd/incus/operation.go:144 cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898 cmd/incus/snapshot.go:323 cmd/incus/storage.go:707 cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968 cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776 cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid   "Columns"
 msgstr  ""
 
@@ -1370,12 +1370,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1404,7 +1404,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1726,7 +1726,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81 cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21 cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47 cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31 cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32 cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327 cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522 cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710 cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021 cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268 cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484 cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36 cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189 cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341 cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622 cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763 cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903 cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060 cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52 cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96 cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752 cmd/incus/config.go:884 cmd/incus/config_device.go:26 cmd/incus/config_device.go:81 cmd/incus/config_device.go:225 cmd/incus/config_device.go:324 cmd/incus/config_device.go:409 cmd/incus/config_device.go:513 cmd/incus/config_device.go:631 cmd/incus/config_device.go:638 cmd/incus/config_device.go:773 cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28 cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192 cmd/incus/config_template.go:28 cmd/incus/config_template.go:69 cmd/incus/config_template.go:139 cmd/incus/config_template.go:195 cmd/incus/config_template.go:297 cmd/incus/config_template.go:371 cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93 cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285 cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:616 cmd/incus/config_trust.go:775 cmd/incus/config_trust.go:823 cmd/incus/config_trust.go:896 cmd/incus/console.go:40 cmd/incus/copy.go:43 cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33 cmd/incus/file.go:53 cmd/incus/file.go:100 cmd/incus/file.go:300 cmd/incus/file.go:384 cmd/incus/file.go:464 cmd/incus/file.go:698 cmd/incus/file.go:1370 cmd/incus/image.go:44 cmd/incus/image.go:153 cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509 cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088 cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599 cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32 cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140 cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386 cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25 cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25 cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:40 cmd/incus/network.go:152 cmd/incus/network.go:251 cmd/incus/network.go:352 cmd/incus/network.go:470 cmd/incus/network.go:530 cmd/incus/network.go:629 cmd/incus/network.go:728 cmd/incus/network.go:866 cmd/incus/network.go:949 cmd/incus/network.go:1109 cmd/incus/network.go:1329 cmd/incus/network.go:1489 cmd/incus/network.go:1551 cmd/incus/network.go:1649 cmd/incus/network.go:1723 cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97 cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262 cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397 cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592 cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778 cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897 cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060 cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93 cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247 cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429 cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594 cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703 cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36 cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94 cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337 cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534 cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695 cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928 cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029 cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86 cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231 cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417 cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618 cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732 cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:340 cmd/incus/network_load_balancer.go:450 cmd/incus/network_load_balancer.go:520 cmd/incus/network_load_balancer.go:632 cmd/incus/network_load_balancer.go:664 cmd/incus/network_load_balancer.go:831 cmd/incus/network_load_balancer.go:907 cmd/incus/network_load_balancer.go:923 cmd/incus/network_load_balancer.go:1003 cmd/incus/network_load_balancer.go:1104 cmd/incus/network_load_balancer.go:1120 cmd/incus/network_load_balancer.go:1197 cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30 cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258 cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678 cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866 cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94 cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327 cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507 cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642 cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829 cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971 cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117 cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314 cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574 cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32 cmd/incus/operation.go:66 cmd/incus/operation.go:119 cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113 cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369 cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658 cmd/incus/profile.go:736 cmd/incus/profile.go:927 cmd/incus/profile.go:1017 cmd/incus/profile.go:1079 cmd/incus/profile.go:1170 cmd/incus/profile.go:1236 cmd/incus/project.go:39 cmd/incus/project.go:109 cmd/incus/project.go:215 cmd/incus/project.go:315 cmd/incus/project.go:453 cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826 cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025 cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35 cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45 cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686 cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983 cmd/incus/remote.go:1048 cmd/incus/remote.go:1096 cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33 cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301 cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525 cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105 cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418 cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852 cmd/incus/storage.go:958 cmd/incus/storage.go:1054 cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101 cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277 cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:792 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:899 cmd/incus/storage_bucket.go:947 cmd/incus/storage_bucket.go:1098 cmd/incus/storage_bucket.go:1211 cmd/incus/storage_bucket.go:1277 cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1487 cmd/incus/storage_bucket.go:1638 cmd/incus/storage_volume.go:60 cmd/incus/storage_volume.go:172 cmd/incus/storage_volume.go:265 cmd/incus/storage_volume.go:375 cmd/incus/storage_volume.go:595 cmd/incus/storage_volume.go:713 cmd/incus/storage_volume.go:788 cmd/incus/storage_volume.go:888 cmd/incus/storage_volume.go:987 cmd/incus/storage_volume.go:1213 cmd/incus/storage_volume.go:1351 cmd/incus/storage_volume.go:1513 cmd/incus/storage_volume.go:1598 cmd/incus/storage_volume.go:1854 cmd/incus/storage_volume.go:1949 cmd/incus/storage_volume.go:2031 cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2303 cmd/incus/storage_volume.go:2363 cmd/incus/storage_volume.go:2393 cmd/incus/storage_volume.go:2493 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2772 cmd/incus/storage_volume.go:2778 cmd/incus/storage_volume.go:2941 cmd/incus/storage_volume.go:3030 cmd/incus/storage_volume.go:3112 cmd/incus/storage_volume.go:3201 cmd/incus/storage_volume.go:3369 cmd/incus/top.go:43 cmd/incus/version.go:23 cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273 cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81 cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21 cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47 cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31 cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32 cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327 cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522 cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710 cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021 cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268 cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484 cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36 cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189 cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341 cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622 cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763 cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903 cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060 cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52 cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96 cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752 cmd/incus/config.go:884 cmd/incus/config_device.go:26 cmd/incus/config_device.go:81 cmd/incus/config_device.go:225 cmd/incus/config_device.go:324 cmd/incus/config_device.go:409 cmd/incus/config_device.go:513 cmd/incus/config_device.go:631 cmd/incus/config_device.go:638 cmd/incus/config_device.go:773 cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28 cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192 cmd/incus/config_template.go:28 cmd/incus/config_template.go:69 cmd/incus/config_template.go:139 cmd/incus/config_template.go:195 cmd/incus/config_template.go:297 cmd/incus/config_template.go:371 cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93 cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285 cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:616 cmd/incus/config_trust.go:775 cmd/incus/config_trust.go:823 cmd/incus/config_trust.go:896 cmd/incus/console.go:40 cmd/incus/copy.go:43 cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33 cmd/incus/file.go:53 cmd/incus/file.go:100 cmd/incus/file.go:300 cmd/incus/file.go:384 cmd/incus/file.go:464 cmd/incus/file.go:698 cmd/incus/file.go:1370 cmd/incus/image.go:44 cmd/incus/image.go:153 cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509 cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088 cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599 cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32 cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140 cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386 cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25 cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25 cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:40 cmd/incus/network.go:152 cmd/incus/network.go:251 cmd/incus/network.go:352 cmd/incus/network.go:470 cmd/incus/network.go:530 cmd/incus/network.go:629 cmd/incus/network.go:728 cmd/incus/network.go:866 cmd/incus/network.go:949 cmd/incus/network.go:1109 cmd/incus/network.go:1329 cmd/incus/network.go:1489 cmd/incus/network.go:1551 cmd/incus/network.go:1649 cmd/incus/network.go:1723 cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97 cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262 cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397 cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592 cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778 cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897 cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060 cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93 cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247 cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429 cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594 cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703 cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36 cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94 cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337 cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534 cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695 cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928 cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029 cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86 cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231 cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417 cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618 cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732 cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:340 cmd/incus/network_load_balancer.go:450 cmd/incus/network_load_balancer.go:520 cmd/incus/network_load_balancer.go:632 cmd/incus/network_load_balancer.go:664 cmd/incus/network_load_balancer.go:831 cmd/incus/network_load_balancer.go:907 cmd/incus/network_load_balancer.go:923 cmd/incus/network_load_balancer.go:1003 cmd/incus/network_load_balancer.go:1104 cmd/incus/network_load_balancer.go:1120 cmd/incus/network_load_balancer.go:1197 cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30 cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258 cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678 cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866 cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94 cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327 cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507 cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642 cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829 cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971 cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117 cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314 cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574 cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32 cmd/incus/operation.go:66 cmd/incus/operation.go:119 cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113 cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369 cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658 cmd/incus/profile.go:736 cmd/incus/profile.go:927 cmd/incus/profile.go:1017 cmd/incus/profile.go:1079 cmd/incus/profile.go:1170 cmd/incus/profile.go:1236 cmd/incus/project.go:39 cmd/incus/project.go:109 cmd/incus/project.go:215 cmd/incus/project.go:315 cmd/incus/project.go:453 cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826 cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025 cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35 cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49 cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698 cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049 cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243 cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33 cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301 cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525 cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105 cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418 cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852 cmd/incus/storage.go:958 cmd/incus/storage.go:1054 cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101 cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277 cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:792 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:899 cmd/incus/storage_bucket.go:947 cmd/incus/storage_bucket.go:1098 cmd/incus/storage_bucket.go:1211 cmd/incus/storage_bucket.go:1277 cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1487 cmd/incus/storage_bucket.go:1638 cmd/incus/storage_volume.go:60 cmd/incus/storage_volume.go:172 cmd/incus/storage_volume.go:265 cmd/incus/storage_volume.go:375 cmd/incus/storage_volume.go:595 cmd/incus/storage_volume.go:713 cmd/incus/storage_volume.go:788 cmd/incus/storage_volume.go:888 cmd/incus/storage_volume.go:987 cmd/incus/storage_volume.go:1213 cmd/incus/storage_volume.go:1351 cmd/incus/storage_volume.go:1513 cmd/incus/storage_volume.go:1598 cmd/incus/storage_volume.go:1854 cmd/incus/storage_volume.go:1949 cmd/incus/storage_volume.go:2031 cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2303 cmd/incus/storage_volume.go:2363 cmd/incus/storage_volume.go:2393 cmd/incus/storage_volume.go:2493 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2772 cmd/incus/storage_volume.go:2778 cmd/incus/storage_volume.go:2941 cmd/incus/storage_volume.go:3030 cmd/incus/storage_volume.go:3112 cmd/incus/storage_volume.go:3201 cmd/incus/storage_volume.go:3369 cmd/incus/top.go:43 cmd/incus/version.go:23 cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273 cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
@@ -2066,7 +2066,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150 cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463 cmd/incus/config_trust.go:661 cmd/incus/image.go:1161 cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1182 cmd/incus/network.go:1389 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465 cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147 cmd/incus/network_zone.go:154 cmd/incus/operation.go:176 cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778 cmd/incus/snapshot.go:357 cmd/incus/storage.go:746 cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993 cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891 cmd/incus/top.go:92 cmd/incus/warning.go:245
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150 cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463 cmd/incus/config_trust.go:661 cmd/incus/image.go:1161 cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1182 cmd/incus/network.go:1389 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465 cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147 cmd/incus/network_zone.go:154 cmd/incus/operation.go:176 cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925 cmd/incus/snapshot.go:357 cmd/incus/storage.go:746 cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993 cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891 cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2438,7 +2438,7 @@ msgstr  ""
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid   "Failed to add remote"
 msgstr  ""
 
@@ -2457,7 +2457,7 @@ msgstr  ""
 msgid   "Failed to close export file: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -2487,7 +2487,7 @@ msgstr  ""
 msgid   "Failed to connect to target cluster node %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -2502,7 +2502,7 @@ msgstr  ""
 msgid   "Failed to create backup: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
@@ -2532,7 +2532,7 @@ msgstr  ""
 msgid   "Failed to fetch storage volume backup file: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -2652,7 +2652,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -2756,7 +2756,7 @@ msgstr  ""
 msgid   "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154 cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:635 cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137 cmd/incus/network.go:1137 cmd/incus/network.go:1350 cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61 cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113 cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890 cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551 cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322 cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623 cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154 cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:635 cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137 cmd/incus/network.go:1137 cmd/incus/network.go:1350 cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61 cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113 cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890 cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551 cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322 cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623 cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
 msgid   "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr  ""
 
@@ -2800,7 +2800,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2812,15 +2812,25 @@ msgstr  ""
 msgid   "GPUs:"
 msgstr  ""
 
+#: cmd/incus/remote.go:762
+msgid   "Generate a client token derived from the client certificate"
+msgstr  ""
+
+#: cmd/incus/remote.go:763
+msgid   "Generate a client trust token derived from the existing client certificate and private key.\n"
+        "\n"
+        "This is useful for remote authentication workflows where a token is passed to another Incus server."
+msgstr  ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 msgid   "Generate the client certificate"
 msgstr  ""
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676 cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -3301,7 +3311,7 @@ msgstr  ""
 msgid   "Invalid URL %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -3415,7 +3425,7 @@ msgstr  ""
 msgid   "Invalid peer type"
 msgstr  ""
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -4261,11 +4271,11 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid   "List the available remotes"
 msgstr  ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid   "List the available remotes\n"
         "\n"
         "Default column layout: nupaPsg\n"
@@ -4640,7 +4650,7 @@ msgid   "Manage storage volumes\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
@@ -4652,7 +4662,7 @@ msgstr  ""
 msgid   "Manage warnings"
 msgstr  ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid   "Manually trigger the generation of a client certificate"
 msgstr  ""
 
@@ -4912,7 +4922,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140 cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:651 cmd/incus/list.go:511 cmd/incus/network.go:1162 cmd/incus/network_acl.go:176 cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454 cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140 cmd/incus/network_zone.go:952 cmd/incus/profile.go:785 cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764 cmd/incus/snapshot.go:346 cmd/incus/storage.go:732 cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983 cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140 cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:651 cmd/incus/list.go:511 cmd/incus/network.go:1162 cmd/incus/network_acl.go:176 cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454 cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140 cmd/incus/network_zone.go:952 cmd/incus/profile.go:785 cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911 cmd/incus/snapshot.go:346 cmd/incus/storage.go:732 cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983 cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
 msgid   "NAME"
 msgstr  ""
 
@@ -4941,7 +4951,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: cmd/incus/network.go:1211 cmd/incus/operation.go:209 cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630 cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657 cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/network.go:1211 cmd/incus/operation.go:209 cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630 cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657 cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid   "NO"
 msgstr  ""
 
@@ -5000,7 +5010,7 @@ msgstr  ""
 msgid   "Name of the new storage pool"
 msgstr  ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
@@ -5302,7 +5312,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid   "Only https URLs are supported for oci and simplestreams"
 msgstr  ""
 
@@ -5393,11 +5403,11 @@ msgstr  ""
 msgid   "PROJECTS"
 msgstr  ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -5448,7 +5458,7 @@ msgstr  ""
 msgid   "Please create those missing entries and then hit ENTER:"
 msgstr  ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -5456,7 +5466,7 @@ msgstr  ""
 msgid   "Please provide join token:"
 msgstr  ""
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -5516,6 +5526,10 @@ msgstr  ""
 
 #: cmd/incus/main.go:118
 msgid   "Print help"
+msgstr  ""
+
+#: cmd/incus/remote.go:716
+msgid   "Print the client certificate used by this Incus client"
 msgstr  ""
 
 #: cmd/incus/query.go:44
@@ -5634,7 +5648,7 @@ msgstr  ""
 msgid   "Project description"
 msgstr  ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid   "Project to use for the remote"
 msgstr  ""
 
@@ -5660,7 +5674,7 @@ msgstr  ""
 msgid   "Proxy timeout (exits when no connections)"
 msgstr  ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid   "Public image server"
 msgstr  ""
 
@@ -5771,36 +5785,36 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931 cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078 cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid   "Remote trust token"
 msgstr  ""
 
@@ -5879,7 +5893,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -5948,7 +5962,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -6120,7 +6134,7 @@ msgstr  ""
 msgid   "STATEFUL"
 msgstr  ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid   "STATIC"
 msgstr  ""
 
@@ -6176,15 +6190,15 @@ msgstr  ""
 msgid   "Serial: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -6192,7 +6206,7 @@ msgstr  ""
 msgid   "Server isn't part of a cluster"
 msgstr  ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid   "Server protocol (incus, oci or simplestreams)"
 msgstr  ""
 
@@ -6394,7 +6408,7 @@ msgid   "Set storage volume configuration keys\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -6662,7 +6676,7 @@ msgstr  ""
 msgid   "Show the current project"
 msgstr  ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -6933,7 +6947,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -7333,7 +7347,7 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
@@ -7372,7 +7386,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid   "URL"
 msgstr  ""
 
@@ -7410,7 +7424,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -7424,7 +7438,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156 cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469 cmd/incus/config_trust.go:667 cmd/incus/image.go:1167 cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1188 cmd/incus/network.go:1395 cmd/incus/network_allocations.go:95 cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471 cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153 cmd/incus/network_zone.go:160 cmd/incus/operation.go:182 cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784 cmd/incus/snapshot.go:363 cmd/incus/storage.go:752 cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999 cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897 cmd/incus/top.go:98 cmd/incus/warning.go:251
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156 cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469 cmd/incus/config_trust.go:667 cmd/incus/image.go:1167 cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1188 cmd/incus/network.go:1395 cmd/incus/network_allocations.go:95 cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471 cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153 cmd/incus/network_zone.go:160 cmd/incus/operation.go:182 cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931 cmd/incus/snapshot.go:363 cmd/incus/storage.go:752 cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999 cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897 cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -7879,7 +7893,7 @@ msgstr  ""
 msgid   "Would you like to use clustering?"
 msgstr  ""
 
-#: cmd/incus/network.go:1208 cmd/incus/operation.go:212 cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659 cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/network.go:1208 cmd/incus/operation.go:212 cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659 cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid   "YES"
 msgstr  ""
 
@@ -8539,7 +8553,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
@@ -8551,7 +8565,7 @@ msgstr  ""
 msgid   "application"
 msgstr  ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid   "current"
 msgstr  ""
 
@@ -9045,7 +9059,7 @@ msgstr  ""
 msgid   "info"
 msgstr  ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid   "n"
 msgstr  ""
 
@@ -9057,7 +9071,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -9090,7 +9104,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid   "y"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -753,15 +753,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "Certificato del client salvato dal server: "
@@ -827,11 +827,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -900,11 +900,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1114,7 +1114,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1137,7 +1137,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr ""
 
@@ -1339,7 +1339,7 @@ msgstr "Impossible leggere da stdin: %s"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr "Il nome del container è: %s"
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1444,7 +1444,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1468,7 +1468,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1579,7 +1579,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1766,12 +1766,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1800,7 +1800,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -2283,10 +2283,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2701,7 +2701,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3112,7 +3112,7 @@ msgstr "Accetta certificato"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -3131,7 +3131,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -3161,7 +3161,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -3176,7 +3176,7 @@ msgstr "Accetta certificato"
 msgid "Failed to create backup: %v"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
@@ -3206,7 +3206,7 @@ msgstr "Accetta certificato"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3329,7 +3329,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -3455,7 +3455,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3506,7 +3506,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3518,16 +3518,31 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "Accetta certificato"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -4043,7 +4058,7 @@ msgstr "Il nome del container è: %s"
 msgid "Invalid URL %q: %w"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -4162,7 +4177,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -5070,11 +5085,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5483,7 +5498,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5496,7 +5511,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5884,7 +5899,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5919,7 +5934,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5981,7 +5996,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -6287,7 +6302,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -6386,11 +6401,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6442,7 +6457,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6451,7 +6466,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6523,6 +6538,11 @@ msgstr ""
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr ""
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "Certificato del client salvato dal server: "
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -6642,7 +6662,7 @@ msgstr ""
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6668,7 +6688,7 @@ msgstr "Il nome del container è: %s"
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6788,37 +6808,37 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6906,7 +6926,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -6982,7 +7002,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -7166,7 +7186,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -7222,15 +7242,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -7239,7 +7259,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7482,7 +7502,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7777,7 +7797,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -8058,7 +8078,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8491,7 +8511,7 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Password amministratore per %s: "
@@ -8535,7 +8555,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8580,7 +8600,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
@@ -8603,7 +8623,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -9105,7 +9125,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9971,7 +9991,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
@@ -9985,7 +10005,7 @@ msgstr "Creazione del container in corso"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -10578,7 +10598,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -10592,7 +10612,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -10625,7 +10645,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-12-14 14:00+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -741,15 +741,15 @@ msgstr "<local|global> <query>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr "<remote>"
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -776,7 +776,7 @@ msgstr "<target>"
 msgid "=> Query %d:"
 msgstr "=> クエリ %d:"
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "クライアント証明書がサーバに格納されました:"
@@ -814,11 +814,11 @@ msgstr "APP"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -885,11 +885,11 @@ msgstr "メンバーをグループに追加します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1033,7 +1033,7 @@ msgstr "クラスターに join すると、すべてのデータが削除され
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
@@ -1116,7 +1116,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1139,7 +1139,7 @@ msgstr "自動更新: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr "自動（非インタラクティブ）モード"
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
@@ -1346,7 +1346,7 @@ msgstr "標準入力から読み込めません: %w"
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1445,7 +1445,7 @@ msgstr "%s に対する証明書追加トークンが削除されました"
 msgid "Certificate description"
 msgstr "証明書のフィンガープリント: %s"
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1460,7 +1460,7 @@ msgstr ""
 "証明書のフィンガープリントが join するためのトークンとクラスターメンバーの間"
 "で一致しません %q"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1484,7 +1484,7 @@ msgstr "選択してください %s"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1594,7 +1594,7 @@ msgstr "クラスタリングが有効になりました"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1805,12 +1805,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1839,7 +1839,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -2310,10 +2310,10 @@ msgstr "警告を削除します"
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2757,7 +2757,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3217,7 +3217,7 @@ msgstr "sshfs の起動に失敗しました: %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
@@ -3236,7 +3236,7 @@ msgstr "デーモンが利用可能かどうかのチェックに失敗しまし
 msgid "Failed to close export file: %w"
 msgstr "エクスポートするファイルのクローズに失敗しました: %w"
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
@@ -3266,7 +3266,7 @@ msgstr "ローカルデーモンへの接続に失敗しました: %w"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "ターゲットのクラスターノード %q への接続に失敗しました: %w"
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -3281,7 +3281,7 @@ msgstr "エイリアス %s の作成に失敗しました: %w"
 msgid "Failed to create backup: %v"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
@@ -3311,7 +3311,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "ストレージボリュームのバックアップファイルの取得に失敗しました: %w"
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -3434,7 +3434,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
@@ -3575,7 +3575,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3627,7 +3627,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -3639,16 +3639,31 @@ msgstr "GPU:"
 msgid "GPUs:"
 msgstr "GPUs:"
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "新たに信頼済みのクライアント証明書を追加します"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "新たに信頼済みのクライアント証明書を追加します"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -4179,7 +4194,7 @@ msgstr "不正なスナップショット名"
 msgid "Invalid URL %q: %w"
 msgstr "不正なフォーマット %q"
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -4302,7 +4317,7 @@ msgstr "不正なパス %s"
 msgid "Invalid peer type"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -5834,11 +5849,11 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -6309,7 +6324,7 @@ msgstr ""
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
@@ -6321,7 +6336,7 @@ msgstr "信頼済みのクライアントを管理します"
 msgid "Manage warnings"
 msgstr "警告を管理します"
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr "クライアント証明書の生成を手動でトリガーする"
 
@@ -6717,7 +6732,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -6752,7 +6767,7 @@ msgstr "NICs:"
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr "NO"
 
@@ -6816,7 +6831,7 @@ msgstr "既存のブリッジ名、もしくはホストインターフェース
 msgid "Name of the new storage pool"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
@@ -7136,7 +7151,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 #, fuzzy
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
@@ -7240,11 +7255,11 @@ msgstr "PROJECT"
 msgid "PROJECTS"
 msgstr "PROJECT"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -7296,7 +7311,7 @@ msgstr "インクリメンタルコピーを実行します"
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr "不足しているエントリーを作成してから ENTER を押してください:"
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
@@ -7305,7 +7320,7 @@ msgstr "別のサーバアドレスを指定してください（空の場合は
 msgid "Please provide join token:"
 msgstr "クライアント名を入力してください: "
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -7380,6 +7395,11 @@ msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr "ヘルプを表示します"
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "クライアント証明書がサーバに格納されました:"
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -7499,7 +7519,7 @@ msgstr "プロジェクト名 %s を %s に変更しました"
 msgid "Project description"
 msgstr "説明"
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
@@ -7525,7 +7545,7 @@ msgstr "クライアント %s の証明書追加トークン: %s"
 msgid "Proxy timeout (exits when no connections)"
 msgstr "プロキシータイムアウト (接続がない場合終了)"
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -7653,37 +7673,37 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 #, fuzzy
 msgid "Remote trust token"
 msgstr "信頼済みクライアントを削除します"
@@ -7769,7 +7789,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -7844,7 +7864,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -8030,7 +8050,7 @@ msgstr "STATE"
 msgid "STATEFUL"
 msgstr "STATE"
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -8087,16 +8107,16 @@ msgstr "デバイス: %s"
 msgid "Serial: %v"
 msgstr "合計: %v"
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 #, fuzzy
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -8106,7 +8126,7 @@ msgstr "認証後、サーバが我々を信用していません"
 msgid "Server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 #, fuzzy
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
@@ -8420,7 +8440,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -8724,7 +8744,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -9006,7 +9026,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -9504,7 +9524,7 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -9549,7 +9569,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr "URL"
 
@@ -9594,7 +9614,7 @@ msgstr "クラスタメンバへの接続に失敗しました"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
@@ -9616,7 +9636,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -10145,7 +10165,7 @@ msgstr "クラスタリングを使用しますか?"
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr "YES"
 
@@ -10902,7 +10922,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
@@ -10915,7 +10935,7 @@ msgstr "[[<remote>:]<member>]"
 msgid "application"
 msgstr "operation"
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr "現在値"
 
@@ -11820,7 +11840,7 @@ msgstr ""
 msgid "info"
 msgstr "ストレージ情報"
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr "n"
 
@@ -11833,7 +11853,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -11867,7 +11887,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr "y"
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -504,15 +504,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr ""
 
@@ -574,11 +574,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr ""
 
@@ -644,11 +644,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -776,7 +776,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -852,7 +852,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr ""
 
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1180,7 +1180,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1204,7 +1204,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1498,12 +1498,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1990,10 +1990,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2388,7 +2388,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -2793,7 +2793,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2887,7 +2887,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -3134,7 +3134,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3185,7 +3185,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3197,15 +3197,29 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+msgid "Generate a client token derived from the client certificate"
+msgstr ""
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3695,7 +3709,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3811,7 +3825,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -4697,11 +4711,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5087,7 +5101,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5099,7 +5113,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5467,7 +5481,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5502,7 +5516,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5564,7 +5578,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5870,7 +5884,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -5966,11 +5980,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6021,7 +6035,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6029,7 +6043,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6100,6 +6114,10 @@ msgstr ""
 
 #: cmd/incus/main.go:118
 msgid "Print help"
+msgstr ""
+
+#: cmd/incus/remote.go:716
+msgid "Print the client certificate used by this Incus client"
 msgstr ""
 
 #: cmd/incus/query.go:44
@@ -6218,7 +6236,7 @@ msgstr ""
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6244,7 +6262,7 @@ msgstr ""
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6361,37 +6379,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6473,7 +6491,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -6543,7 +6561,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -6718,7 +6736,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -6774,15 +6792,15 @@ msgstr ""
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -6791,7 +6809,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7026,7 +7044,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7300,7 +7318,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -7574,7 +7592,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8004,7 +8022,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -8047,7 +8065,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8089,7 +8107,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8111,7 +8129,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -8590,7 +8608,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9298,7 +9316,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -9310,7 +9328,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -9903,7 +9921,7 @@ msgstr ""
 msgid "info"
 msgstr "informasjon"
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr "n"
 
@@ -9916,7 +9934,7 @@ msgstr "navn"
 msgid "no"
 msgstr "nei"
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9949,7 +9967,7 @@ msgstr "utilgjengelig"
 msgid "used by"
 msgstr "brukt av"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr "j"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 "
 "<nlincus@users.noreply.hosted.weblate.org>\n"
@@ -772,15 +772,15 @@ msgstr "<local|global> <Query>"
 msgid "<old alias> <new alias>"
 msgstr "<oude alias> <nieuwe alias>"
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr "<remote>"
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr "Een client certificaat is al aanwezig"
 
@@ -843,11 +843,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr "AUTHENTICATIE TYPE"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "Accepteer certificaat"
 
@@ -915,11 +915,11 @@ msgstr "Voeg een lid (member) toe aan een group (group)"
 msgid "Add new aliases"
 msgstr "Voeg nieuwe aliassen toe"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr "Voeg nieuwe remote servers toe"
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Alle projecten"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr "Alle server adressen zijn onbeschikbaar"
 
@@ -1144,7 +1144,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1462,7 +1462,7 @@ msgstr ""
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1474,7 +1474,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1498,7 +1498,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1607,7 +1607,7 @@ msgstr "Clustering aan"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1800,12 +1800,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -2294,10 +2294,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2693,7 +2693,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3098,7 +3098,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -3117,7 +3117,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -3147,7 +3147,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -3162,7 +3162,7 @@ msgstr ""
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -3192,7 +3192,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3315,7 +3315,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -3439,7 +3439,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3502,15 +3502,30 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "Genereer het client certificaat"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 msgid "Generate the client certificate"
 msgstr "Genereer het client certificaat"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3999,7 +4014,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -4115,7 +4130,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -5002,11 +5017,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5394,7 +5409,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5406,7 +5421,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5776,7 +5791,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5811,7 +5826,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5873,7 +5888,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -6179,7 +6194,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -6275,11 +6290,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6330,7 +6345,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6338,7 +6353,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6410,6 +6425,11 @@ msgstr ""
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr ""
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "Een client certificaat is al aanwezig"
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -6527,7 +6547,7 @@ msgstr ""
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6553,7 +6573,7 @@ msgstr ""
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6670,37 +6690,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6782,7 +6802,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -6853,7 +6873,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -7028,7 +7048,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -7084,15 +7104,15 @@ msgstr "Serienummer: %s"
 msgid "Serial: %v"
 msgstr "Serienummer: %v"
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -7101,7 +7121,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7337,7 +7357,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7616,7 +7636,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -7890,7 +7910,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8320,7 +8340,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -8363,7 +8383,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8405,7 +8425,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8427,7 +8447,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -8909,7 +8929,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9617,7 +9637,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -9629,7 +9649,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -10229,7 +10249,7 @@ msgstr ""
 msgid "info"
 msgstr "informatie"
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr "n"
 
@@ -10242,7 +10262,7 @@ msgstr "naam"
 msgid "no"
 msgstr "nee"
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (j/n/[vingerafdruk])?"
 
@@ -10275,7 +10295,7 @@ msgstr "onbereikbaar"
 msgid "used by"
 msgstr "gebruikt door"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr "j"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -492,15 +492,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr ""
 
@@ -562,11 +562,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr ""
 
@@ -632,11 +632,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -764,7 +764,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -840,7 +840,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -863,7 +863,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgstr ""
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1168,7 +1168,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1486,12 +1486,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1520,7 +1520,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1978,10 +1978,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2376,7 +2376,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2800,7 +2800,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2830,7 +2830,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2845,7 +2845,7 @@ msgstr ""
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2875,7 +2875,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -3122,7 +3122,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3173,7 +3173,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3185,15 +3185,29 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+msgid "Generate a client token derived from the client certificate"
+msgstr ""
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3682,7 +3696,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3798,7 +3812,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -4684,11 +4698,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5074,7 +5088,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5086,7 +5100,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5454,7 +5468,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5489,7 +5503,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5551,7 +5565,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5857,7 +5871,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -5953,11 +5967,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6008,7 +6022,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6016,7 +6030,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6087,6 +6101,10 @@ msgstr ""
 
 #: cmd/incus/main.go:118
 msgid "Print help"
+msgstr ""
+
+#: cmd/incus/remote.go:716
+msgid "Print the client certificate used by this Incus client"
 msgstr ""
 
 #: cmd/incus/query.go:44
@@ -6205,7 +6223,7 @@ msgstr ""
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6231,7 +6249,7 @@ msgstr ""
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6348,37 +6366,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6460,7 +6478,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -6530,7 +6548,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -6705,7 +6723,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -6761,15 +6779,15 @@ msgstr ""
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -6778,7 +6796,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7013,7 +7031,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7287,7 +7305,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -7561,7 +7579,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -7991,7 +8009,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -8034,7 +8052,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8076,7 +8094,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8098,7 +8116,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -8577,7 +8595,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9285,7 +9303,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -9297,7 +9315,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -9890,7 +9908,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr ""
 
@@ -9903,7 +9921,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9936,7 +9954,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -752,15 +752,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -826,11 +826,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
@@ -900,11 +900,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1122,7 +1122,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1145,7 +1145,7 @@ msgstr "Atualização automática: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
@@ -1351,7 +1351,7 @@ msgstr "Não é possível ler stdin: %s"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1446,7 +1446,7 @@ msgstr "Clustering ativado"
 msgid "Certificate description"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1458,7 +1458,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1593,7 +1593,7 @@ msgstr "Clustering ativado"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1793,12 +1793,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1827,7 +1827,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -2322,10 +2322,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2749,7 +2749,7 @@ msgstr "Editar configurações de perfil como YAML"
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3158,7 +3158,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -3177,7 +3177,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -3207,7 +3207,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -3222,7 +3222,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to create backup: %v"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
@@ -3252,7 +3252,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3375,7 +3375,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -3500,7 +3500,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3563,16 +3563,31 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "Adicionar novos clientes confiáveis"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -4095,7 +4110,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid URL %q: %w"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -4213,7 +4228,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -5119,11 +5134,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5536,7 +5551,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5549,7 +5564,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5938,7 +5953,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5973,7 +5988,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -6035,7 +6050,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -6346,7 +6361,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -6445,11 +6460,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6501,7 +6516,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6510,7 +6525,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6583,6 +6598,11 @@ msgstr ""
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr ""
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "Certificado do cliente armazenado no servidor: "
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -6707,7 +6727,7 @@ msgstr ""
 msgid "Project description"
 msgstr "Descrição"
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6733,7 +6753,7 @@ msgstr "Nome de membro do cluster"
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6854,37 +6874,37 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Adicionar novos clientes confiáveis"
@@ -6976,7 +6996,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -7055,7 +7075,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -7245,7 +7265,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -7301,15 +7321,15 @@ msgstr "Em cache: %s"
 msgid "Serial: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -7318,7 +7338,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7568,7 +7588,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7874,7 +7894,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -8157,7 +8177,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8589,7 +8609,7 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Senha de administrador para %s: "
@@ -8633,7 +8653,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8678,7 +8698,7 @@ msgstr "Nome de membro do cluster"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
@@ -8701,7 +8721,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -9215,7 +9235,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -10013,7 +10033,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
@@ -10027,7 +10047,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -10620,7 +10640,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr ""
 
@@ -10633,7 +10653,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -10666,7 +10686,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -767,15 +767,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -848,11 +848,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -922,11 +922,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1160,7 +1160,7 @@ msgstr "Авто-обновление: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
@@ -1364,7 +1364,7 @@ msgstr "Невозможно прочитать из стандартного в
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1457,7 +1457,7 @@ msgstr " Использование сети:"
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1469,7 +1469,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1493,7 +1493,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1604,7 +1604,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1791,12 +1791,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1825,7 +1825,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -2316,10 +2316,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2735,7 +2735,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3152,7 +3152,7 @@ msgstr "Принять сертификат"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -3171,7 +3171,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -3201,7 +3201,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -3216,7 +3216,7 @@ msgstr "Принять сертификат"
 msgid "Failed to create backup: %v"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
@@ -3246,7 +3246,7 @@ msgstr "Принять сертификат"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3369,7 +3369,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -3494,7 +3494,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3545,7 +3545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3557,16 +3557,31 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "Принять сертификат"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -4090,7 +4105,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid URL %q: %w"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -4208,7 +4223,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -5119,11 +5134,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5539,7 +5554,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5552,7 +5567,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5942,7 +5957,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5977,7 +5992,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -6041,7 +6056,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -6356,7 +6371,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -6455,11 +6470,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6510,7 +6525,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6519,7 +6534,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6591,6 +6606,11 @@ msgstr ""
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr ""
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "Сертификат клиента хранится на сервере: "
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -6708,7 +6728,7 @@ msgstr ""
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6734,7 +6754,7 @@ msgstr "Копирование образа: %s"
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6855,37 +6875,37 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6973,7 +6993,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -7049,7 +7069,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -7234,7 +7254,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -7290,15 +7310,15 @@ msgstr "Авто-обновление: %s"
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -7307,7 +7327,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7552,7 +7572,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7855,7 +7875,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -8141,7 +8161,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8572,7 +8592,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Пароль администратора для %s: "
@@ -8616,7 +8636,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8661,7 +8681,7 @@ msgstr "Копирование образа: %s"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8683,7 +8703,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -9192,7 +9212,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -10524,7 +10544,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -10544,7 +10564,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -11137,7 +11157,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr ""
 
@@ -11150,7 +11170,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -11183,7 +11203,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -492,15 +492,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr ""
 
@@ -562,11 +562,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr ""
 
@@ -632,11 +632,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -764,7 +764,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -840,7 +840,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -863,7 +863,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgstr ""
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1168,7 +1168,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1486,12 +1486,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1520,7 +1520,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1978,10 +1978,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2376,7 +2376,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2800,7 +2800,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2830,7 +2830,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2845,7 +2845,7 @@ msgstr ""
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2875,7 +2875,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -3122,7 +3122,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3173,7 +3173,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3185,15 +3185,29 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+msgid "Generate a client token derived from the client certificate"
+msgstr ""
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3682,7 +3696,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3798,7 +3812,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -4684,11 +4698,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5074,7 +5088,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5086,7 +5100,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5454,7 +5468,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5489,7 +5503,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5551,7 +5565,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5857,7 +5871,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -5953,11 +5967,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6008,7 +6022,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6016,7 +6030,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6087,6 +6101,10 @@ msgstr ""
 
 #: cmd/incus/main.go:118
 msgid "Print help"
+msgstr ""
+
+#: cmd/incus/remote.go:716
+msgid "Print the client certificate used by this Incus client"
 msgstr ""
 
 #: cmd/incus/query.go:44
@@ -6205,7 +6223,7 @@ msgstr ""
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6231,7 +6249,7 @@ msgstr ""
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6348,37 +6366,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6460,7 +6478,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -6530,7 +6548,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -6705,7 +6723,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -6761,15 +6779,15 @@ msgstr ""
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -6778,7 +6796,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7013,7 +7031,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7287,7 +7305,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -7561,7 +7579,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -7991,7 +8009,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -8034,7 +8052,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8076,7 +8094,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8098,7 +8116,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -8577,7 +8595,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9285,7 +9303,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -9297,7 +9315,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -9890,7 +9908,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr ""
 
@@ -9903,7 +9921,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9936,7 +9954,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2025-03-01 08:01+0000\n"
 "Last-Translator: Loge X <wazolm5643@163.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -748,15 +748,15 @@ msgstr "<本地|全局> <查询>"
 msgid "<old alias> <new alias>"
 msgstr "<旧别名> <新别名>"
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr "<远程>"
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr "<远程> <URL>"
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr "<远程> <新名称>"
 
@@ -782,7 +782,7 @@ msgstr "<目标>"
 msgid "=> Query %d:"
 msgstr "=> 查询 %d："
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr "客户端证书已存在"
 
@@ -819,11 +819,11 @@ msgstr "应用"
 msgid "ARCHITECTURE"
 msgstr "架构"
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr "认证类型"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr "接受证书"
 
@@ -890,11 +890,11 @@ msgstr "将成员添加到组"
 msgid "Add new aliases"
 msgstr "添加新别名"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr "添加新的远程服务器"
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -1037,7 +1037,7 @@ msgstr "加入集群会丢失所有现有数据，是否继续？"
 msgid "All projects"
 msgstr "所有项目"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr "所有服务器地址都不可用"
 
@@ -1116,7 +1116,7 @@ msgstr ""
 "\n"
 "此命令允许您与实例的引导控制台进行交互，并从中检索过去的日志条目。"
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "服务器不支持身份验证类型“%s”"
@@ -1139,7 +1139,7 @@ msgstr "自动更新：%s"
 msgid "Automatic (non-interactive) mode"
 msgstr "自动（非交互）模式"
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr "可用项目："
 
@@ -1339,7 +1339,7 @@ msgstr "无法读取环境文件：%w"
 msgid "Can't read from stdin: %w"
 msgstr "无法从标准输入读取：%w"
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr "无法移除默认远程服务器"
 
@@ -1432,7 +1432,7 @@ msgstr "已删除 %s 的证书添加令牌"
 msgid "Certificate description"
 msgstr "证书描述"
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1444,7 +1444,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr "连接令牌与集群成员 %q 之间的证书指纹不匹配"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "证书指纹：%s"
@@ -1468,7 +1468,7 @@ msgstr "选择 %s："
 msgid "Client %s certificate add token:"
 msgstr "客户端 %s 证书添加令牌："
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr "服务器现已信任客户端证书："
 
@@ -1577,7 +1577,7 @@ msgstr "已启用集群"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1782,12 +1782,12 @@ msgstr "核心 %d"
 msgid "Cores:"
 msgstr "核心："
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "无法关闭服务器证书文件 %q：%w"
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr "无法创建服务器证书目录"
 
@@ -1816,7 +1816,7 @@ msgstr "无法读取证书密钥文件：%s，出现错误：%v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "无法为远程服务器“%s”写入新的远程证书，出现错误：%v"
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "无法写入服务器证书文件 %q：%w"
@@ -2279,10 +2279,10 @@ msgstr "删除警告"
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2699,7 +2699,7 @@ msgstr "将信任配置编辑为 YAML"
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -3145,7 +3145,7 @@ msgstr "启动 sshfs 失败：%w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "接受传入连接失败：%w"
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr "添加远程服务器失败"
 
@@ -3164,7 +3164,7 @@ msgstr "无法检查守护进程是否已就绪（第 %d 次尝试）：%v"
 msgid "Failed to close export file: %w"
 msgstr "关闭导出文件失败：%w"
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "关闭服务器证书文件 %q 失败：%w"
@@ -3194,7 +3194,7 @@ msgstr "无法连接到本地守护进程：%w"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "无法连接到目标集群节点 %q：%w"
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "创建 %q 失败：%w"
@@ -3209,7 +3209,7 @@ msgstr "创建别名 %s 失败：%w"
 msgid "Failed to create backup: %v"
 msgstr "创建备份失败：%v"
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "创建证书失败：%w"
@@ -3239,7 +3239,7 @@ msgstr "获取存储桶备份失败：%w"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "获取存储卷备份文件失败：%w"
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "找不到项目：%w"
@@ -3362,7 +3362,7 @@ msgstr "更新群集成员状态失败：%w"
 msgid "Failed to walk path for %s: %s"
 msgstr "为 %s 遍历路径失败：%s"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "无法写入服务器证书文件 %q：%w"
@@ -3500,7 +3500,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3553,7 +3553,7 @@ msgstr "频率：%v Mhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "频率：%v Mhz（最低：%v Mhz，最高：%v Mhz）"
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr "全局"
 
@@ -3565,15 +3565,30 @@ msgstr "GPU："
 msgid "GPUs:"
 msgstr "GPU："
 
+#: cmd/incus/remote.go:762
+#, fuzzy
+msgid "Generate a client token derived from the client certificate"
+msgstr "生成客户端证书"
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr "为所有命令生成手册"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 msgid "Generate the client certificate"
 msgstr "生成客户端证书"
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "正在生成客户端证书。这可能会花点时间……"
 
@@ -4068,7 +4083,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -4184,7 +4199,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -5089,11 +5104,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5480,7 +5495,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5492,7 +5507,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5862,7 +5877,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5897,7 +5912,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5959,7 +5974,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -6266,7 +6281,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -6362,11 +6377,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6417,7 +6432,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6425,7 +6440,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6497,6 +6512,11 @@ msgstr ""
 #: cmd/incus/main.go:118
 msgid "Print help"
 msgstr ""
+
+#: cmd/incus/remote.go:716
+#, fuzzy
+msgid "Print the client certificate used by this Incus client"
+msgstr "客户端证书已存在"
 
 #: cmd/incus/query.go:44
 msgid "Print the raw response"
@@ -6614,7 +6634,7 @@ msgstr ""
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6640,7 +6660,7 @@ msgstr "提供的证书路径不存在: %s"
 msgid "Proxy timeout (exits when no connections)"
 msgstr "代理已超时 (无连接时退出)"
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr "公共镜像服务器"
 
@@ -6760,38 +6780,38 @@ msgstr "正在刷新实例: %s"
 msgid "Refreshing the image: %s"
 msgstr "正在刷新镜像: %s"
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr "远程 %s 已存在"
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "远程 %s 不存在"
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "远程 %s 已存在地址 <%s>"
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "远程服务器 %s 是全局的，无法移除"
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "远程 %s 是静态的, 无法修改"
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 #, fuzzy
 msgid "Remote names may not contain colons"
 msgstr "远程名称不应包含冒号"
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 #, fuzzy
 msgid "Remote trust token"
 msgstr "远程验证令牌"
@@ -6879,7 +6899,7 @@ msgstr "从负载均衡器中移除端口"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -6949,7 +6969,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -7124,7 +7144,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -7180,15 +7200,15 @@ msgstr ""
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -7197,7 +7217,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7433,7 +7453,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7709,7 +7729,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -7983,7 +8003,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -8414,7 +8434,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -8457,7 +8477,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8499,7 +8519,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8521,7 +8541,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -9002,7 +9022,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9712,7 +9732,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -9724,7 +9744,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -10317,7 +10337,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr ""
 
@@ -10330,7 +10350,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -10363,7 +10383,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-05-07 00:48-0400\n"
+"POT-Creation-Date: 2025-05-07 02:33-0400\n"
 "PO-Revision-Date: 2024-12-30 10:00+0000\n"
 "Last-Translator: pesder <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
@@ -495,15 +495,15 @@ msgstr "<本地|全域> <查詢>"
 msgid "<old alias> <new alias>"
 msgstr "<舊别名> <新别名>"
 
-#: cmd/incus/remote.go:980 cmd/incus/remote.go:1046
+#: cmd/incus/remote.go:1127 cmd/incus/remote.go:1193
 msgid "<remote>"
 msgstr "<遠端>"
 
-#: cmd/incus/remote.go:1094
+#: cmd/incus/remote.go:1241
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:1046
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:659
+#: cmd/incus/remote.go:671
 msgid "A client certificate is already present"
 msgstr ""
 
@@ -565,11 +565,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:767
+#: cmd/incus/remote.go:914
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:132
 msgid "Accept certificate"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:121
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:110
+#: cmd/incus/remote.go:122
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -767,7 +767,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:212
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -843,7 +843,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:565
+#: cmd/incus/remote.go:577
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:155
+#: cmd/incus/remote.go:167
 msgid "Available projects:"
 msgstr ""
 
@@ -1066,7 +1066,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:1024
+#: cmd/incus/remote.go:1171
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:238
+#: cmd/incus/remote.go:250
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1171,7 +1171,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:479
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:611
+#: cmd/incus/remote.go:623
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1304,7 +1304,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:549 cmd/incus/remote.go:898
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:968
 #: cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:2776
@@ -1489,12 +1489,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:503
+#: cmd/incus/remote.go:515
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
+#: cmd/incus/remote.go:256 cmd/incus/remote.go:499
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:498
+#: cmd/incus/remote.go:510
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1981,10 +1981,10 @@ msgstr ""
 #: cmd/incus/project.go:530 cmd/incus/project.go:759 cmd/incus/project.go:826
 #: cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025
 #: cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35
-#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
-#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
-#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
-#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49
+#: cmd/incus/remote.go:122 cmd/incus/remote.go:651 cmd/incus/remote.go:698
+#: cmd/incus/remote.go:763 cmd/incus/remote.go:872 cmd/incus/remote.go:1049
+#: cmd/incus/remote.go:1130 cmd/incus/remote.go:1195 cmd/incus/remote.go:1243
 #: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
 #: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
 #: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
@@ -2379,7 +2379,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:591 cmd/incus/remote.go:925
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2891
@@ -2784,7 +2784,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:210
+#: cmd/incus/remote.go:222
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2803,7 +2803,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:261
+#: cmd/incus/remote.go:273
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2833,7 +2833,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:251
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2848,7 +2848,7 @@ msgstr ""
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:276
+#: cmd/incus/remote.go:288
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:283
+#: cmd/incus/remote.go:295
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:268
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -3125,7 +3125,7 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
 #: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:551
-#: cmd/incus/project.go:1098 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/project.go:1098 cmd/incus/remote.go:897 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:966 cmd/incus/storage_volume.go:1623
 #: cmd/incus/storage_volume.go:2789 cmd/incus/warning.go:98
@@ -3176,7 +3176,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:770
+#: cmd/incus/remote.go:917
 msgid "GLOBAL"
 msgstr ""
 
@@ -3188,15 +3188,29 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
+#: cmd/incus/remote.go:762
+msgid "Generate a client token derived from the client certificate"
+msgstr ""
+
+#: cmd/incus/remote.go:763
+msgid ""
+"Generate a client trust token derived from the existing client certificate "
+"and private key.\n"
+"\n"
+"This is useful for remote authentication workflows where a token is passed "
+"to another Incus server."
+msgstr ""
+
 #: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:650
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
+#: cmd/incus/remote.go:190 cmd/incus/remote.go:425 cmd/incus/remote.go:676
+#: cmd/incus/remote.go:734 cmd/incus/remote.go:790
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3685,7 +3699,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:365
+#: cmd/incus/remote.go:377
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3801,7 +3815,7 @@ msgstr ""
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:354
+#: cmd/incus/remote.go:366
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -4687,11 +4701,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:871
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:725
+#: cmd/incus/remote.go:872
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5077,7 +5091,7 @@ msgid ""
 "(user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:48 cmd/incus/remote.go:49
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -5089,7 +5103,7 @@ msgstr ""
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:639
+#: cmd/incus/remote.go:651
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
@@ -5457,7 +5471,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
 #: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
-#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:764
+#: cmd/incus/project.go:574 cmd/incus/project.go:725 cmd/incus/remote.go:911
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:983
 #: cmd/incus/storage_volume.go:1726 cmd/incus/storage_volume.go:2881
@@ -5492,7 +5506,7 @@ msgstr ""
 #: cmd/incus/network.go:1211 cmd/incus/operation.go:209
 #: cmd/incus/project.go:612 cmd/incus/project.go:621 cmd/incus/project.go:630
 #: cmd/incus/project.go:639 cmd/incus/project.go:648 cmd/incus/project.go:657
-#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
+#: cmd/incus/remote.go:975 cmd/incus/remote.go:984 cmd/incus/remote.go:993
 msgid "NO"
 msgstr ""
 
@@ -5554,7 +5568,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:160
+#: cmd/incus/remote.go:172
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5860,7 +5874,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:348
+#: cmd/incus/remote.go:360
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
@@ -5956,11 +5970,11 @@ msgstr ""
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:913
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:915
 msgid "PUBLIC"
 msgstr ""
 
@@ -6011,7 +6025,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:201
+#: cmd/incus/remote.go:213
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -6019,7 +6033,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:479
+#: cmd/incus/remote.go:491
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -6090,6 +6104,10 @@ msgstr ""
 
 #: cmd/incus/main.go:118
 msgid "Print help"
+msgstr ""
+
+#: cmd/incus/remote.go:716
+msgid "Print the client certificate used by this Incus client"
 msgstr ""
 
 #: cmd/incus/query.go:44
@@ -6208,7 +6226,7 @@ msgstr ""
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:125
+#: cmd/incus/remote.go:137
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -6234,7 +6252,7 @@ msgstr ""
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:136
 msgid "Public image server"
 msgstr ""
 
@@ -6351,37 +6369,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:940
+#: cmd/incus/remote.go:1087
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:931
-#: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1060 cmd/incus/project.go:1232 cmd/incus/remote.go:1078
+#: cmd/incus/remote.go:1159 cmd/incus/remote.go:1224 cmd/incus/remote.go:1272
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:317
+#: cmd/incus/remote.go:329
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:1020
+#: cmd/incus/remote.go:1167
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:935 cmd/incus/remote.go:1016 cmd/incus/remote.go:1129
+#: cmd/incus/remote.go:1082 cmd/incus/remote.go:1163 cmd/incus/remote.go:1276
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:311
+#: cmd/incus/remote.go:323
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:133
 msgid "Remote trust token"
 msgstr ""
 
@@ -6463,7 +6481,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:982 cmd/incus/remote.go:983
+#: cmd/incus/remote.go:1129 cmd/incus/remote.go:1130
 msgid "Remove remotes"
 msgstr ""
 
@@ -6533,7 +6551,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:901 cmd/incus/remote.go:902
+#: cmd/incus/remote.go:1048 cmd/incus/remote.go:1049
 msgid "Rename remotes"
 msgstr ""
 
@@ -6708,7 +6726,7 @@ msgstr ""
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:916
 msgid "STATIC"
 msgstr ""
 
@@ -6764,15 +6782,15 @@ msgstr ""
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:135
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:489
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:607
+#: cmd/incus/remote.go:619
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -6781,7 +6799,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:134
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
@@ -7016,7 +7034,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/remote.go:1095 cmd/incus/remote.go:1096
+#: cmd/incus/remote.go:1242 cmd/incus/remote.go:1243
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -7290,7 +7308,7 @@ msgstr ""
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:697 cmd/incus/remote.go:698
 msgid "Show the default remote"
 msgstr ""
 
@@ -7564,7 +7582,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:1047 cmd/incus/remote.go:1048
+#: cmd/incus/remote.go:1194 cmd/incus/remote.go:1195
 msgid "Switch the default remote"
 msgstr ""
 
@@ -7994,7 +8012,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:579
+#: cmd/incus/remote.go:591
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -8037,7 +8055,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:912
 msgid "URL"
 msgstr ""
 
@@ -8079,7 +8097,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
+#: cmd/incus/remote.go:245 cmd/incus/remote.go:279
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -8101,7 +8119,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:597 cmd/incus/remote.go:931
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:999
 #: cmd/incus/storage_volume.go:1761 cmd/incus/storage_volume.go:2897
@@ -8580,7 +8598,7 @@ msgstr ""
 #: cmd/incus/network.go:1208 cmd/incus/operation.go:212
 #: cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632
 #: cmd/incus/project.go:641 cmd/incus/project.go:650 cmd/incus/project.go:659
-#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
+#: cmd/incus/remote.go:977 cmd/incus/remote.go:986 cmd/incus/remote.go:995
 msgid "YES"
 msgstr ""
 
@@ -9288,7 +9306,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:120
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -9300,7 +9318,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:727 cmd/incus/remote.go:799
+#: cmd/incus/project.go:727 cmd/incus/remote.go:946
 msgid "current"
 msgstr ""
 
@@ -9893,7 +9911,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:488
 msgid "n"
 msgstr ""
 
@@ -9906,7 +9924,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:468
+#: cmd/incus/remote.go:480
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9939,7 +9957,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:490
 msgid "y"
 msgstr ""
 


### PR DESCRIPTION
This PR adds two new CLI subcommands under `incus remote`:

- `get-client-certificate`: Prints the client certificate in PEM format.
- `get-client-token`: Generates a JWT using the existing client certificate and private key.

These commands might replace the tls2jwt test tool, improve certificate discoverability. Hope that the format and code is good.

Closes #2010

Signed-off-by: stoven2k17 <stoven2k17@gmail.com>