### PR TITLE
vscode: Add VSCode launch.json for incusd "Run and Debug" functionality

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,57 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            // if the incusd is running, this will attach to it.
+            "name": "Attach to Incusd",
+            "type": "go",
+            "request": "attach",
+            "mode": "local",
+            "processId": "incusd",
+            "asRoot":true,
+            "console": "integratedTerminal"
+        },
+        {
+            
+            // after running `make` to install incusd, assuming that your go/bin is in your home directory, this should launch incusd if its not a service.
+            // if it is an active service, you actually need to restart the service, and then attach to it.
+            "name": "Launch Incusd",
+            "type":"go",
+            "request": "launch",
+            "mode": "exec",
+            "asRoot": true,
+            "program": "${userHome}/go/bin/incusd",
+            "env": {
+                "PATH": "${env:PATH}:${userHome}/go/bin/",
+                "LD_LIBRARY_PATH": "${userHome}/go/deps/raft/.libs/:${userHome}/go/deps/cowsql/.libs/"
+            },
+            "args": [
+                "--group",
+                "sudo"
+            ],
+            "console": "integratedTerminal",
+        },
+        {
+            "name": "Launch Incusd --debug",
+            "type":"go",
+            "request": "launch",
+            "mode": "exec",
+            "asRoot": true,
+            "program": "${userHome}/go/bin/incusd",
+            "env": {
+                "PATH": "${env:PATH}:${userHome}/go/bin/",
+                "LD_LIBRARY_PATH": "${userHome}/go/deps/raft/.libs/:${userHome}/go/deps/cowsql/.libs/"
+            },
+            "args": [
+                "--group",
+                "sudo",
+                "--debug"
+            ],
+            "console": "integratedTerminal",
+        }
+    ]
+}


### PR DESCRIPTION
The Visual Studio Code editor has the ability to attach to or launch golang binaries for interactive debugging, with variable inspection and breakpoints

The launch.json file adds the following menu entries to the "Run and Debug" menu in VS Code

- Attach to Incusd
- Launch Incusd
- Launch Incusd --debug

The first menu will allow the user to select a running incusd instance to attach the VS Code Go Delve debugger to.

The other two options will launch the most recently built incusd, with or without the --debug option, allowing live debugging in the editor with breakpoints

Assuming incusd is built into the ~/go/bin directory.

<img width="449" alt="Screenshot 2025-05-29 at 1 48 56 PM" src="https://github.com/user-attachments/assets/29d36e90-8777-41d8-bc08-1bfce4c2c729" />
