### PR TITLE
Remove target check when server clustered

### DIFF
--- a/cmd/incusd/storage_volumes.go
+++ b/cmd/incusd/storage_volumes.go
@@ -727,13 +727,11 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 		return response.Conflict(errors.New("Volume by that name already exists"))
 	}
 
-	target := request.QueryParam(r, "target")
-
 	// Check if we need to switch to migration
 	serverName := s.ServerName
 	var nodeAddress string
 
-	if s.ServerClustered && target != "" && (req.Source.Location != "" && serverName != req.Source.Location) {
+	if s.ServerClustered && (req.Source.Location != "" && serverName != req.Source.Location) {
 		err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 			nodeInfo, err := tx.GetNodeByName(ctx, req.Source.Location)
 			if err != nil {


### PR DESCRIPTION
When the server is part of a cluster and the source volume is on different target, we don't need to check the `target` parameter. In such cases, `clusterCopyCustomVolumeInternal` should always be used.

That said, when executing the command:
`incus storage volume copy local/bug-test local/bug-test-copy`
if the source volume is located on a different cluster node, the system should always call `clusterCopyCustomVolumeInternal`.

Closes: #2178