### PR TITLE
incusd/device/nic_ovn: Allow specifying static IPv4/IPv6 when DHCP is…

### DIFF
--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -321,11 +321,6 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	netConfig := d.network.Config()
 
 	if d.config["ipv4.address"] != "" && d.config["ipv4.address"] != "none" {
-		// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs).
-		if n.DHCPv4Subnet() == nil {
-			return fmt.Errorf("Cannot specify %q when DHCP is disabled on network %q", "ipv4.address", d.config["network"])
-		}
-
 		ip, subnet, err := net.ParseCIDR(netConfig["ipv4.address"])
 		if err != nil {
 			return fmt.Errorf("Invalid network ipv4.address: %w", err)
@@ -344,11 +339,6 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	if d.config["ipv6.address"] != "" && d.config["ipv6.address"] != "none" {
-		// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs).
-		if n.DHCPv6Subnet() == nil || util.IsFalseOrEmpty(netConfig["ipv6.dhcp.stateful"]) {
-			return fmt.Errorf("Cannot specify %q when DHCP or %q are disabled on network %q", "ipv6.address", "ipv6.dhcp.stateful", d.config["network"])
-		}
-
 		// Static IPv6 is allowed only if static IPv4 is set as well.
 		if d.config["ipv4.address"] == "" {
 			return fmt.Errorf("Cannot specify %q when %q is not set", "ipv6.address", "ipv4.address")


### PR DESCRIPTION
… disabled

Even when doing static assignment, OVN must be made aware of the address in use.