### PR TITLE
incusd/storage: fix squashfs unpacking to NFS destinations

### DIFF
--- a/internal/linux/filesystem.go
+++ b/internal/linux/filesystem.go
@@ -42,6 +42,16 @@ func DetectFilesystem(path string) (string, error) {
 	return FSTypeToName(int32(fs.Type))
 }
 
+// IsNfs returns true if the path exists and is NFS
+func IsNfs(path string) bool {
+	backingFs, err := DetectFilesystem(path)
+	if err != nil {
+		return false
+	}
+
+	return backingFs == "nfs"
+}
+
 // FSTypeToName returns the name of the given fs type.
 // The fsType is from the Type field of unix.Statfs_t. We use int32 so that this function behaves the same on both
 // 32bit and 64bit platforms by requiring any 64bit FS types to be overflowed before being passed in. They will

--- a/shared/archive/archive.go
+++ b/shared/archive/archive.go
@@ -15,6 +15,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/lxc/incus/v6/internal/linux"
 	"github.com/lxc/incus/v6/shared/ioprogress"
 	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/subprocess"
@@ -198,6 +199,12 @@ func Unpack(file string, path string, blockBackend bool, maxMemory int64, tracke
 			if mem < 256 {
 				args = append(args, "-da", fmt.Sprintf("%d", mem), "-fr", fmt.Sprintf("%d", mem), "-p", "1")
 			}
+		}
+
+		// NFS 4.2 can support xattrs, but not security.xattr
+		if linux.IsNfs(path) {
+			logger.Warn("Unpack: destination path is NFS, disabling non-user xatttr unpacking", logger.Ctx{"file": file, "command": command, "extension": extension, "path": path, "args": args})
+			args = append(args, "-user-xattrs")
 		}
 
 		args = append(args, file)


### PR DESCRIPTION
NFS4v2 supports user.xattrs, and can be used with Incus via the dir driver, but image unpacking will fail when the container image uses non-user xattrs such as security.xattr

This fix will skip extraction of security.xattrs when extracting to an NFS hosted directory

The fix is not specific to the dir driver, and could benefit a future NFS driver (#2025)

In my testing, privileged containers can successfully be started from NFS hosted dir storage pools.