### PR TITLE
incus-migrate: prompt for cluster target

### DIFF
--- a/cmd/incus-migrate/main_migrate.go
+++ b/cmd/incus-migrate/main_migrate.go
@@ -44,6 +44,7 @@ type Migration struct {
 	server        incus.InstanceServer
 	sourceFormat  string
 	sourcePath    string
+	target        string
 }
 
 func (m *Migration) runMigration(migrationHandler func(path string) error) error {
@@ -195,6 +196,30 @@ func (m *Migration) setSourceFormat() error {
 			m.sourceFormat = "raw"
 		}
 	}
+
+	return nil
+}
+
+func (m *Migration) askTarget() error {
+	if !m.server.IsClustered() {
+		return nil
+	}
+
+	ok, err := m.asker.AskBool("Would you like to target a specific server or group in the cluster? [default=no]: ", "no")
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return nil
+	}
+
+	clusterTarget, err := m.asker.AskString("Target name: ", "", nil)
+	if err != nil {
+		return err
+	}
+
+	m.target = clusterTarget
 
 	return nil
 }

--- a/cmd/incus-migrate/migrate_instance.go
+++ b/cmd/incus-migrate/migrate_instance.go
@@ -72,6 +72,14 @@ func (m *InstanceMigration) gatherInfo() error {
 		m.server = m.server.UseProject(m.project)
 	}
 
+	// Target
+	err = m.askTarget()
+	if err != nil {
+		return err
+	}
+
+	m.server = m.server.UseTarget(m.target)
+
 	// Instance name
 	instanceNames, err := m.server.GetInstanceNames(api.InstanceTypeAny)
 	if err != nil {

--- a/cmd/incus-migrate/migrate_ova.go
+++ b/cmd/incus-migrate/migrate_ova.go
@@ -127,6 +127,14 @@ func (m *OVAMigration) gatherInfo() error {
 		m.server = m.server.UseProject(m.project)
 	}
 
+	// Target
+	err = m.askTarget()
+	if err != nil {
+		return err
+	}
+
+	m.server = m.server.UseTarget(m.target)
+
 	// Pool
 	pools, err := m.server.GetStoragePools()
 	if err != nil {

--- a/cmd/incus-migrate/migrate_volume.go
+++ b/cmd/incus-migrate/migrate_volume.go
@@ -61,6 +61,14 @@ func (m *VolumeMigration) gatherInfo() error {
 		m.server = m.server.UseProject(m.project)
 	}
 
+	// Target
+	err = m.askTarget()
+	if err != nil {
+		return err
+	}
+
+	m.server = m.server.UseTarget(m.target)
+
 	// Pool
 	pools, err := m.server.GetStoragePools()
 	if err != nil {


### PR DESCRIPTION
```
sudo ~/go/bin/incus-migrate
The local Incus server is the target [default=yes]:
Want to specify cluster target server? [default=no]: yes
Please provide name of cluster target server [default=none]: incus-svr1

What would you like to create?
1) Container
2) Virtual Machine
3) Virtual Machine (from .ova)
4) Custom Volume

Please enter the number of your choice:
```

**What was changed?**
    Changes or issue https://github.com/lxc/incus/issues/2094 
- [x] During migration of physical or virtual machines to Incus, we will prompt for cluster target and set in client
- [x] or cluster group

**Tests Done**
    build complete fine
    Applied `incus-migrate` on test system and confirmed that prompt is made and validates if server is clustered