### PR TITLE
Move scriptlet utils to `shared/scriptlet`

### DIFF
--- a/internal/server/scriptlet/auth/auth.go
+++ b/internal/server/scriptlet/auth/auth.go
@@ -9,9 +9,9 @@ import (
 	"github.com/lxc/incus/v6/internal/server/auth/common"
 	scriptletLoad "github.com/lxc/incus/v6/internal/server/scriptlet/load"
 	"github.com/lxc/incus/v6/internal/server/scriptlet/log"
-	"github.com/lxc/incus/v6/internal/server/scriptlet/marshal"
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/logger"
+	"github.com/lxc/incus/v6/shared/scriptlet"
 )
 
 // AuthorizationRun runs the authorization scriptlet.
@@ -44,7 +44,7 @@ func AuthorizationRun(l logger.Logger, details *common.RequestDetails, object st
 		return false, errors.New("Scriptlet missing authorize function")
 	}
 
-	detailsv, err := marshal.StarlarkMarshal(details)
+	detailsv, err := scriptlet.StarlarkMarshal(details)
 	if err != nil {
 		return false, fmt.Errorf("Marshalling details failed: %w", err)
 	}
@@ -110,7 +110,7 @@ func getAccess(l logger.Logger, fun string, args []starlark.Tuple) (*api.Access,
 		return emptyAccess, fmt.Errorf("Failed to run: %w", err)
 	}
 
-	value, err := marshal.StarlarkUnmarshal(v)
+	value, err := scriptlet.StarlarkUnmarshal(v)
 	if err != nil {
 		return emptyAccess, err
 	}

--- a/internal/server/scriptlet/instance_placement.go
+++ b/internal/server/scriptlet/instance_placement.go
@@ -14,11 +14,11 @@ import (
 	"github.com/lxc/incus/v6/internal/server/resources"
 	scriptletLoad "github.com/lxc/incus/v6/internal/server/scriptlet/load"
 	"github.com/lxc/incus/v6/internal/server/scriptlet/log"
-	"github.com/lxc/incus/v6/internal/server/scriptlet/marshal"
 	"github.com/lxc/incus/v6/internal/server/state"
 	"github.com/lxc/incus/v6/shared/api"
 	apiScriptlet "github.com/lxc/incus/v6/shared/api/scriptlet"
 	"github.com/lxc/incus/v6/shared/logger"
+	"github.com/lxc/incus/v6/shared/scriptlet"
 )
 
 // InstancePlacementRun runs the instance placement scriptlet and returns the chosen cluster member target.
@@ -96,7 +96,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 			}
 		}
 
-		rv, err := marshal.StarlarkMarshal(res)
+		rv, err := scriptlet.StarlarkMarshal(res)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling cluster member resources for %q failed: %w", memberName, err)
 		}
@@ -145,7 +145,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 			}
 		}
 
-		rv, err := marshal.StarlarkMarshal(memberState)
+		rv, err := scriptlet.StarlarkMarshal(memberState)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling cluster member state for %q failed: %w", memberName, err)
 		}
@@ -166,7 +166,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 		res.MemorySize = uint64(usageMemory)
 		res.RootDiskSize = uint64(usageDisk)
 
-		rv, err := marshal.StarlarkMarshal(res)
+		rv, err := scriptlet.StarlarkMarshal(res)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling instance resources failed: %w", err)
 		}
@@ -234,7 +234,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 			return nil, err
 		}
 
-		rv, err := marshal.StarlarkMarshal(instanceList)
+		rv, err := scriptlet.StarlarkMarshal(instanceList)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling instances failed: %w", err)
 		}
@@ -262,7 +262,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 			return nil, err
 		}
 
-		rv, err := marshal.StarlarkMarshal(count)
+		rv, err := scriptlet.StarlarkMarshal(count)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling instance count failed: %w", err)
 		}
@@ -350,7 +350,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 			return nil, err
 		}
 
-		rv, err := marshal.StarlarkMarshal(allMembersInfo)
+		rv, err := scriptlet.StarlarkMarshal(allMembersInfo)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling cluster members failed: %w", err)
 		}
@@ -385,7 +385,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 			return nil, err
 		}
 
-		rv, err := marshal.StarlarkMarshal(p)
+		rv, err := scriptlet.StarlarkMarshal(p)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling project failed: %w", err)
 		}
@@ -487,12 +487,12 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 		return nil, errors.New("Scriptlet missing instance_placement function")
 	}
 
-	rv, err := marshal.StarlarkMarshal(req)
+	rv, err := scriptlet.StarlarkMarshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("Marshalling request failed: %w", err)
 	}
 
-	candidateMembersv, err := marshal.StarlarkMarshal(candidateMembersInfo)
+	candidateMembersv, err := scriptlet.StarlarkMarshal(candidateMembersInfo)
 	if err != nil {
 		return nil, fmt.Errorf("Marshalling candidate members failed: %w", err)
 	}

--- a/internal/server/scriptlet/qemu.go
+++ b/internal/server/scriptlet/qemu.go
@@ -12,9 +12,9 @@ import (
 	"github.com/lxc/incus/v6/internal/server/instance/drivers/qmp"
 	scriptletLoad "github.com/lxc/incus/v6/internal/server/scriptlet/load"
 	"github.com/lxc/incus/v6/internal/server/scriptlet/log"
-	"github.com/lxc/incus/v6/internal/server/scriptlet/marshal"
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/logger"
+	"github.com/lxc/incus/v6/shared/scriptlet"
 )
 
 // marshalQEMUConf marshals a configuration into a []map[string]any.
@@ -87,7 +87,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 			return nil, err
 		}
 
-		value, err := marshal.StarlarkUnmarshal(command)
+		value, err := scriptlet.StarlarkUnmarshal(command)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +111,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 			return nil, err
 		}
 
-		rv, err := marshal.StarlarkMarshal(resp)
+		rv, err := scriptlet.StarlarkMarshal(resp)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling QMP response failed: %w", err)
 		}
@@ -122,12 +122,12 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 	runCommandFromKwargs := func(funName string, kwargs []starlark.Tuple) (starlark.Value, error) {
 		qmpArgs := make(map[string]any)
 		for _, kwarg := range kwargs {
-			key, err := marshal.StarlarkUnmarshal(kwarg.Index(0))
+			key, err := scriptlet.StarlarkUnmarshal(kwarg.Index(0))
 			if err != nil {
 				return nil, err
 			}
 
-			value, err := marshal.StarlarkUnmarshal(kwarg.Index(1))
+			value, err := scriptlet.StarlarkUnmarshal(kwarg.Index(1))
 			if err != nil {
 				return nil, err
 			}
@@ -145,7 +145,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 		}
 
 		// Extract the return value
-		rv, err := marshal.StarlarkMarshal(resp.Return)
+		rv, err := scriptlet.StarlarkMarshal(resp.Return)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling QMP response failed: %w", err)
 		}
@@ -167,7 +167,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 			return nil, fmt.Errorf("%s Expected exactly one positional argument, got %d", errPrefix, argsLen)
 		}
 
-		arg, err := marshal.StarlarkUnmarshal(args.Index(0))
+		arg, err := scriptlet.StarlarkUnmarshal(args.Index(0))
 		if err != nil {
 			return nil, err
 		}
@@ -217,7 +217,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 			return nil, err
 		}
 
-		rv, err := marshal.StarlarkMarshal(cmdArgs)
+		rv, err := scriptlet.StarlarkMarshal(cmdArgs)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling QEMU command-line arguments failed: %w", err)
 		}
@@ -237,7 +237,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 			return nil, err
 		}
 
-		newCmdArgsAny, err := marshal.StarlarkUnmarshal(newCmdArgsv)
+		newCmdArgsAny, err := scriptlet.StarlarkUnmarshal(newCmdArgsv)
 		if err != nil {
 			return nil, err
 		}
@@ -294,7 +294,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 			return nil, err
 		}
 
-		rv, err := marshal.StarlarkMarshal(cfgSections)
+		rv, err := scriptlet.StarlarkMarshal(cfgSections)
 		if err != nil {
 			return nil, fmt.Errorf("Marshalling QEMU configuration failed: %w", err)
 		}
@@ -314,7 +314,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 			return nil, err
 		}
 
-		confAny, err := marshal.StarlarkUnmarshal(newConf)
+		confAny, err := scriptlet.StarlarkUnmarshal(newConf)
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +393,7 @@ func QEMURun(l logger.Logger, instance *api.Instance, cmdArgs *[]string, conf *[
 		return errors.New("Scriptlet missing qemu_hook function")
 	}
 
-	instancev, err := marshal.StarlarkMarshal(instance)
+	instancev, err := scriptlet.StarlarkMarshal(instance)
 	if err != nil {
 		return fmt.Errorf("Marshalling instance failed: %w", err)
 	}

--- a/shared/scriptlet/marshal.go
+++ b/shared/scriptlet/marshal.go
@@ -1,4 +1,4 @@
-package marshal
+package scriptlet
 
 import (
 	"fmt"
@@ -16,25 +16,31 @@ type starlarkObject struct {
 	typeName string
 }
 
+// Type is a starlark object type.
 func (s *starlarkObject) Type() string {
 	return s.typeName
 }
 
+// String is a starlark object string.
 func (s *starlarkObject) String() string {
 	return s.d.String()
 }
 
+// Freeze freezes the starlark object.
 func (s *starlarkObject) Freeze() {
 }
 
+// Hash returns a hash of the starlark object.
 func (s *starlarkObject) Hash() (uint32, error) {
 	return 0, fmt.Errorf("Unhashable type %s", s.Type())
 }
 
+// Truth returns whether the starlark object is true.
 func (s *starlarkObject) Truth() starlark.Bool {
 	return starlark.True
 }
 
+// AttrNames returns the attribute names of the starlark object.
 func (s *starlarkObject) AttrNames() []string {
 	keys := s.d.Keys()
 	keyNames := make([]string, 0, len(keys))
@@ -45,6 +51,7 @@ func (s *starlarkObject) AttrNames() []string {
 	return keyNames
 }
 
+// Attr gets an attribute of the starlark object.
 func (s *starlarkObject) Attr(name string) (starlark.Value, error) {
 	field, found, err := s.d.Get(starlark.String(name))
 	if err != nil {

--- a/shared/scriptlet/marshal_test.go
+++ b/shared/scriptlet/marshal_test.go
@@ -1,4 +1,4 @@
-package marshal
+package scriptlet
 
 import (
 	"fmt"


### PR DESCRIPTION
Moves the loading, marshalling, and validating logic for starlark scriptlets over to `shared/scriptlet` so that it can be used externally. 