### PR TITLE
Fix validation of 'L' shorthand column in list command

### DIFF
--- a/cmd/incus/list.go
+++ b/cmd/incus/list.go
@@ -541,13 +541,6 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 		columnsShorthandMap['L'] = column{
 			i18n.G("LOCATION"), c.locationColumnData, false, false,
 		}
-	} else {
-		if c.flagColumns != defaultColumns && c.flagColumns != defaultColumnsAllProjects {
-			if strings.ContainsAny(c.flagColumns, "L") {
-				return nil, false, errors.New(i18n.G("Can't specify column L when not clustered"))
-			}
-		}
-		c.flagColumns = strings.ReplaceAll(c.flagColumns, "L", "")
 	}
 
 	columnList := strings.Split(c.flagColumns, ",")
@@ -562,6 +555,15 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 		// Config keys always contain a period, parse anything without a
 		// period as a series of shorthand runes.
 		if !strings.Contains(columnEntry, ".") {
+			if !clustered {
+				if columnEntry != defaultColumns && columnEntry != defaultColumnsAllProjects {
+					if strings.ContainsAny(columnEntry, "L") {
+						return nil, false, errors.New(i18n.G("Can't specify column L when not clustered"))
+					}
+				}
+				columnEntry = strings.ReplaceAll(columnEntry, "L", "")
+			}
+
 			for _, columnRune := range columnEntry {
 				column, ok := columnsShorthandMap[columnRune]
 				if !ok {


### PR DESCRIPTION
Currently, in a non-clustered environment, validation fails when the value of the `--columns` flag includes any phrase containing 'L', because we check whether the 'L' shorthand (for Location) is present, which isn't allowed in such environments.

However, users can also specify custom column keys, like:
`--columns devices:uwe-work.source:LOCATION`
In this case, validation incorrectly fails because the phrase contains 'L', even though it refers to a config/device key, not a shorthand.

This PR fixes the issue by improving the validation logic:
- Each column entry is now evaluated individually.
- If an entry contains a dot (.), it’s treated as a config/device key, not a shorthand. The Location shorthand check is skipped for such entries.

Fixes: #2279