### PR TITLE
cmd/incus_agent: Replace gorilla/mux with http.ServeMux

### DIFF
--- a/cmd/incus-agent/dev_incus.go
+++ b/cmd/incus-agent/dev_incus.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/internal/server/daemon"
@@ -86,8 +83,8 @@ var DevIncusConfigGet = devIncusHandler{"/1.0/config", func(d *Daemon, w http.Re
 }}
 
 var DevIncusConfigKeyGet = devIncusHandler{"/1.0/config/{key}", func(d *Daemon, w http.ResponseWriter, r *http.Request) *devIncusResponse {
-	key, err := url.PathUnescape(mux.Vars(r)["key"])
-	if err != nil {
+	key := r.PathValue("key")
+	if key == "" {
 		return &devIncusResponse{"bad request", http.StatusBadRequest, "raw"}
 	}
 
@@ -251,8 +248,7 @@ func hoistReq(f func(*Daemon, http.ResponseWriter, *http.Request) *devIncusRespo
 }
 
 func devIncusAPI(d *Daemon) http.Handler {
-	router := mux.NewRouter()
-	router.UseEncodedPath() // Allow encoded values in path segments.
+	router := http.NewServeMux()
 
 	for _, handler := range handlers {
 		router.HandleFunc(handler.path, hoistReq(handler.f, d))

--- a/cmd/incus-agent/server.go
+++ b/cmd/incus-agent/server.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	internalIO "github.com/lxc/incus/v6/internal/io"
 	"github.com/lxc/incus/v6/internal/server/response"
 	localUtil "github.com/lxc/incus/v6/internal/server/util"
@@ -18,9 +16,7 @@ import (
 )
 
 func restServer(tlsConfig *tls.Config, cert *x509.Certificate, debug bool, d *Daemon) *http.Server {
-	router := mux.NewRouter()
-	router.StrictSlash(false) // Don't redirect to URL with trailing slash.
-	router.UseEncodedPath()   // Allow encoded values in path segments.
+	router := http.NewServeMux()
 
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -34,7 +30,7 @@ func restServer(tlsConfig *tls.Config, cert *x509.Certificate, debug bool, d *Da
 	return &http.Server{Handler: router, TLSConfig: tlsConfig}
 }
 
-func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Certificate, debug bool, d *Daemon) {
+func createCmd(restAPI *http.ServeMux, version string, c APIEndpoint, cert *x509.Certificate, debug bool, d *Daemon) {
 	var uri string
 	if c.Path == "" {
 		uri = fmt.Sprintf("/%s", version)
@@ -42,7 +38,7 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 		uri = fmt.Sprintf("/%s/%s", version, c.Path)
 	}
 
-	route := restAPI.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
+	restAPI.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		if !authenticate(r, cert) {
@@ -101,12 +97,6 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 			}
 		}
 	})
-
-	// If the endpoint has a canonical name then record it so it can be used to build URLS
-	// and accessed in the context of the request by the handler function.
-	if c.Name != "" {
-		route.Name(c.Name)
-	}
 }
 
 func authenticate(r *http.Request, cert *x509.Certificate) bool {


### PR DESCRIPTION
Since Go 1.22, we have the ability to create a request multiplexer using `http.ServeMux` with native libraries. This makes the [`gorilla/mux`](https://github.com/gorilla/mux) library obsolete (which also hasn't received any new commits for over a year now).

This PR removes usage of `gorilla/mux` for the `incus_agent` as a start. I do think it would be a wise decision to adopt this for all usages of it in this repository eventually.