### PR TITLE
incus/console: Add default console command in configuration file

### DIFF
--- a/cmd/incus/main.go
+++ b/cmd/incus/main.go
@@ -584,3 +584,22 @@ func (c *cmdGlobal) defaultListFormat() string {
 
 	return c.conf.Defaults.ListFormat
 }
+
+// Return "vga" if preferred console type is VGA, otherwise return "console".
+func (c *cmdGlobal) defaultConsoleType() string {
+	if c.conf == nil || c.conf.Defaults.ConsoleType == "" {
+		return "console"
+	}
+
+	return c.conf.Defaults.ConsoleType
+}
+
+// Return the default console type if the user configured it, otherwise just return "console".
+func (c *cmdGlobal) defaultConsoleSpiceCommand() string {
+	// Alternative SPICE command.
+	if c.conf == nil || c.conf.Defaults.ConsoleSpiceCommand == "" {
+		return ""
+	}
+
+	return c.conf.Defaults.ConsoleSpiceCommand
+}

--- a/shared/cliconfig/default.go
+++ b/shared/cliconfig/default.go
@@ -34,6 +34,12 @@ var DefaultRemotes = map[string]Remote{
 type DefaultSettings struct {
 	// Default flag format for list commands.
 	ListFormat string `yaml:"list_format"`
+
+	// Preferred console type.
+	ConsoleType string `yaml:"console_type"`
+
+	// Alternative SPICE command (SOCKET will be replaced by the socket path).
+	ConsoleSpiceCommand string `yaml:"console_spice_command"`
 }
 
 // DefaultConfig returns the default configuration.


### PR DESCRIPTION
**Ask**
https://github.com/lxc/incus/issues/2054: Ability to add arguments for VM console without a workaround on the OS. for ex: incus console instance --type=vga will launch spicy or remote-viewer.

**What was changed?**
After discussion in https://github.com/lxc/incus/issues/2054 :
1. Add the 2 vars in shared/cliconfig/default.go under `DefaultSettings` struct:
```
ConsolePreferVga bool  `yaml:"console_prefer_vga"`
ConsoleVgaCommand string `yaml:"console_vga_command"` // takes a string where the SOCKET keyword is replaced with the path to the SPICE socket
```
2. Add a methods `defaultConsoleType()` and `defaultConsoleVgaCommand()` in `cmd/incus/main.go` to return the "vga" if the user configured console_prefer_vga, otherwise return "console"

3. for flag, replace `console` with call to `defaultConsoleType()` in `cmd/incus/console.go`

4. update logic in `vga()` method to call `defaultConsoleVgaCommand()` and apply returned string after replacing SOCKET keyword

**Tests Done**

- [x] build complete fine
- [ ] Apply `incus` on test system and confirmed that new rule was put in place

Note to self:
Basic setup:
- Setup windows VM
- Setup a separate windows server
	- install incus client and install remote-viewer for Windows.
	- add user to incus-admin on server
	- start a VM console: incus console vm_name --type vga
	- Verify local socket: tasklist | findstr remote-viewer
	- verify console works

Manual test procedure:
- edit your config.yml
	- in ~/.config/incus)
	- add section:
defaults:
  console_prefer_vga: true
  console_vga_command: /usr/bin/remote-viewer -t i2054 SOCKET
- apply `incus` cmd
- Start console again: incus console vm_name
- Validate title is set

Ref: https://discuss.linuxcontainers.org/t/how-to-connect-to-remote-windows-vm/20210/2
Ref: https://linuxcontainers.org/incus/news/ section: Configuration of list format