### PR TITLE
Prevent initialization of `qmpLog` with an empty log file path

### DIFF
--- a/internal/server/instance/drivers/qmp/log.go
+++ b/internal/server/instance/drivers/qmp/log.go
@@ -1,6 +1,7 @@
 package qmp
 
 import (
+	"fmt"
 	"os"
 	"sync"
 )
@@ -12,6 +13,10 @@ type qmpLog struct {
 }
 
 func newQmpLog(logFile string) (*qmpLog, error) {
+	if logFile == "" {
+		return nil, fmt.Errorf("Log file path is empty")
+	}
+
 	ql := &qmpLog{
 		logFile: logFile,
 	}

--- a/internal/server/instance/drivers/qmp/monitor.go
+++ b/internal/server/instance/drivers/qmp/monitor.go
@@ -292,7 +292,7 @@ func Connect(path string, serialCharDev string, eventHandler func(name string, d
 	}
 
 	qmpConn := &qemuMachineProtocal{uc: uc}
-	if util.PathExists(filepath.Dir(logFile)) {
+	if logFile != "" && util.PathExists(filepath.Dir(logFile)) {
 		qlog, err := newQmpLog(logFile)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
PR #2181 introduced a regression that can lead to errors during VM initialization when the log file path is empty. In such cases, QEMU fails to start properly, resulting in errors like:
```
Unable to run feature checks during QEMU initialization: QEMU monitor connect error: dial unix /tmp/3114984335: connect: resource temporarily unavailable
```
This PR addresses the issue by ensuring that an empty log file path is properly handled, preventing `qmpLog` from being initialized with an invalid value.
