### PR TITLE
Add directional port groups with allow/reject priority based on default policy

### DIFF
--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -2688,7 +2688,7 @@ func (o *NB) GetPortGroupInfo(ctx context.Context, portGroupName OVNPortGroup) (
 }
 
 // CreatePortGroup creates a new port group and optionally adds logical switch ports to the group.
-func (o *NB) CreatePortGroup(ctx context.Context, projectID int64, portGroupName OVNPortGroup, associatedPortGroup OVNPortGroup, associatedSwitch OVNSwitch, initialPortMembers ...OVNSwitchPort) error {
+func (o *NB) CreatePortGroup(ctx context.Context, projectID int64, portGroupName OVNPortGroup, associatedPortGroups []OVNPortGroup, associatedSwitch OVNSwitch, initialPortMembers ...OVNSwitchPort) error {
 	// Resolve the initial members.
 	members := []string{}
 	for _, portName := range initialPortMembers {
@@ -2713,9 +2713,14 @@ func (o *NB) CreatePortGroup(ctx context.Context, projectID int64, portGroupName
 		},
 	}
 
-	if associatedPortGroup != "" || associatedSwitch != "" {
-		if associatedPortGroup != "" {
-			pg.ExternalIDs[ovnExtIDIncusPortGroup] = string(associatedPortGroup)
+	if len(associatedPortGroups) > 0 || associatedSwitch != "" {
+		if len(associatedPortGroups) > 0 {
+			var parts []string
+			for _, v := range associatedPortGroups {
+				parts = append(parts, string(v))
+			}
+
+			pg.ExternalIDs[ovnExtIDIncusPortGroup] = string(strings.Join(parts, ","))
 		}
 
 		if associatedSwitch != "" {


### PR DESCRIPTION
This change adds support for prioritizing allow rules when the default policy for a network or interface is set to allow. By default, the policy is reject, so reject rules have higher priority.
To implement this, the original single port group was replaced with four separate port groups:
- Ingress (allow-first)
- Ingress (reject-first)
- Egress (allow-first)
- Egress (reject-first)

These groups store rules in the required order, allowing correct rule evaluation based on the default policy.

Fixes: #1833