### PR TITLE
Implement disk ejection

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2838,3 +2838,7 @@ on schedule.
 This adds tracking of CPU address sizes in the resources API.
 The main use of this is within clusters to calculate a cluster-wide
 maximum memory amount for hotplugging into virtual machines.
+
+## `disk_attached`
+
+This introduces a new `attached` property to disk devices describing whether disks are attached or ejected.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -42,6 +42,14 @@ User keys can be used in search.
 
 <!-- config group cluster_group-common end -->
 <!-- config group devices-disk start -->
+```{config:option} attached devices-disk
+:default: "`true`"
+:required: "no"
+:shortdesc: "Only for VMs: Whether the disk is attached or ejected"
+:type: "bool"
+
+```
+
 ```{config:option} boot.priority devices-disk
 :required: "no"
 :shortdesc: "Boot priority for VMs (higher value boots first)"

--- a/internal/server/device/config/device_runconfig.go
+++ b/internal/server/device/config/device_runconfig.go
@@ -31,6 +31,7 @@ type MountEntryItem struct {
 	OwnerShift string      // Ownership shifting mode, use constants MountOwnerShiftNone, MountOwnerShiftStatic or MountOwnerShiftDynamic.
 	Limits     *DiskLimits // Disk limits.
 	Size       int64       // Expected disk size in bytes.
+	Attached   bool        // Whether the disk is attached
 }
 
 // RootFSEntryItem represents the root filesystem options for an Instance.

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4249,6 +4249,7 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]any, mountInfo *storagePool
 		Opts:       rootDriveConf.Opts,
 		TargetPath: rootDriveConf.TargetPath,
 		Limits:     rootDriveConf.Limits,
+		Attached:   true,
 	}
 
 	if d.storagePool.Driver().Info().Remote {
@@ -4664,7 +4665,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 			blockDev["filename"] = fmt.Sprintf("/dev/fdset/%d", info.ID)
 		}
 
-		err := m.AddBlockDevice(blockDev, qemuDev)
+		err := m.AddBlockDevice(blockDev, qemuDev, driveConf.Attached)
 		if err != nil {
 			return fmt.Errorf("Failed adding block device for disk device %q: %w", driveConf.DevName, err)
 		}
@@ -7386,7 +7387,7 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 				"driver":   "file",
 				"filename": fmt.Sprintf("/dev/fdset/%d", info.ID),
 			},
-		}, nil)
+		}, nil, true)
 		if err != nil {
 			return fmt.Errorf("Failed adding migration storage snapshot block device: %w", err)
 		}
@@ -7529,7 +7530,7 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 					"path":     strings.TrimPrefix(listener.Addr().String(), "@"),
 				},
 			},
-		}, nil)
+		}, nil, true)
 		if err != nil {
 			return fmt.Errorf("Failed adding NBD device: %w", err)
 		}
@@ -9462,7 +9463,7 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 		"aio":       "io_uring",
 	}
 
-	err = monitor.AddBlockDevice(blockDev, nil)
+	err = monitor.AddBlockDevice(blockDev, nil, true)
 	if err != nil {
 		logger.Debug("Failed adding block device during VM feature check", logger.Ctx{"err": err})
 	} else {

--- a/internal/server/instance/drivers/driver_qemu_metrics.go
+++ b/internal/server/instance/drivers/driver_qemu_metrics.go
@@ -20,7 +20,7 @@ import (
 
 func (d *qemu) getQemuMetrics() (*metrics.MetricSet, error) {
 	// Connect to the monitor.
-	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler(), d.QMPLogFilePath())
+	monitor, err := d.qmpConnect()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -711,7 +711,11 @@ func (m *Monitor) AddObject(args map[string]any) error {
 }
 
 // AddBlockDevice adds a block device.
-func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]any) error {
+func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]any, attached bool) error {
+	if !attached {
+		return nil
+	}
+
 	reverter := revert.New()
 	defer reverter.Fail()
 

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -1250,22 +1250,6 @@ func (m *Monitor) BlockJobComplete(deviceNodeName string) error {
 	return nil
 }
 
-// Eject ejects a removable drive.
-func (m *Monitor) Eject(id string) error {
-	var args struct {
-		ID string `json:"id"`
-	}
-
-	args.ID = id
-
-	err := m.Run("eject", args, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // UpdateBlockSize updates the size of a disk.
 func (m *Monitor) UpdateBlockSize(id string) error {
 	var args struct {

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -52,6 +52,15 @@
 			"disk": {
 				"keys": [
 					{
+						"attached": {
+							"default": "`true`",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Only for VMs: Whether the disk is attached or ejected",
+							"type": "bool"
+						}
+					},
+					{
 						"boot.priority": {
 							"longdesc": "",
 							"required": "no",

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -489,6 +489,7 @@ var APIExtensions = []string{
 	"backup_s3_upload",
 	"snapshot_manual_expiry",
 	"resources_cpu_address_sizes",
+	"disk_attached",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR is not 100% ready. I’d like to discuss 2 things:
- Whether the attached/detached logic can stay as is, or should only concern CD-ROM drives (cf. TODO);
- Whether the attached/detached logic should be emulated like a full/empty CD-ROM tray, or (as it’s currently done in this PR) by simply removing/re-adding another CD-ROM drive.

Emulating an empty tray will require a bit more work, but can look a bit fancier to the user, actually seeing that the device is here but not the blockdev.

Closes #2093