### PR TITLE
incusd/instance/qemu: Fix memory calculation logic

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4183,11 +4183,8 @@ func (d *qemu) addCPUMemoryConfig(conf *[]cfg.Section, cpuType string, cpuInfo *
 			}
 		}
 
-		if cpuType == "host" && lowestPhysBits > 0 {
-			// Line up cpuPhysBits with the lowest physical CPU value.
-			cpuPhysBits = lowestPhysBits
-		} else if lowestPhysBits < cpuPhysBits {
-			// Reduce curPhysBits below the default of 39 if a physical CPU uses a lower value.
+		// If a physical address size was detected, either align it with the VM (CPU passthrough) or use it as an upper bound.
+		if lowestPhysBits > 0 && (cpuType == "host" || lowestPhysBits < cpuPhysBits) {
 			cpuPhysBits = lowestPhysBits
 		}
 


### PR DESCRIPTION
This fixes another issue with the logic where a system with no detected physical bits would cause a 0 value which would then be decreased, leading to the maximum value possible of 1TB.