### PR TITLE
Feature: Added support for "physical" interface with bridge as parent

### DIFF
--- a/internal/server/device/nic_physical.go
+++ b/internal/server/device/nic_physical.go
@@ -130,6 +130,12 @@ func (d *nicPhysical) validateConfig(instConf instance.ConfigReader) error {
 		// Get actual parent device from network's parent setting.
 		d.config["parent"] = netConfig["parent"]
 
+		// If parent is a bridge, ensure it's managed.
+		isParentBridge := d.config["parent"] != "" && util.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", d.config["parent"]))
+		if isParentBridge && d.network == nil {
+			return fmt.Errorf("Parent device is a bridge, use nictype=bridged instead")
+		}
+
 		// Copy certain keys verbatim from the network's settings.
 		for _, field := range optionalFields {
 			_, found := netConfig[field]


### PR DESCRIPTION
fixes #1735 

After checking if parent property points to a bridge network, we create and instantiate a bridged device which we use to call `Start()` and `Stop()`. 

Meaning we are using 'bridged' logic already implemented, avoiding attempts to attach the parent interface into the container namespace which was the cause of previous errors.

This is the log showing success in launching a container following [these steps](https://github.com/lxc/incus/issues/1735#issuecomment-2799170436) :

```
Name: c1
Description: 
Status: RUNNING
Type: container
Architecture: x86_64
PID: 270002
Created: 2025/05/20 22:48 UTC
Last Used: 2025/05/20 23:26 UTC
Started: 2025/05/20 23:26 UTC

Resources:
  Processes: 10
  CPU usage:
    CPU usage (in seconds): 0
  Memory usage:
    Memory (current): 20.75MiB
  Network usage:
    eth0:
      Type: broadcast
      State: UP
      Host interface: veth57af7d0c
      MAC address: 32:da:df:6b:fc:d6
      MTU: 1500
      Bytes received: 300B
      Bytes sent: 904B
      Packets received: 2
      Packets sent: 5
      IP addresses:
        inet6: fe80::a046:6bff:fe0a:156d/64 (link)
    lo:
      Type: loopback
      State: UP
      MTU: 65536
      Bytes received: 0B
      Bytes sent: 0B
      Packets received: 0
      Packets sent: 0
      IP addresses:
        inet:  127.0.0.1/8 (local)
        inet6: ::1/128 (local)
```