### PR TITLE
shared/idmap: Skip ACLs that are out of range

### DIFF
--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -527,6 +527,11 @@ func shiftACLType(path string, aclType int, shiftIDs func(uid int64, gid int64) 
 			_, newID = shiftIDs(-1, (int64)(*idp))
 		}
 
+		// Skip values that are out of range.
+		if newID == -1 {
+			continue
+		}
+
 		// Update the new entry with the shifted value
 		ret = C.acl_set_qualifier(ent, unsafe.Pointer(&newID))
 		if ret == -1 {


### PR DESCRIPTION
This is typically ACLs that were set from outside of the containers or that have already been shifted. That -1 value would cause the ACL calls to fail, leading to a partly shifted container.


Sponsored-by: https://webdock.io