### PR TITLE
incusd/instance/qemu: Cleanup volume eject/detach logic

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -5893,33 +5893,8 @@ func qemuDetachDisk(s *state.State, id int) func(string) error {
 // Detach a disk from the instance.
 func (d *qemu) detachDisk(name string) error {
 	diskName := strings.TrimPrefix(name, qemuDeviceIDPrefix)
-	var id int
-	var devices map[string]dbCluster.Device
-	err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		object, err := dbCluster.GetInstance(ctx, tx.Tx(), d.project.Name, d.name)
-		if err != nil {
-			return err
-		}
 
-		id = object.ID
-		devices, err = dbCluster.GetInstanceDevices(ctx, tx.Tx(), id)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	disk, ok := devices[diskName]
-	if !ok {
-		return fmt.Errorf("Device %s not found", diskName)
-	}
-
-	disk.Config["attached"] = "false"
-
+	// Load and detach the disk.
 	config, ok := d.expandedDevices[diskName]
 	if !ok {
 		return fmt.Errorf("Couldn't find device %s", diskName)
@@ -5935,8 +5910,27 @@ func (d *qemu) detachDisk(name string) error {
 		return err
 	}
 
+	// Check if it's a special device (we don't store detached state on those).
+	if slices.Contains([]string{"agent:config", "cloud-init:config"}, config["source"]) {
+		return nil
+	}
+
+	// Find the disk device.
+	_, ok = d.localDevices[diskName]
+	if !ok {
+		// Device came from a profile, we can't save its state.
+		return nil
+	}
+
+	d.localDevices[diskName]["attached"] = "false"
+
 	return d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return dbCluster.UpdateInstanceDevices(ctx, tx.Tx(), int64(id), devices)
+		devices, err := dbCluster.APIToDevices(d.localDevices.CloneNative())
+		if err != nil {
+			return err
+		}
+
+		return dbCluster.UpdateInstanceDevices(ctx, tx.Tx(), int64(d.id), devices)
 	})
 }
 


### PR DESCRIPTION
This removes some duplicate logic, avoids failures when volumes come from profiles and adds special-handling for our internal volumes.


Sponsored-by: https://webdock.io