### PR TITLE
Return empty slice instead of nil when no storage pool is present

### DIFF
--- a/cmd/incusd/storage_pools.go
+++ b/cmd/incusd/storage_pools.go
@@ -198,8 +198,9 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	var linkResults []string
-	var fullResults []api.StoragePool
+	linkResults := make([]string, 0)
+	fullResults := make([]api.StoragePool, 0)
+
 	for _, poolName := range poolNames {
 		// Hide storage pools with a 0 project limit.
 		if slices.Contains(hiddenPoolNames, poolName) {


### PR DESCRIPTION
In https://github.com/lxc/incus/pull/1679, the behavior of the `GET /1.0/storage-pools` endpoint was changed to return null (nil) when no storage pools are present, instead of returning an empty array.
This PR reverts that specific change, restoring the original behavior of returning an empty array when no storage pools are available.