### PR TITLE
Use our own QMP monitor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/checkpoint-restore/go-criu/v6 v6.3.0
 	github.com/cowsql/go-cowsql v1.22.0
-	github.com/digitalocean/go-qemu v0.0.0-20250212194115-ee9b0668d242
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
 	github.com/flosch/pongo2/v6 v6.0.0
@@ -80,7 +79,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da // indirect
-	github.com/digitalocean/go-libvirt v0.0.0-20250512231903-57024326652b // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,10 +106,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
-github.com/digitalocean/go-libvirt v0.0.0-20250512231903-57024326652b h1:o/RoLbHmKtibc3lMpuPcYGUjnboEORpLFnqtC89tfqY=
-github.com/digitalocean/go-libvirt v0.0.0-20250512231903-57024326652b/go.mod h1:B2R8mtJc0BNx0NvvfOajL5no+MaFDumyD5sHsxll62g=
-github.com/digitalocean/go-qemu v0.0.0-20250212194115-ee9b0668d242 h1:rh6rt8pF5U4iyQ86h6lRDenJoX4ht2wFnZXB9ogIrIM=
-github.com/digitalocean/go-qemu v0.0.0-20250212194115-ee9b0668d242/go.mod h1:LGHUtlhsY4vRGM6AHejEQKVI5e3eHbSylMHwTSpQtVw=
 github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e h1:vUmf0yezR0y7jJ5pceLHthLaYf4bA5T14B6q39S4q2Q=
 github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e/go.mod h1:YTIHhz/QFSYnu/EhlF2SpU2Uk+32abacUYA5ZPljz1A=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -222,7 +222,7 @@ func (m *Monitor) SendFile(name string, file *os.File) error {
 	}
 
 	// Query the status.
-	_, err = m.qmp.RunWithFile(reqJSON, file)
+	_, err = m.qmp.runWithFile(reqJSON, file)
 	if err != nil {
 		// Confirm the daemon didn't die.
 		errPing := m.ping()
@@ -279,7 +279,7 @@ func (m *Monitor) SendFileWithFDSet(name string, file *os.File, readonly bool) (
 		return nil, err
 	}
 
-	ret, err := m.qmp.RunWithFile(reqJSON, file)
+	ret, err := m.qmp.runWithFile(reqJSON, file)
 	if err != nil {
 		// Confirm the daemon didn't die.
 		errPing := m.ping()

--- a/internal/server/instance/drivers/qmp/monitor.go
+++ b/internal/server/instance/drivers/qmp/monitor.go
@@ -97,7 +97,7 @@ func (m *Monitor) start() error {
 	}
 
 	// Start event monitoring go routine.
-	chEvents, err := m.qmp.Events(context.Background())
+	chEvents, err := m.qmp.getEvents(context.Background())
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (m *Monitor) ping() error {
 	}
 
 	// Query the capabilities to validate the monitor.
-	_, err := m.qmp.Run([]byte("{'execute': 'query-version'}"))
+	_, err := m.qmp.run([]byte("{'execute': 'query-version'}"))
 	if err != nil {
 		m.Disconnect()
 		return ErrMonitorDisconnect
@@ -211,7 +211,7 @@ func (m *Monitor) RunJSON(request []byte, resp any, logCommand bool) error {
 		}
 	}
 
-	out, err := m.qmp.Run(request)
+	out, err := m.qmp.run(request)
 	if err != nil {
 		// Confirm the daemon didn't die.
 		errPing := m.ping()
@@ -294,7 +294,7 @@ func Connect(path string, serialCharDev string, eventHandler func(name string, d
 
 	chError := make(chan error, 1)
 	go func() {
-		err = qmpConn.Connect()
+		err = qmpConn.connect()
 		chError <- err
 	}()
 
@@ -305,7 +305,7 @@ func Connect(path string, serialCharDev string, eventHandler func(name string, d
 		}
 
 	case <-time.After(5 * time.Second):
-		_ = qmpConn.Disconnect()
+		_ = qmpConn.disconnect()
 		return nil, errors.New("QMP connection timed out")
 	}
 
@@ -355,7 +355,7 @@ func (m *Monitor) Disconnect() {
 	if !m.disconnected {
 		close(m.chDisconnect)
 		m.disconnected = true
-		_ = m.qmp.Disconnect()
+		_ = m.qmp.disconnect()
 	}
 
 	// Remove from the map.

--- a/internal/server/instance/drivers/qmp/qmp.go
+++ b/internal/server/instance/drivers/qmp/qmp.go
@@ -1,0 +1,263 @@
+package qmp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"golang.org/x/sys/unix"
+)
+
+type qemuMachineProtocal struct {
+	oobSupported bool               // Out of band support or not
+	c            net.Conn           // Underlying connection
+	mu           sync.Mutex         // Serialize running command
+	stream       <-chan rawResponse // Send command responses and errors
+	events       <-chan Event       // Events channel
+	listeners    atomic.Uint32      // Listeners number
+	cid          atomic.Uint32      // Auto increase command id
+}
+
+// Event represents a QEMU QMP event.
+type Event struct {
+	// Event name, e.g., BLOCK_JOB_COMPLETE
+	Event string `json:"event"`
+
+	// Arbitrary event data
+	Data map[string]any `json:"data"`
+
+	// Event timestamp, provided by QEMU.
+	Timestamp *struct {
+		Seconds      int64 `json:"seconds"`
+		Microseconds int64 `json:"microseconds"`
+	} `json:"timestamp"`
+}
+
+// Command represents a QMP command.
+type Command struct {
+	// Name of the command to run
+	Execute string `json:"execute,omitempty"`
+
+	// Name of the Out-off-band execution to run
+	ExecuteOutOfBand string `json:"exec-oob,omitempty"`
+
+	// Optional arguments for the above command.
+	Arguments any `json:"arguments,omitempty"`
+
+	// Optional id for transaction identification associated with the command
+	// execution
+	//
+	// According QMP spec it should be any json value type. For incus `uint32`
+	// (skip zero) is good enough to identify transaction.
+	ID uint32 `json:"id,omitempty"`
+}
+
+// Response represents a QMP response with id and return.
+type Response struct {
+	// Optional id for transaction identification associated with the response
+	ID uint32 `json:"id,omitempty"`
+
+	// Return response return
+	Return any `json:"return,omitempty"`
+}
+
+// Error represents a QMP response error.
+type Error struct {
+	Class string `json:"class,omitempty"`
+	Desc  string `json:"desc,omitempty"`
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%s: %s", e.Class, e.Desc)
+}
+
+// rawResponse represents QMP raw response with id, error and raw bytes.
+type rawResponse struct {
+	// Optional id for transaction identification associated with the response
+	ID uint32 `json:"id"`
+
+	// Error response error
+	Error *Error `json:"error,omitempty"`
+
+	raw []byte // raw data, json field ignored
+	err error  // runtime error, json field ignored
+}
+
+// Disconnect closes the QEMU monitor socket connection.
+func (qmp *qemuMachineProtocal) Disconnect() error {
+	qmp.listeners.Store(0)
+	return qmp.c.Close()
+}
+
+// qmpIncreaseID increase ID and skip zero.
+func (qmp *qemuMachineProtocal) qmpIncreaseID() uint32 {
+	const ZeroKey = uint32(0)
+	id := qmp.cid.Add(1)
+	if id == ZeroKey {
+		id = qmp.cid.Add(1)
+	}
+
+	return id
+}
+
+// Connect sets up a QMP connection.
+func (qmp *qemuMachineProtocal) Connect() error {
+	enc := json.NewEncoder(qmp.c)
+	dec := json.NewDecoder(qmp.c)
+
+	// Check for banner on startup
+	ban := struct {
+		QMP struct {
+			Capabilities []string `json:"capabilities"`
+		} `json:"QMP"`
+	}{}
+
+	err := dec.Decode(&ban)
+	if err != nil {
+		return err
+	}
+
+	qmp.oobSupported = slices.Contains(ban.QMP.Capabilities, "oob")
+
+	// Issue capabilities handshake
+	id := qmp.qmpIncreaseID()
+	cmd := Command{Execute: "qmp_capabilities", ID: id}
+	err = enc.Encode(cmd)
+	if err != nil {
+		return err
+	}
+
+	// Check for no error on return
+	r := &rawResponse{}
+	err = dec.Decode(r)
+	if err != nil {
+		return err
+	}
+
+	if r.Error != nil {
+		return r.Error
+	}
+
+	if r.ID != id {
+		return fmt.Errorf("reply id %d and command id %d mismatch", r.ID, id)
+	}
+
+	// Initialize listener for command responses and asynchronous events
+	events := make(chan Event)
+	stream := make(chan rawResponse)
+	go qmp.listen(qmp.c, events, stream)
+
+	qmp.events = events
+	qmp.stream = stream
+
+	return nil
+}
+
+// Events streams QEMU QMP Events.
+func (qmp *qemuMachineProtocal) Events(context.Context) (<-chan Event, error) {
+	qmp.listeners.Add(1)
+	return qmp.events, nil
+}
+
+func (qmp *qemuMachineProtocal) listen(r io.Reader, events chan<- Event, stream chan<- rawResponse) {
+	defer close(events)
+	defer close(stream)
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		var e Event
+
+		b := scanner.Bytes()
+		err := json.Unmarshal(b, &e)
+		if err != nil {
+			continue
+		}
+
+		// If data does not have an event type, it must be in response to a command.
+		if e.Event == "" {
+			r := rawResponse{}
+			err = json.Unmarshal(b, &r)
+			if err != nil {
+				continue
+			}
+
+			r.raw = make([]byte, len(b))
+			copy(r.raw, b)
+			stream <- r
+			continue
+		}
+
+		// If nobody is listening for events, do not bother sending them.
+		if qmp.listeners.Load() == 0 {
+			continue
+		}
+
+		events <- e
+	}
+
+	err := scanner.Err()
+	if err != nil {
+		stream <- rawResponse{err: err}
+	}
+}
+
+// Run executes the given QAPI command against a domain's QEMU instance.
+func (qmp *qemuMachineProtocal) Run(command []byte) ([]byte, error) {
+	// Just call RunWithFile with no file
+	return qmp.RunWithFile(command, nil)
+}
+
+// RunWithFile executes for passing a file through out-of-band data.
+func (qmp *qemuMachineProtocal) RunWithFile(command []byte, file *os.File) ([]byte, error) {
+	// Only allow a single command to be run at a time to ensure that responses
+	// to a command cannot be mixed with responses from another command
+	qmp.mu.Lock()
+	defer qmp.mu.Unlock()
+
+	if file == nil {
+		// Just send a normal command through.
+		_, err := qmp.c.Write(command)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		unixConn, ok := qmp.c.(*net.UnixConn)
+		if !ok {
+			return nil, fmt.Errorf("RunWithFile only works with unix monitor sockets")
+		}
+
+		if !qmp.oobSupported {
+			return nil, fmt.Errorf("The QEMU server doesn't support oob (needed for RunWithFile)")
+		}
+
+		// Send the command along with the file descriptor.
+		oob := unix.UnixRights(int(file.Fd()))
+		_, _, err := unixConn.WriteMsgUnix(command, oob, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Wait for a response or error to our command
+	res := <-qmp.stream
+	if res.err != nil {
+		return nil, res.err
+	}
+
+	if res.Error != nil {
+		return nil, res.Error
+	}
+
+	return res.raw, nil
+}

--- a/internal/server/instance/drivers/qmp/qmp.go
+++ b/internal/server/instance/drivers/qmp/qmp.go
@@ -20,13 +20,13 @@ type qemuMachineProtocal struct {
 	c            net.Conn           // Underlying connection
 	mu           sync.Mutex         // Serialize running command
 	stream       <-chan rawResponse // Send command responses and errors
-	events       <-chan Event       // Events channel
+	events       <-chan qmpEvent    // Events channel
 	listeners    atomic.Uint32      // Listeners number
 	cid          atomic.Uint32      // Auto increase command id
 }
 
-// Event represents a QEMU QMP event.
-type Event struct {
+// qmpEvent represents a QEMU QMP event.
+type qmpEvent struct {
 	// Event name, e.g., BLOCK_JOB_COMPLETE
 	Event string `json:"event"`
 
@@ -40,8 +40,8 @@ type Event struct {
 	} `json:"timestamp"`
 }
 
-// Command represents a QMP command.
-type Command struct {
+// qmpCommand represents a QMP command.
+type qmpCommand struct {
 	// Name of the command to run
 	Execute string `json:"execute,omitempty"`
 
@@ -59,8 +59,8 @@ type Command struct {
 	ID uint32 `json:"id,omitempty"`
 }
 
-// Response represents a QMP response with id and return.
-type Response struct {
+// qmpResponse represents a QMP response with id and return.
+type qmpResponse struct {
 	// Optional id for transaction identification associated with the response
 	ID uint32 `json:"id,omitempty"`
 
@@ -68,13 +68,13 @@ type Response struct {
 	Return any `json:"return,omitempty"`
 }
 
-// Error represents a QMP response error.
-type Error struct {
+// qmpError represents a QMP response error.
+type qmpError struct {
 	Class string `json:"class,omitempty"`
 	Desc  string `json:"desc,omitempty"`
 }
 
-func (e *Error) Error() string {
+func (e *qmpError) Error() string {
 	if e == nil {
 		return ""
 	}
@@ -88,14 +88,14 @@ type rawResponse struct {
 	ID uint32 `json:"id"`
 
 	// Error response error
-	Error *Error `json:"error,omitempty"`
+	Error *qmpError `json:"error,omitempty"`
 
 	raw []byte // raw data, json field ignored
 	err error  // runtime error, json field ignored
 }
 
-// Disconnect closes the QEMU monitor socket connection.
-func (qmp *qemuMachineProtocal) Disconnect() error {
+// disconnect closes the QEMU monitor socket connection.
+func (qmp *qemuMachineProtocal) disconnect() error {
 	qmp.listeners.Store(0)
 	return qmp.c.Close()
 }
@@ -111,8 +111,8 @@ func (qmp *qemuMachineProtocal) qmpIncreaseID() uint32 {
 	return id
 }
 
-// Connect sets up a QMP connection.
-func (qmp *qemuMachineProtocal) Connect() error {
+// connect sets up a QMP connection.
+func (qmp *qemuMachineProtocal) connect() error {
 	enc := json.NewEncoder(qmp.c)
 	dec := json.NewDecoder(qmp.c)
 
@@ -132,7 +132,7 @@ func (qmp *qemuMachineProtocal) Connect() error {
 
 	// Issue capabilities handshake
 	id := qmp.qmpIncreaseID()
-	cmd := Command{Execute: "qmp_capabilities", ID: id}
+	cmd := qmpCommand{Execute: "qmp_capabilities", ID: id}
 	err = enc.Encode(cmd)
 	if err != nil {
 		return err
@@ -154,7 +154,7 @@ func (qmp *qemuMachineProtocal) Connect() error {
 	}
 
 	// Initialize listener for command responses and asynchronous events
-	events := make(chan Event)
+	events := make(chan qmpEvent)
 	stream := make(chan rawResponse)
 	go qmp.listen(qmp.c, events, stream)
 
@@ -164,19 +164,19 @@ func (qmp *qemuMachineProtocal) Connect() error {
 	return nil
 }
 
-// Events streams QEMU QMP Events.
-func (qmp *qemuMachineProtocal) Events(context.Context) (<-chan Event, error) {
+// getEvents streams QEMU QMP Events.
+func (qmp *qemuMachineProtocal) getEvents(context.Context) (<-chan qmpEvent, error) {
 	qmp.listeners.Add(1)
 	return qmp.events, nil
 }
 
-func (qmp *qemuMachineProtocal) listen(r io.Reader, events chan<- Event, stream chan<- rawResponse) {
+func (qmp *qemuMachineProtocal) listen(r io.Reader, events chan<- qmpEvent, stream chan<- rawResponse) {
 	defer close(events)
 	defer close(stream)
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		var e Event
+		var e qmpEvent
 
 		b := scanner.Bytes()
 		err := json.Unmarshal(b, &e)
@@ -212,14 +212,14 @@ func (qmp *qemuMachineProtocal) listen(r io.Reader, events chan<- Event, stream 
 	}
 }
 
-// Run executes the given QAPI command against a domain's QEMU instance.
-func (qmp *qemuMachineProtocal) Run(command []byte) ([]byte, error) {
+// run executes the given QAPI command against a domain's QEMU instance.
+func (qmp *qemuMachineProtocal) run(command []byte) ([]byte, error) {
 	// Just call RunWithFile with no file
-	return qmp.RunWithFile(command, nil)
+	return qmp.runWithFile(command, nil)
 }
 
-// RunWithFile executes for passing a file through out-of-band data.
-func (qmp *qemuMachineProtocal) RunWithFile(command []byte, file *os.File) ([]byte, error) {
+// runWithFile executes for passing a file through out-of-band data.
+func (qmp *qemuMachineProtocal) runWithFile(command []byte, file *os.File) ([]byte, error) {
 	// Only allow a single command to be run at a time to ensure that responses
 	// to a command cannot be mixed with responses from another command
 	qmp.mu.Lock()

--- a/internal/server/instance/drivers/qmp/qmp_test.go
+++ b/internal/server/instance/drivers/qmp/qmp_test.go
@@ -1,0 +1,264 @@
+package qmp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+var testingGreeting = map[string]any{
+	"QMP": map[string]any{
+		"version": map[string]any{
+			"qemu": map[string]any{
+				"micro": 2,
+				"minor": 2,
+				"major": 9,
+			},
+			"package": "v9.2.2",
+		},
+		"capabilities": []string{"oob"},
+	},
+}
+
+type testingErrReader struct {
+	err error
+}
+
+func (r *testingErrReader) Read(b []byte) (int, error) {
+	return 0, r.err
+}
+
+func TestConnectDisconnect(t *testing.T) {
+	eg := &errgroup.Group{}
+	m := mockMonitorServer(t, eg)
+
+	err := m.Connect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = m.Disconnect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = eg.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEvents(t *testing.T) {
+	eg := &errgroup.Group{}
+	es := []Event{
+		{Event: "STOP"},
+		{Event: "SHUTDOWN"},
+		{Event: "RESET"},
+	}
+
+	m := mockMonitorServer(t, eg, func(tc net.Conn) error {
+		enc := json.NewEncoder(tc)
+		for i, e := range es {
+			err := enc.Encode(e)
+			if err != nil {
+				t.Log(i, e, err)
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	err := m.Connect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := m.Events(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i, want := range es {
+		got := <-events
+		if !reflect.DeepEqual(want, got) {
+			t.Fatal(i, want, got)
+		}
+	}
+
+	err = eg.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListenEmptyStream(t *testing.T) {
+	mon := &qemuMachineProtocal{}
+
+	r := strings.NewReader("")
+
+	events := make(chan Event)
+	stream := make(chan rawResponse)
+
+	mon.listen(r, events, stream)
+
+	_, ok := <-events
+	if ok {
+		t.Fatal("events channel should be closed")
+	}
+
+	_, ok = <-stream
+	if ok {
+		t.Fatal("stream channel should be closed")
+	}
+}
+
+func TestListenScannerErr(t *testing.T) {
+	mon := &qemuMachineProtocal{}
+
+	errFoo := errors.New("foo")
+	r := &testingErrReader{err: errFoo}
+
+	events := make(chan Event)
+	stream := make(chan rawResponse)
+
+	go mon.listen(r, events, stream)
+	res := <-stream
+
+	if errFoo != res.err {
+		t.Fatalf("unexpected error:\n- want: %v\n-  got: %v", errFoo, res.err)
+	}
+}
+
+func TestListenInvalidJson(t *testing.T) {
+	mon := &qemuMachineProtocal{}
+
+	r := strings.NewReader("<html>")
+
+	events := make(chan Event)
+	stream := make(chan rawResponse)
+
+	mon.listen(r, events, stream)
+
+	_, ok := <-stream
+	if ok {
+		t.Fatal("stream channel should be closed")
+	}
+}
+
+func TestListenStreamResponse(t *testing.T) {
+	mon := &qemuMachineProtocal{}
+
+	want := `{"foo": "bar"}`
+	r := strings.NewReader(want)
+
+	events := make(chan Event)
+	stream := make(chan rawResponse)
+
+	go mon.listen(r, events, stream)
+
+	res := <-stream
+	if res.err != nil {
+		t.Fatalf("unexpected error: %v", res.err)
+	}
+
+	got := string(res.raw)
+	if want != got {
+		t.Fatalf("unexpected response:\n- want: %q\n-  got: %q", want, got)
+	}
+}
+
+func TestListenEventNoListeners(t *testing.T) {
+	mon := &qemuMachineProtocal{}
+
+	r := strings.NewReader(`{"event":"STOP"}`)
+
+	events := make(chan Event)
+	stream := make(chan rawResponse)
+
+	go mon.listen(r, events, stream)
+
+	_, ok := <-events
+	if ok {
+		t.Fatal("events channel should be closed")
+	}
+}
+
+func TestListenEventOneListener(t *testing.T) {
+	mon := &qemuMachineProtocal{}
+	mon.listeners.Store(1)
+
+	eventStop := "STOP"
+	r := strings.NewReader(fmt.Sprintf(`{"event":%q}`, eventStop))
+
+	events := make(chan Event)
+	stream := make(chan rawResponse)
+
+	go mon.listen(r, events, stream)
+
+	e := <-events
+	want, got := eventStop, e.Event
+	if want != got {
+		t.Fatalf("unexpected event:\n- want: %q\n-  got: %q", want, got)
+	}
+}
+
+func mockMonitorServer(t *testing.T, eg *errgroup.Group, hands ...func(net.Conn) error) *qemuMachineProtocal {
+	t.Helper()
+	sc, tc := net.Pipe()
+
+	m := &qemuMachineProtocal{
+		c: sc,
+	}
+
+	eg.Go(func() error {
+		enc := json.NewEncoder(tc)
+		dec := json.NewDecoder(tc)
+		err := enc.Encode(testingGreeting)
+		if err != nil {
+			t.Logf("unexpected error: %v", err)
+			return err
+		}
+
+		var cmd Command
+		err = dec.Decode(&cmd)
+		if err != nil {
+			err = fmt.Errorf("unexpected error: %w", err)
+			t.Log(err)
+			return err
+		}
+
+		if cmd.Execute != "qmp_capabilities" {
+			err = fmt.Errorf("unexpected capabilities handshake:\n- want: %q\n-  got: %q",
+				"qmp_capabilities", cmd.Execute)
+			t.Log(err)
+			return err
+		}
+
+		err = enc.Encode(Response{ID: cmd.ID})
+		if err != nil {
+			err = fmt.Errorf("unexpected error: %w", err)
+			t.Log(err)
+			return err
+		}
+
+		for i, hand := range hands {
+			err = hand(tc)
+			if err != nil {
+				t.Log(i, err)
+				return err
+			}
+		}
+
+		return err
+	})
+
+	return m
+}


### PR DESCRIPTION
`digitalocean/go-qemu/qmp` depends on `digitalocean/go-qemu` and `digitalocean/go-libvirt` as well, incus does not use anything related with go-libvrit, and the qmp part less maintaining, and do not associate response id with command id. So remove it.