### PR TITLE
Fixes for virtiofs and 9p shares

### DIFF
--- a/cmd/incus-agent/os_linux.go
+++ b/cmd/incus-agent/os_linux.go
@@ -119,38 +119,13 @@ func osMountShared(src string, dst string, fstype string, opts []string) error {
 		return nil
 	}
 
-	// Prepare the arguments.
-	sharedArgs := []string{}
-	p9Args := []string{}
-
+	args := []string{"-t", fstype, src, dst}
 	for _, opt := range opts {
-		// transport and msize mount option are specific to 9p.
-		if strings.HasPrefix(opt, "trans=") || strings.HasPrefix(opt, "msize=") {
-			p9Args = append(p9Args, "-o", opt)
-			continue
-		}
-
-		sharedArgs = append(sharedArgs, "-o", opt)
+		args = append(args, "-o", opt)
 	}
-
-	// Always try virtiofs first.
-	args := []string{"-t", "virtiofs", src, dst}
-	args = append(args, sharedArgs...)
 
 	_, err := subprocess.RunCommand("mount", args...)
 	if err == nil {
-		return nil
-	} else if fstype == "virtiofs" {
-		return err
-	}
-
-	// Then fallback to 9p.
-	args = []string{"-t", "9p", src, dst}
-	args = append(args, sharedArgs...)
-	args = append(args, p9Args...)
-
-	_, err = subprocess.RunCommand("mount", args...)
-	if err != nil {
 		return err
 	}
 

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -95,8 +95,12 @@ For block devices (disks), this is one of:
 
 For file systems (shared directories or custom volumes), this is one of:
 - `9p`
-- `auto` (default) (`virtiofs` + `9p`, just `9p` if `virtiofsd` is missing)
+- `auto` (default) (`virtiofs` if possible, else `9p`)
 - `virtiofs`
+
+`9p` doesn't support hotplugging and `virtiofs` doesn't support live migration. `auto` tries
+to use `virtiofs` if possible (`migration.stateful` not set to `true` and host support for
+`virtiofsd`) and falls back to `9p` otherwise.
 ```
 
 ```{config:option} io.cache devices-disk
@@ -2587,6 +2591,12 @@ The disk quota is applied the next time the instance starts.
 :shortdesc: "Network device MAC address"
 :type: "string"
 The network device MAC address is used when no `hwaddr` property is set on the device itself.
+```
+
+```{config:option} volatile.<name>.io.bus instance-volatile
+:shortdesc: "IO bus in use"
+:type: "string"
+The IO bus stores the actual IO bus being used, checked in case `io.bus=auto`.
 ```
 
 ```{config:option} volatile.<name>.last_state.created instance-volatile

--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -1241,6 +1241,15 @@ func ConfigKeyChecker(key string, instanceType api.InstanceType) (func(value str
 			return validate.IsAny, nil
 		}
 
+		// gendoc:generate(entity=instance, group=volatile, key=volatile.<name>.io.bus)
+		// The IO bus stores the actual IO bus being used, checked in case `io.bus=auto`.
+		// ---
+		//  type: string
+		//  shortdesc: IO bus in use
+		if strings.HasSuffix(key, ".io.bus") {
+			return validate.IsAny, nil
+		}
+
 		// gendoc:generate(entity=instance, group=volatile, key=volatile.<name>.mig.uuid)
 		// The NVIDIA MIG instance UUID.
 		// ---

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2707,7 +2707,7 @@ func (d *lxc) detachInterfaceRename(netns string, ifName string, hostName string
 // Start starts the instance.
 func (d *lxc) Start(stateful bool) error {
 	// Check that migration.stateful is set for stateful actions.
-	if stateful && util.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) {
+	if stateful && !d.CanLiveMigrate() {
 		return errors.New("Stateful start requires that the instance migration.stateful be set to true")
 	}
 
@@ -2999,7 +2999,7 @@ func (d *lxc) Stop(stateful bool) error {
 	defer d.logger.Debug("Stop finished", logger.Ctx{"stateful": stateful})
 
 	// Check that migration.stateful is set for stateful actions.
-	if stateful && util.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) {
+	if stateful && !d.CanLiveMigrate() {
 		return errors.New("Stateful stop requires the instance to have migration.stateful be set to true")
 	}
 
@@ -3858,7 +3858,7 @@ func (d *lxc) RenderState(hostInterfaces []net.Interface) (*api.InstanceState, e
 // snapshot creates a snapshot of the instance.
 func (d *lxc) snapshot(name string, expiry time.Time, stateful bool) error {
 	// Check that migration.stateful is set for stateful actions.
-	if stateful && util.IsFalseOrEmpty(d.expandedConfig["migration.stateful"]) {
+	if stateful && !d.CanLiveMigrate() {
 		return errors.New("Stateful snapshots require that the instance has migration.stateful be set to true")
 	}
 
@@ -9181,4 +9181,9 @@ func (d *lxc) ReloadDevice(devName string) error {
 	}
 
 	return dev.Update(d.expandedDevices, true)
+}
+
+// CanLiveMigrate returns whether the container is live-migratable.
+func (d *lxc) CanLiveMigrate() bool {
+	return util.IsTrue(d.expandedConfig["migration.stateful"])
 }

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4247,7 +4247,7 @@ func (d *qemu) driveDirConfig9p(qemuDev map[string]any, busName string, agentMou
 	agentMount := instancetype.VMAgentMount{
 		Source: mountTag,
 		Target: driveConf.TargetPath,
-		FSType: driveConf.FSType,
+		FSType: "9p",
 
 		// We need to specify to use the virtio transport to support more VM guest OSes.
 		// Also set the msize to 32MB to allow for reasonably fast 9p access.
@@ -4293,7 +4293,7 @@ func (d *qemu) addDriveDirConfigVirtiofs(qemuDev map[string]any, agentMounts *[]
 		agentMount := instancetype.VMAgentMount{
 			Source: mountTag,
 			Target: driveConf.TargetPath,
-			FSType: driveConf.FSType,
+			FSType: "virtiofs",
 		}
 
 		// Indicate to agent to mount this readonly. Note: This is purely to indicate to VM guest that this is

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3905,10 +3905,7 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuType string, cpuI
 					// Populate the qemu device with port info.
 					qemuDev["bus"] = devBus
 					qemuDev["addr"] = devAddr
-
-					if multi {
-						qemuDev["multifunction"] = true
-					}
+					qemuDev["multifunction"] = multi
 				}
 
 				if drive.TargetPath == "/" {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4648,7 +4648,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 			qemuDev["driver"] = "scsi-cd"
 		}
 	} else if slices.Contains([]string{"nvme", "virtio-blk"}, bus) {
-		if qemuDev["bus"] == "" {
+		if qemuDev["bus"] == nil {
 			// Try to get a PCI address for hotplugging.
 			pciDeviceName, err := d.getPCIHotplug()
 			if err != nil {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -2532,93 +2532,22 @@ func (d *qemu) deviceStart(dev device.Device, instanceRunning bool) (*deviceConf
 }
 
 func (d *qemu) deviceAttachPath(deviceName string, configCopy map[string]string, mount deviceConfig.MountEntryItem) error {
-	escapedDeviceName := linux.PathNameEncode(deviceName)
-	deviceID := fmt.Sprintf("%s%s", qemuDeviceIDPrefix, escapedDeviceName)
-	mountTag := fmt.Sprintf("incus_%s", deviceName)
-
-	// Detect virtiofsd path.
-	virtiofsdSockPath := filepath.Join(d.DevicesPath(), fmt.Sprintf("virtio-fs.%s.sock", deviceName))
-	if !util.PathExists(virtiofsdSockPath) {
-		return errors.New("Virtiofsd isn't running")
-	}
-
-	reverter := revert.New()
-	defer reverter.Fail()
-
 	// Check if the agent is running.
 	monitor, err := d.qmpConnect()
 	if err != nil {
 		return fmt.Errorf("Failed to connect to QMP monitor: %w", err)
 	}
 
-	addr, err := net.ResolveUnixAddr("unix", virtiofsdSockPath)
+	monHook, err := d.addDriveDirConfigVirtiofs(nil, nil, mount)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to add drive config: %w", err)
 	}
 
-	virtiofsSock, err := net.DialUnix("unix", nil, addr)
+	err = monHook(monitor)
 	if err != nil {
-		return fmt.Errorf("Error connecting to virtiofs socket %q: %w", virtiofsdSockPath, err)
+		return fmt.Errorf("Failed to call monitor hook for block device: %w", err)
 	}
 
-	defer func() { _ = virtiofsSock.Close() }() // Close file after device has been added.
-
-	virtiofsFile, err := virtiofsSock.File()
-	if err != nil {
-		return fmt.Errorf("Error opening virtiofs socket %q: %w", virtiofsdSockPath, err)
-	}
-
-	err = monitor.SendFile(virtiofsdSockPath, virtiofsFile)
-	if err != nil {
-		return fmt.Errorf("Failed to send virtiofs file descriptor: %w", err)
-	}
-
-	reverter.Add(func() { _ = monitor.CloseFile(virtiofsdSockPath) })
-
-	err = monitor.AddCharDevice(map[string]any{
-		"id": mountTag,
-		"backend": map[string]any{
-			"type": "socket",
-			"data": map[string]any{
-				"addr": map[string]any{
-					"type": "fd",
-					"data": map[string]any{
-						"str": virtiofsdSockPath,
-					},
-				},
-				"server": false,
-			},
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("Failed to add the character device: %w", err)
-	}
-
-	reverter.Add(func() { _ = monitor.RemoveCharDevice(mountTag) })
-
-	// Try to get a PCI address for hotplugging.
-	pciDeviceName, err := d.getPCIHotplug()
-	if err != nil {
-		return err
-	}
-
-	d.logger.Debug("Using PCI bus device to hotplug virtiofs into", logger.Ctx{"device": deviceName, "port": pciDeviceName})
-
-	qemuDev := map[string]any{
-		"driver":  "vhost-user-fs-pci",
-		"bus":     pciDeviceName,
-		"addr":    "00.0",
-		"tag":     mountTag,
-		"chardev": mountTag,
-		"id":      deviceID,
-	}
-
-	err = monitor.AddDevice(qemuDev)
-	if err != nil {
-		return fmt.Errorf("Failed to add the virtiofs device: %w", err)
-	}
-
-	reverter.Success()
 	return nil
 }
 
@@ -3911,7 +3840,11 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuType string, cpuI
 				if drive.TargetPath == "/" {
 					monHook, err = d.addRootDriveConfig(qemuDev, mountInfo, bootIndexes, drive)
 				} else if drive.FSType == "9p" {
-					err = d.addDriveDirConfig(&conf, bus, fdFiles, &agentMounts, drive)
+					if busName == "9p" {
+						conf = append(conf, d.driveDirConfig9p(qemuDev, bus.name, &agentMounts, drive)...)
+					} else {
+						monHook, err = d.addDriveDirConfigVirtiofs(qemuDev, &agentMounts, drive)
+					}
 				} else {
 					monHook, err = d.addDriveConfig(qemuDev, bootIndexes, drive)
 				}
@@ -4307,20 +4240,18 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]any, mountInfo *storagePool
 	return d.addDriveConfig(qemuDev, bootIndexes, driveConf)
 }
 
-// addDriveDirConfig adds the qemu config required for adding a supplementary drive directory share.
-func (d *qemu) addDriveDirConfig(conf *[]cfg.Section, bus *qemuBus, fdFiles *[]*os.File, agentMounts *[]instancetype.VMAgentMount, driveConf deviceConfig.MountEntryItem) error {
-	mountTag := fmt.Sprintf("incus_%s", driveConf.DevName)
+// driveDirConfig9p generates the qemu config required for adding a supplementary drive directory share using 9p.
+func (d *qemu) driveDirConfig9p(qemuDev map[string]any, busName string, agentMounts *[]instancetype.VMAgentMount, driveConf deviceConfig.MountEntryItem) []cfg.Section {
+	mountTag := "incus_" + driveConf.DevName
 
 	agentMount := instancetype.VMAgentMount{
 		Source: mountTag,
 		Target: driveConf.TargetPath,
 		FSType: driveConf.FSType,
-	}
 
-	// If mount type is 9p, we need to specify to use the virtio transport to support more VM guest OSes.
-	// Also set the msize to 32MB to allow for reasonably fast 9p access.
-	if agentMount.FSType == "9p" {
-		agentMount.Options = append(agentMount.Options, "trans=virtio,msize=33554432")
+		// We need to specify to use the virtio transport to support more VM guest OSes.
+		// Also set the msize to 32MB to allow for reasonably fast 9p access.
+		Options: []string{"trans=virtio,msize=33554432"},
 	}
 
 	readonly := slices.Contains(driveConf.Opts, "ro")
@@ -4331,63 +4262,137 @@ func (d *qemu) addDriveDirConfig(conf *[]cfg.Section, bus *qemuBus, fdFiles *[]*
 		agentMount.Options = append(agentMount.Options, "ro")
 	}
 
-	// Record the 9p mount for the agent.
+	// Record the mount for the agent.
 	*agentMounts = append(*agentMounts, agentMount)
 
-	// Check if the disk device has provided a virtiofsd socket path.
-	var virtiofsdSockPath string
-	for _, opt := range driveConf.Opts {
-		if strings.HasPrefix(opt, fmt.Sprintf("%s=", device.DiskVirtiofsdSockMountOpt)) {
-			parts := strings.SplitN(opt, "=", 2)
-			virtiofsdSockPath = parts[1]
-		}
-	}
-
-	// If there is a virtiofsd socket path setup the virtio-fs share.
-	if virtiofsdSockPath != "" {
-		if !util.PathExists(virtiofsdSockPath) {
-			return fmt.Errorf("virtiofsd socket path %q doesn't exist", virtiofsdSockPath)
-		}
-
-		devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
-
-		// Add virtio-fs device as this will be preferred over 9p.
-		driveDirVirtioOpts := qemuDriveDirOpts{
-			dev: qemuDevOpts{
-				busName:       bus.name,
-				devBus:        devBus,
-				devAddr:       devAddr,
-				multifunction: multi,
-			},
-			devName:  driveConf.DevName,
-			mountTag: mountTag,
-			path:     virtiofsdSockPath,
-			protocol: "virtio-fs",
-		}
-		*conf = append(*conf, qemuDriveDir(&driveDirVirtioOpts)...)
-	}
-
 	// Add 9p share config.
-	if !slices.Contains(driveConf.Opts, "bus=virtiofs") {
-		devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
-
-		driveDir9pOpts := qemuDriveDirOpts{
-			dev: qemuDevOpts{
-				busName:       bus.name,
-				devBus:        devBus,
-				devAddr:       devAddr,
-				multifunction: multi,
-			},
-			devName:  driveConf.DevName,
-			mountTag: mountTag,
-			readonly: readonly,
-			path:     driveConf.DevPath,
-			protocol: "9p",
-		}
-		*conf = append(*conf, qemuDriveDir(&driveDir9pOpts)...)
+	driveDir9pOpts := qemuDriveDirOpts{
+		dev: qemuDevOpts{
+			busName:       busName,
+			devBus:        qemuDev["bus"].(string),
+			devAddr:       qemuDev["addr"].(string),
+			multifunction: qemuDev["multifunction"].(bool),
+		},
+		devName:  driveConf.DevName,
+		mountTag: mountTag,
+		readonly: readonly,
+		path:     driveConf.DevPath,
+		protocol: "9p",
 	}
 
-	return nil
+	return qemuDriveDir(&driveDir9pOpts)
+}
+
+// addDriveDirConfigVirtiofs adds the qemu config required for adding a supplementary drive directory share using virtiofs.
+func (d *qemu) addDriveDirConfigVirtiofs(qemuDev map[string]any, agentMounts *[]instancetype.VMAgentMount, driveConf deviceConfig.MountEntryItem) (monitorHook, error) {
+	escapedDeviceName := linux.PathNameEncode(driveConf.DevName)
+	deviceID := qemuDeviceIDPrefix + escapedDeviceName
+	mountTag := "incus_" + driveConf.DevName
+
+	if agentMounts != nil {
+		agentMount := instancetype.VMAgentMount{
+			Source: mountTag,
+			Target: driveConf.TargetPath,
+			FSType: driveConf.FSType,
+		}
+
+		// Indicate to agent to mount this readonly. Note: This is purely to indicate to VM guest that this is
+		// readonly, it should *not* be used as a security measure, as the VM guest could remount it R/W.
+		if slices.Contains(driveConf.Opts, "ro") {
+			agentMount.Options = append(agentMount.Options, "ro")
+		}
+
+		// Record the mount for the agent.
+		*agentMounts = append(*agentMounts, agentMount)
+	}
+
+	if qemuDev == nil {
+		qemuDev = map[string]any{}
+	}
+
+	qemuDev["driver"] = "vhost-user-fs-pci"
+	qemuDev["tag"] = mountTag
+	qemuDev["chardev"] = mountTag
+	qemuDev["id"] = deviceID
+
+	monHook := func(m *qmp.Monitor) error {
+		reverter := revert.New()
+		defer reverter.Fail()
+
+		// Detect virtiofsd path.
+		virtiofsdSockPath := filepath.Join(d.DevicesPath(), fmt.Sprintf("virtio-fs.%s.sock", driveConf.DevName))
+		if !util.PathExists(virtiofsdSockPath) {
+			return errors.New("Virtiofsd isn't running")
+		}
+
+		addr, err := net.ResolveUnixAddr("unix", virtiofsdSockPath)
+		if err != nil {
+			return err
+		}
+
+		virtiofsSock, err := net.DialUnix("unix", nil, addr)
+		if err != nil {
+			return fmt.Errorf("Error connecting to virtiofs socket %q: %w", virtiofsdSockPath, err)
+		}
+
+		defer func() { _ = virtiofsSock.Close() }() // Close file after device has been added.
+
+		virtiofsFile, err := virtiofsSock.File()
+		if err != nil {
+			return fmt.Errorf("Error opening virtiofs socket %q: %w", virtiofsdSockPath, err)
+		}
+
+		err = m.SendFile(virtiofsdSockPath, virtiofsFile)
+		if err != nil {
+			return fmt.Errorf("Failed to send virtiofs file descriptor: %w", err)
+		}
+
+		reverter.Add(func() { _ = m.CloseFile(virtiofsdSockPath) })
+
+		err = m.AddCharDevice(map[string]any{
+			"id": mountTag,
+			"backend": map[string]any{
+				"type": "socket",
+				"data": map[string]any{
+					"addr": map[string]any{
+						"type": "fd",
+						"data": map[string]any{
+							"str": virtiofsdSockPath,
+						},
+					},
+					"server": false,
+				},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("Failed to add the character device: %w", err)
+		}
+
+		reverter.Add(func() { _ = m.RemoveCharDevice(mountTag) })
+
+		_, ok := qemuDev["bus"]
+		if !ok {
+			// Try to get a PCI address for hotplugging.
+			pciDeviceName, err := d.getPCIHotplug()
+			if err != nil {
+				return err
+			}
+
+			d.logger.Debug("Using PCI bus device to hotplug virtiofs into", logger.Ctx{"device": driveConf.DevName, "port": pciDeviceName, "was": qemuDev["bus"]})
+			qemuDev["bus"] = pciDeviceName
+			qemuDev["addr"] = "00.0"
+		}
+
+		err = m.AddDevice(qemuDev)
+		if err != nil {
+			return fmt.Errorf("Failed to add the virtiofs device: %w", err)
+		}
+
+		reverter.Success()
+		return nil
+	}
+
+	return monHook, nil
 }
 
 // addDriveConfig adds the qemu config required for adding a supplementary drive.

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3892,10 +3892,15 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuType string, cpuI
 				}
 
 				qemuDev := make(map[string]any)
-				if slices.Contains([]string{"nvme", "virtio-blk"}, busName) {
+				if slices.Contains([]string{"9p", "nvme", "virtio-blk", "virtiofs"}, busName) {
 					// Allocate a PCI(e) port and write it to the config file so QMP can "hotplug" the
 					// drive into it later.
-					devBus, devAddr, multi := bus.allocate(busFunctionGroupNone)
+					functionGroup := busFunctionGroupNone
+					if busName == "9p" {
+						functionGroup = busFunctionGroup9p
+					}
+
+					devBus, devAddr, multi := bus.allocate(functionGroup)
 
 					// Populate the qemu device with port info.
 					qemuDev["bus"] = devBus

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -97,6 +97,7 @@ type Instance interface {
 	Snapshots() ([]Instance, error)
 	Backups() ([]backup.InstanceBackup, error)
 	UpdateBackupFile() error
+	CanLiveMigrate() bool
 
 	// Config handling.
 	Rename(newName string, applyTemplateTrigger bool) error

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -97,7 +97,7 @@
 					{
 						"io.bus": {
 							"default": "`virtio-scsi` for block, `auto` for file system",
-							"longdesc": "This controls what bus a disk device should be attached to.\n\nFor block devices (disks), this is one of:\n- `nvme`\n- `virtio-blk`\n- `virtio-scsi` (default)\n- `usb`\n\nFor file systems (shared directories or custom volumes), this is one of:\n- `9p`\n- `auto` (default) (`virtiofs` + `9p`, just `9p` if `virtiofsd` is missing)\n- `virtiofs`",
+							"longdesc": "This controls what bus a disk device should be attached to.\n\nFor block devices (disks), this is one of:\n- `nvme`\n- `virtio-blk`\n- `virtio-scsi` (default)\n- `usb`\n\nFor file systems (shared directories or custom volumes), this is one of:\n- `9p`\n- `auto` (default) (`virtiofs` if possible, else `9p`)\n- `virtiofs`\n\n`9p` doesn't support hotplugging and `virtiofs` doesn't support live migration. `auto` tries\nto use `virtiofs` if possible (`migration.stateful` not set to `true` and host support for\n`virtiofsd`) and falls back to `9p` otherwise.",
 							"required": "no",
 							"shortdesc": "Only for VMs: Override the bus for the device",
 							"type": "string"
@@ -2890,6 +2890,13 @@
 						"volatile.\u003cname\u003e.hwaddr": {
 							"longdesc": "The network device MAC address is used when no `hwaddr` property is set on the device itself.",
 							"shortdesc": "Network device MAC address",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.\u003cname\u003e.io.bus": {
+							"longdesc": "The IO bus stores the actual IO bus being used, checked in case `io.bus=auto`.",
+							"shortdesc": "IO bus in use",
 							"type": "string"
 						}
 					},


### PR DESCRIPTION

Bugs solved:
* Typing regressions caused by #1531
* Non-hot-unpluggable pre-boot virtiofs shares (Closes: #2323)
* 9p post-boot shares being wrongfully mounted as virtiofs
* Useless checks probably caused by confusion because `FSType=9p` server-side even in virtiofs shares (note that it’s different agent-side)

Additional actions:
* Remove pre-boot virtiofs logic
* Remove dual virtiofs+9p logic, enforcing a **single** mount type
* Make the agent a little dumber on path mounts (removing a virtiofs dmesg error when mounting 9p-only shares)

Future directions (to discuss here):
* Maybe add more intelligence to disable virtiofs if `image.os` and related keys match a house-tailored heuristic?
* Clarify `FSType=9p` into `FSType=share` or something like that?
* (more globally) Actually restrict the user / non-internal server operations from setting some volatile keys? (some volatile keys should IMO still be settable by the user, like `hwaddr`)

That was a tough one to do, I tried to split the commits into easily reviewable ones, although some still are pretty big.