### PR TITLE
Fixed non-constant format string in call to fmt.Errorf

### DIFF
--- a/client/incus.go
+++ b/client/incus.go
@@ -474,7 +474,7 @@ func (r *ProtocolIncus) rawWebsocket(url string) (*websocket.Conn, error) {
 			}
 
 			if apiResp != nil && apiResp.Error != "" {
-				err = errors.Join(err, fmt.Errorf(apiResp.Error))
+				err = errors.Join(err, errors.New(apiResp.Error))
 			}
 		}
 


### PR DESCRIPTION
This PR fixes formatting for string passed to `fmt.Errorf`.  This is inline with the recent golang 1.24 changes to its printf analyzer.  

I am one of the package maintainers for Fedora, incus fails our go vet checks due to this.