### PR TITLE
incusd/storage/zfs: Fix missing incus:content_type after cloning a custom volume

### DIFF
--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -833,6 +833,11 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			args = append(args, "-o", "volmode=none")
 		}
 
+		if vol.volType == VolumeTypeCustom {
+			// Regenerate incus:content_type, which was lost when cloning
+			args = append(args, "-o", fmt.Sprintf("incus:content_type=%s", vol.contentType))
+		}
+
 		args = append(args, srcSnapshot, d.dataset(vol, false))
 
 		// Clone the snapshot.


### PR DESCRIPTION
When creating a volume of type `VolumeTypeCustom` with the ZFS driver the `incus:content_type` user property
is used to capture the `ContentType`. When recovering the storage pool or the volume, this
`content_type` is used to disambiguate the volume if it is using `zfs.block_mode`.

Unfortunately, when cloning the volume using `zfs.clone_copy` mode the `content_type` is lost
and the filesystem block mode volumes are imported as block mode volumes instead.

The fix corrects by regenerating the content_type during the clone when it is still known.

A test has been added to storage_driver_zfs.sh which reproduces the issue, and confirms the fix.