### PR TITLE
incusd/storage: Fix ISO renaming

### DIFF
--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -70,8 +70,16 @@ func genericVFSRenameVolume(d Driver, vol Volume, newVolName string, op *operati
 	reverter := revert.New()
 	defer reverter.Fail()
 
+	volName := vol.name
+
+	// Add a .iso suffix to ISO volumes.
+	if vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeISO {
+		volName = volName + genericISOVolumeSuffix
+		newVolName = newVolName + genericISOVolumeSuffix
+	}
+
 	// Rename the volume itself.
-	srcVolumePath := GetVolumeMountPath(d.Name(), vol.volType, vol.name)
+	srcVolumePath := GetVolumeMountPath(d.Name(), vol.volType, volName)
 	dstVolumePath := GetVolumeMountPath(d.Name(), vol.volType, newVolName)
 
 	if util.PathExists(srcVolumePath) {


### PR DESCRIPTION
Closes: #2290

Not a huge fan of the solution, as it leads to code duplication with `MountPath`. Some refactoring may be worth it, LMK if it’s something you’d like me to look at.