### PR TITLE
client: Don't swallow error if incusParseResponse is successful

### DIFF
--- a/client/incus.go
+++ b/client/incus.go
@@ -468,7 +468,14 @@ func (r *ProtocolIncus) rawWebsocket(url string) (*websocket.Conn, error) {
 	conn, resp, err := r.DoWebsocket(dialer, url, req)
 	if err != nil {
 		if resp != nil {
-			_, _, err = incusParseResponse(resp)
+			apiResp, _, parseErr := incusParseResponse(resp)
+			if parseErr != nil {
+				err = errors.Join(err, parseErr)
+			}
+
+			if apiResp != nil && apiResp.Error != "" {
+				err = errors.Join(err, fmt.Errorf(apiResp.Error))
+			}
 		}
 
 		return nil, err


### PR DESCRIPTION
During my testing, I had a situation, where `r.DoWebsocket` returned an error and `incusParseResponse` was successful, which caused the `err` to be `nil` and therefore a the method did `return nil, nil`. This caused a panic, since the `websocket.Conn` was `nil`. If there is an error, we need to make sure, that the method actually does return an error, even if the parsing of the incus response is successful.