### PR TITLE
Clear the "volatile.cpu.nodes" if needed

### DIFF
--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -1668,3 +1668,17 @@ func (d *common) ETag() []any {
 
 	return etag
 }
+
+// ClearLimitsCPUNodes clears the "volatile.cpu.nodes" configuration if necessary.
+func (d *common) ClearLimitsCPUNodes(changedConfig []string) {
+	if !slices.Contains(changedConfig, "limits.cpu.nodes") {
+		return
+	}
+
+	value := d.expandedConfig["limits.cpu.nodes"]
+	if value == "balanced" {
+		return
+	}
+
+	d.localConfig["volatile.cpu.nodes"] = ""
+}

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -5091,6 +5091,9 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 					}
 				}
 			} else if key == "limits.cpu" || key == "limits.cpu.nodes" {
+				// Clear the "volatile.cpu.nodes" if needed.
+				d.ClearLimitsCPUNodes(changedConfig)
+
 				// Trigger a scheduler re-run
 				defer cgroup.TaskSchedulerTrigger("container", d.name, "changed") //nolint:revive
 			} else if key == "limits.cpu.priority" || key == "limits.cpu.allowance" {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -6145,6 +6145,9 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 	}
 
+	// Clear the "volatile.cpu.nodes" if needed.
+	d.ClearLimitsCPUNodes(changedConfig)
+
 	if d.architectureSupportsUEFI(d.architecture) && (slices.Contains(changedConfig, "security.secureboot") || slices.Contains(changedConfig, "security.csm")) {
 		// setupNvram() requires instance's config volume to be mounted.
 		// The easiest way to detect that is to check if instance is running.


### PR DESCRIPTION
Currently, the `volatile.cpu.nodes` value is only set when `limits.cpu.nodes` is set to `balanced`. In all other cases, `volatile.cpu.nodes` remains unchanged. This can be confusing, as it may lead to situations where `volatile.cpu.nodes` and `limits.cpu.nodes` contain different numeric values

Closes: #2121