### PR TITLE
incusd/ip: fix allmulti regression

### DIFF
--- a/internal/server/ip/link.go
+++ b/internal/server/ip/link.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 // Link represents base arguments for link device.
@@ -69,11 +68,22 @@ func (l *Link) netlinkAttrs() (netlink.LinkAttrs, error) {
 		linkAttrs.Flags |= net.FlagUp
 	}
 
-	if l.AllMulticast {
-		linkAttrs.Flags |= unix.IFF_ALLMULTI
+	return linkAttrs, nil
+}
+
+func (l *Link) addLink(link netlink.Link) error {
+	err := netlink.LinkAdd(link)
+	if err != nil {
+		return err
 	}
 
-	return linkAttrs, nil
+	// ALLMULTI can't be set on create
+	err = l.SetAllMulticast(l.AllMulticast)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // LinkByName returns a Link from a device name.

--- a/internal/server/ip/link_bridge.go
+++ b/internal/server/ip/link_bridge.go
@@ -16,7 +16,7 @@ func (b *Bridge) Add() error {
 		return err
 	}
 
-	return netlink.LinkAdd(&netlink.Bridge{
+	return b.addLink(&netlink.Bridge{
 		LinkAttrs: attrs,
 	})
 }

--- a/internal/server/ip/link_dummy.go
+++ b/internal/server/ip/link_dummy.go
@@ -16,7 +16,7 @@ func (d *Dummy) Add() error {
 		return err
 	}
 
-	return netlink.LinkAdd(&netlink.Dummy{
+	return d.addLink(&netlink.Dummy{
 		LinkAttrs: attrs,
 	})
 }

--- a/internal/server/ip/link_gretap.go
+++ b/internal/server/ip/link_gretap.go
@@ -20,7 +20,7 @@ func (g *Gretap) Add() error {
 		return err
 	}
 
-	return netlink.LinkAdd(&netlink.Gretap{
+	return g.addLink(&netlink.Gretap{
 		LinkAttrs: attrs,
 		Local:     g.Local,
 		Remote:    g.Remote,

--- a/internal/server/ip/link_macvlan.go
+++ b/internal/server/ip/link_macvlan.go
@@ -36,7 +36,7 @@ func (macvlan *Macvlan) Add() error {
 		return err
 	}
 
-	return netlink.LinkAdd(&netlink.Macvlan{
+	return macvlan.addLink(&netlink.Macvlan{
 		LinkAttrs: attrs,
 		Mode:      macvlan.netlinkMode(),
 	})

--- a/internal/server/ip/link_macvtap.go
+++ b/internal/server/ip/link_macvtap.go
@@ -16,7 +16,7 @@ func (macvtap *Macvtap) Add() error {
 		return err
 	}
 
-	return netlink.LinkAdd(&netlink.Macvtap{
+	return macvtap.addLink(&netlink.Macvtap{
 		Macvlan: netlink.Macvlan{
 			LinkAttrs: attrs,
 			Mode:      macvtap.netlinkMode(),

--- a/internal/server/ip/link_veth.go
+++ b/internal/server/ip/link_veth.go
@@ -32,5 +32,5 @@ func (veth *Veth) Add() error {
 	link.PeerTxQLen = peerAttrs.TxQLen
 	link.PeerHardwareAddr = peerAttrs.HardwareAddr
 
-	return netlink.LinkAdd(link)
+	return veth.addLink(link)
 }

--- a/internal/server/ip/link_vlan.go
+++ b/internal/server/ip/link_vlan.go
@@ -26,7 +26,7 @@ func (vlan *Vlan) Add() error {
 		return fmt.Errorf("Invalid VLAN ID: %w", err)
 	}
 
-	return netlink.LinkAdd(&netlink.Vlan{
+	return vlan.addLink(&netlink.Vlan{
 		LinkAttrs: attrs,
 		VlanId:    id,
 		Gvrp:      &vlan.Gvrp,

--- a/internal/server/ip/link_vxlan.go
+++ b/internal/server/ip/link_vxlan.go
@@ -57,7 +57,7 @@ func (vxlan *Vxlan) Add() error {
 		group = vxlan.Remote
 	}
 
-	return netlink.LinkAdd(&netlink.Vxlan{
+	return vxlan.addLink(&netlink.Vxlan{
 		LinkAttrs:    attrs,
 		VxlanId:      vxlan.VxlanID,
 		VtepDevIndex: devIndex,


### PR DESCRIPTION
The `ALLMULTI` flag is not sent on device creation, so we need to set it afterwards.
