### PR TITLE
incusd/storage/lvm: Avoid concurrent activation/deactivation

### DIFF
--- a/internal/server/storage/drivers/driver_lvm.go
+++ b/internal/server/storage/drivers/driver_lvm.go
@@ -29,6 +29,8 @@ import (
 
 const lvmVgPoolMarker = "incus_pool" // Indicator tag used to mark volume groups as in use.
 
+var lvmActivation sync.Mutex
+
 var (
 	lvmExtentSize   map[string]int64
 	lvmExtentSizeMu sync.Mutex

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -928,6 +928,9 @@ func (d *lvm) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 	if d.clustered && volSrcArgs.ClusterMove && !volSrcArgs.StorageMove {
 		// Ensure the volume allows shared access.
 		if vol.volType == VolumeTypeVM || vol.IsCustomBlock() {
+			lvmActivation.Lock()
+			defer lvmActivation.Unlock()
+
 			// Block volume.
 			volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.Name())
 			if util.PathExists(volDevPath) {


### PR DESCRIPTION
We've seen a number of cases where we're racing the LVM tools or udev depending on distros and LVM config, so let's just serialize things on our end.