### PR TITLE
incusd/forkproxy: join the correct mntns for listen

### DIFF
--- a/cmd/incusd/main_forkproxy.go
+++ b/cmd/incusd/main_forkproxy.go
@@ -141,7 +141,7 @@ void forkproxy(void)
 		if (in_same_namespace(getpid(), listen_nsfd, "user") > 0)
 			setns_flags |= CLONE_NEWUSER;
 
-		if (needs_mntns & CONNECT_NEEDS_MNTNS)
+		if (needs_mntns & LISTEN_NEEDS_MNTNS)
 			setns_flags |= CLONE_NEWNS;
 
 		if (!change_namespaces(listen_pidfd, listen_nsfd, setns_flags)) {

--- a/internal/server/device/proxy.go
+++ b/internal/server/device/proxy.go
@@ -570,14 +570,6 @@ func (d *proxy) setupNAT() error {
 	return nil
 }
 
-func (d *proxy) rewriteHostAddr(addr string) string {
-	fields := strings.SplitN(addr, ":", 2)
-	proto := fields[0]
-	addr = fields[1]
-
-	return fmt.Sprintf("%s:%s", proto, addr)
-}
-
 func (d *proxy) setupProxyProcInfo() (*proxyProcInfo, error) {
 	cname := project.Instance(d.inst.Project().Name, d.inst.Name())
 	cc, err := liblxc.NewContainer(cname, d.state.OS.LxcPath)
@@ -617,16 +609,12 @@ func (d *proxy) setupProxyProcInfo() (*proxyProcInfo, error) {
 
 		connectPid = containerPid
 		connectPidFd = fmt.Sprintf("%d", containerPidFd)
-
-		listenAddr = d.rewriteHostAddr(listenAddr)
 	case "instance", "guest", "container":
 		listenPid = containerPid
 		listenPidFd = fmt.Sprintf("%d", containerPidFd)
 
 		connectPid = daemonPid
 		connectPidFd = fmt.Sprintf("%d", daemonPidFd)
-
-		connectAddr = d.rewriteHostAddr(connectAddr)
 	default:
 		return nil, fmt.Errorf("Invalid binding side given. Must be \"host\" or \"instance\"")
 	}


### PR DESCRIPTION
This was a copy-paste error introduced in commit https://github.com/lxc/incus/commit/4494bad12c572d069042cf169aa07d8fd82f4b3b
("incusd/main_forkproxy: Join all namespaces at once"). The net result
was that container-binding proxy devices with a unix listener would be
in the wrong mount namespace and the unix socket would accidentally be
created on the host.

Fixes: https://github.com/lxc/incus/commit/4494bad12c572d069042cf169aa07d8fd82f4b3b ("incusd/main_forkproxy: Join all namespaces at once")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>