### PR TITLE
client: request profile scope in oidc device code flow

### DIFF
--- a/client/incus_oidc.go
+++ b/client/incus_oidc.go
@@ -81,7 +81,7 @@ func (o *oidcTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 var (
 	errRefreshAccessToken = errors.New("Failed refreshing access token")
-	oidcScopes            = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail}
+	oidcScopes            = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail, oidc.ScopeProfile}
 )
 
 type oidcClient struct {


### PR DESCRIPTION
Without this scope the IdP may not include claims, such as `preferred_username`, which incus expects to be present if configured in `oidc.claim`. This results in an error `Error: not authorized` which is confusing to users.

The requested scopes should be made configurable, maybe based on the `oidc.scopes` server configuration option, but my go skills are non-existent :) 