### PR TITLE
Fix typo and add clarity for project param. 

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -183,8 +183,8 @@ scrape_configs:
   # to the `/var/lib/incus/cluster.crt` file found on every member of
   # the Incus cluster.
   #
-  # Note: the `project` param is are provided when not using the `default` project
-  #       or when multiple projects are used.
+  # Note: When the `project` param is provided, it overrides the `default` project
+  #       and if not specified will pull all projects.
   #
   # Note: each member of the cluster only provide metrics for instances it runs locally
   #       this is why the `incus-hdc` cluster lists 3 targets


### PR DESCRIPTION
Typo: "the `project` param is are provided" 

I was reading this page and this help question:   https://discuss.linuxcontainers.org/t/problem-with-incus-prometheus-and-multiple-projects/24226  . I was similarly confused by the documentation as an incus-metrics newbie. So in fixing the typo I also changed the note to explicitly state that if you don't use the project param then you get the default project or all projects. 

Todo: Add how to define the default project? 