### PR TITLE
Allow updating root disk size and root io.bus simultaneously

### DIFF
--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -1430,6 +1430,15 @@ func (d *common) devicesUpdate(inst instance.Instance, removeDevices deviceConfi
 
 			reverter.Add(func() { _ = dm.deviceStop(dev, instanceRunning, "") })
 		}
+
+		// For the root disk, call Update as its size may change.
+		// Update will invoke applyQuota, which resizes the disk if necessary.
+		if internalInstance.IsRootDiskDevice(dev.Config()) {
+			err = dev.Update(oldExpandedDevices, instanceRunning)
+			if err != nil {
+				return fmt.Errorf("Failed to update device %q: %w", dev.Name(), err)
+			}
+		}
 	}
 
 	for _, entry := range updateDevices.Sorted() {


### PR DESCRIPTION
When both `io.bus` and disk size are changed together, the device is removed and re-added. In contrast, when only the size is changed, `Update` is called, which in turn invokes `applyQuota` to adjust the disk size .
This change ensures that `Update` is also called for the root disk when it is removed and re-added, allowing the size change to be applied correctly.

Fixes: #2137