### PR TITLE
Allow overriding the external address (NAT) for OVN NICs

### DIFF
--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -71,6 +71,7 @@ You can select this NIC type through the `nictype` option or the `network` optio
 
 A `bridged` NIC uses an existing bridge on the host and creates a virtual device pair to connect the host bridge to the instance.
 
+
 #### Device options
 
 NIC devices of type `bridged` have the following device options:
@@ -149,6 +150,36 @@ You can select this NIC type only through the `network` option (see {ref}`networ
 ```
 
 An `ovn` NIC uses an existing OVN network and creates a virtual device pair to connect the instance to it.
+
+#### External address SNAT override
+
+By default, instances using an `ovn` NIC will have their outbound traffic SNATed to a network-specific address assigned by the OVN network.
+
+If you want an instance to use a specific external IP address (from a network forward) as its **default source address** for outgoing connections, you can configure the NIC with:
+
+- `ipv4.address.external`
+- `ipv6.address.external`
+
+These options override the default SNAT behavior. The specified address must exactly match one of the `target_address` values configured on a **network forward** attached to the same OVN network.
+
+When configured, Incus will inject a static SNAT rule into OVN, ensuring outbound traffic from the instance appears to come from that external IP.
+
+#### Example usage
+
+```note
+#bash
+# Create an OVN network
+incus network create ovn-net --type=ovn
+
+# Add a network forward on that network
+incus network forward create ovn-net 203.0.113.100
+
+# Attach the forward to an instance
+incus network forward add ovn-net 203.0.113.100 device=my-instance
+
+# Assign the external address as SNAT IP
+incus config device set my-instance eth0 ipv4.address.external=203.0.113.100
+
 
 (devices-nic-hw-acceleration)=
 SR-IOV hardware acceleration

--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -149,6 +149,22 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		//  shortdesc: An IPv6 address to assign to the instance through DHCP, `none` can be used to disable IP allocation
 		"ipv6.address",
 
+		// gendoc:generate(entity=devices, group=nic_ovn, key=ipv4.address.external)
+		//
+		// ---
+		// type: string
+		// managed: no
+		// shortdesc: Use this network-forward IPv4 address for SNAT egress
+		"ipv4.address.external",
+
+		// gendoc:generate(entity=devices, group=nic_ovn, key=ipv6.address.external)
+		//
+		// ---
+		// type: string
+		// managed: no
+		// shortdesc: Use this network-forward IPv4 address for SNAT egress
+		"ipv6.address.external",
+
 		// gendoc:generate(entity=devices, group=nic_ovn, key=ipv4.routes)
 		//
 		// ---
@@ -428,10 +444,44 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		return validate.IsNetworkAddressV6(value)
 	})
 
+	rules["ipv4.address.external"] = validate.Optional(func(value string) error{
+		if value == "none" {
+			return nil
+		}
+		
+		return validate.IsNetworkAddressV4(value)
+	})
+
+	rules["ipv6.address.external"] = validate.Optional(func(value string) error{
+		if value == "none" {
+			return nil
+		}
+		
+		return validate.IsNetworkAddressV6(value)
+	})
+
 	// Now run normal validation.
-	err = d.config.Validate(rules)
-	if err != nil {
+	// err = d.config.Validate(rules)
+	// if err != nil {
+	// 	return err
+	// }
+
+	//Updated for address.external
+	if err := d.config.Validate(rules); err != nil {
 		return err
+	}
+
+	//verify that any non-empty address belongs to a forward
+	for _, key := range []string{"ipv4.address.external", "ipv6.address.external"} {
+		//trim might not be needed
+		ip := strings.TrimSpace(d.config[key])
+		if ip == "" || strings.EqualFold(ip, "none") {
+			continue //unset
+		}
+
+		if err := d.externalIPBelongsForward(ip); err != nil {
+			return err
+		}
 	}
 
 	// Check IP external routes are within the network's external routes.
@@ -463,6 +513,28 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	return nil
+}
+
+// Helper method used in validation of address.external 
+// externalIPBelongsForward (name is up for consideration) returns nil if extIP is the address of an already existing network forward that is found 
+// in the NIC's network, return an error otherwise
+func (d *nicOVN) externalIPBelongsForward(extIP string) error {
+	return d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+
+		projectName := d.inst.Project().Name
+
+		netID, _, _, err := tx.GetNetworkInAnyState(ctx, projectName, d.config["network"])
+		if err != nil {
+			return fmt.Errorf("failed getting network ID: %w", err)
+		}
+
+		_, _, err = tx.GetNetworkForward(ctx, netID, false, extIP)
+		if err != nil {
+			return fmt.Errorf("external address %s is not a network forward on network %q: %w",
+				extIP, d.config["network"], err)
+		}
+		return nil
+	})
 }
 
 // checkAddressConflict checks for conflicting IP/MAC addresses on another NIC connected to same network.
@@ -608,6 +680,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 
 		uplinkConfig = uplink.Config
 	}
+	
 
 	// Setup the host network interface (if not nested).
 	var peerName, integrationBridgeNICName string

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -4397,6 +4397,53 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		checkAndStoreIP(net.ParseIP(staticIP))
 	}
 
+	// Per‑NIC SNAT — if the device requests an external address use it for outbound NAT.
+	for _, rule := range []struct {
+		cfgKey string
+		ip     net.IP
+	}{
+		{"ipv4.address.external", dnsIPv4},
+		{"ipv6.address.external", dnsIPv6},
+	} {
+	extStr := opts.DeviceConfig[rule.cfgKey]
+	if rule.ip == nil || extStr == "" || strings.EqualFold(extStr, "none") {
+		continue
+	}
+
+	extIP := net.ParseIP(extStr)
+	if extIP == nil {
+		return "", nil, fmt.Errorf("Invalid %s %q", rule.cfgKey, extStr)
+	}
+
+	prefix := IPToNet(rule.ip)
+	if rule.ip.To4() == nil {
+		prefix.Mask = net.CIDRMask(128, 128)
+	}
+
+	if err := n.ovnnb.CreateLogicalRouterNAT(
+		context.TODO(),
+		n.getRouterName(),
+		"snat",
+		&prefix,
+		extIP,
+		nil,
+		false,
+		true,
+	); err != nil {
+		return "", nil, fmt.Errorf("Failed to add SNAT (%s): %w", extStr, err)
+	}
+
+	reverter.Add(func() {
+		_ = n.ovnnb.DeleteLogicalRouterNAT(
+			context.TODO(),
+			n.getRouterName(),
+			"snat",
+			false,
+			extIP,
+		)
+	})
+	}
+
 	// Get dynamic IPs for switch port if any IPs not assigned statically.
 	if (ipv4 != "none" && dnsIPv4 == nil) || (ipv6 != "none" && dnsIPv6 == nil) {
 		var dynamicIPs []net.IP
@@ -4449,6 +4496,8 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			}
 		}
 	}
+
+	
 
 	// Publish NIC's IPs on uplink network if NAT is disabled and using l2proxy ingress mode on uplink.
 	if slices.Contains([]string{"l2proxy", ""}, opts.UplinkConfig["ovn.ingress_mode"]) {
@@ -4923,6 +4972,27 @@ func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort networkOVN.OVNSwitchPort
 		err = n.ovnnb.DeleteLogicalRouterNAT(context.TODO(), n.getRouterName(), "dnat_and_snat", false, removeNATIPs...)
 		if err != nil {
 			return err
+		}
+	}
+
+	//  Tear down per‑NIC egress SNAT rules (ipv4/ipv6.address.external)
+	for _, k := range []string{"ipv4.address.external", "ipv6.address.external"} {
+		ext := opts.DeviceConfig[k]
+		if ext == "" || strings.EqualFold(ext, "none") {
+			continue
+		}
+
+		if ip := net.ParseIP(ext); ip != nil {
+			// Delete only the row that matches this external IP.
+			if err := n.ovnnb.DeleteLogicalRouterNAT(
+				context.TODO(),
+				n.getRouterName(),
+				"snat",
+				false,
+				ip,
+			); err != nil && !errors.Is(err, networkOVN.ErrNotFound) {
+				return err
+			}
 		}
 	}
 
@@ -7098,3 +7168,4 @@ func (n *ovn) loadBalancerBGPSetupPrefixes() error {
 
 	return nil
 }
+


### PR DESCRIPTION
Added the ability to override NAT for OVN NICs.
Modified:
   - doc/devices-nic.md: Inserted a new feature section for ipvX.address.external option
   - nic_ovn.go: Added two new options, ipvX.address.external, X = {4,6}, added validation logic 
   - driver/ovn: Add support for external SNAT IPs per NIC
Fixes #1850 