### PR TITLE
incusd/cluster/config: Update certificate also on change of acme.http.port

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -804,7 +804,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 
 	for key := range clusterChanged {
 		switch key {
-		case "acme.agree_tos", "acme.ca_url", "acme.challenge", "acme.domain", "acme.email", "acme.provider", "acme.provider.environment", "acme.provider.resolvers":
+		case "acme.agree_tos", "acme.ca_url", "acme.challenge", "acme.domain", "acme.email", "acme.provider", "acme.provider.environment", "acme.provider.resolvers", "acme.http.port":
 			acmeChanged = true
 
 		case "cluster.images_minimal_replica":


### PR DESCRIPTION
I noticed that the setting of acme.http.port was not included in the logic that handles updating certificates.