### PR TITLE
incusd/apparmor: Don't use abi4.0

### DIFF
--- a/internal/server/apparmor/apparmor.go
+++ b/internal/server/apparmor/apparmor.go
@@ -229,7 +229,7 @@ func parserSupports(sysOS *sys.OS, feature string) (bool, error) {
 		return aaVersion.Compare(minVer) >= 0, nil
 	}
 
-	if feature == "abi40" {
+	if feature == "userns" {
 		minVer, err := version.NewDottedVersion("4.0.0")
 		if err != nil {
 			return false, err

--- a/internal/server/apparmor/instance.go
+++ b/internal/server/apparmor/instance.go
@@ -161,7 +161,7 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 		return "", err
 	}
 
-	abi40Supported, err := parserSupports(sysOS, "abi40")
+	usernsSupported, err := parserSupports(sysOS, "userns")
 	if err != nil {
 		return "", err
 	}
@@ -185,7 +185,7 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 			"feature_cgroup2":  sysOS.CGInfo.Layout == cgroup.CgroupsUnified || sysOS.CGInfo.Layout == cgroup.CgroupsHybrid,
 			"feature_stacking": sysOS.AppArmorStacking && !sysOS.AppArmorStacked,
 			"feature_unix":     unixSupported,
-			"feature_abi40":    abi40Supported,
+			"feature_userns":   usernsSupported,
 			"kernel_binfmt":    util.IsFalseOrEmpty(inst.ExpandedConfig()["security.privileged"]) && sysOS.UnprivBinfmt,
 			"name":             InstanceProfileName(inst),
 			"namespace":        InstanceNamespaceName(inst),

--- a/internal/server/apparmor/instance_lxc.profile.go
+++ b/internal/server/apparmor/instance_lxc.profile.go
@@ -4,10 +4,7 @@ import (
 	"text/template"
 )
 
-var lxcProfileTpl = template.Must(template.New("lxcProfile").Parse(`{{- if .feature_abi40 -}}
-abi <abi/4.0>,
-{{ end -}}
-#include <tunables/global>
+var lxcProfileTpl = template.Must(template.New("lxcProfile").Parse(`#include <tunables/global>
 profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   ### Base profile
   capability,
@@ -15,7 +12,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   file,
   network,
   umount,
-{{- if .feature_abi40 }}
+{{- if .feature_userns }}
   userns,
 {{- end }}
 


### PR DESCRIPTION
The userns feature can be used without the abi bump and the abi bump is causing other problematic side effects (breaking Docker in some cases).