### PR TITLE
incus/dhcp: default routes and multiple DHCP clients for OCI containers

### DIFF
--- a/cmd/incusd/main_forknet.go
+++ b/cmd/incusd/main_forknet.go
@@ -490,18 +490,17 @@ func (c *cmdForknet) dhcpRunV4(errorChannel chan error, iface string, hostname s
 			}
 		}
 	} else {
-		route := &ip.Route{
-			DevName: iface,
-			Route:   nil,
-			Via:     lease.Offer.Router()[0],
-			Family:  ip.FamilyV4,
-		}
+		gws := lease.Offer.Router()
 
-		err = route.Add()
-		if err != nil {
-			logger.WithError(err).Error("Giving up on DHCPv4, couldn't add default route")
-			errorChannel <- err
-			return
+		if len(gws) == 0 || gws[0] == nil || gws[0].IsUnspecified() {
+			logger.WithField("interface", iface).Info("No default gateway provided by DHCPv4; skipping default route")
+		} else {
+			err := c.installDefaultRouteV4(iface, gws[0])
+			if err != nil {
+				logger.WithError(err).Error("Giving up on DHCPv4, couldn't add default route")
+				errorChannel <- err
+				return
+			}
 		}
 	}
 
@@ -806,6 +805,71 @@ func (c *cmdForknet) dhcpApplyDNS(logger *logrus.Logger) error {
 			logger.WithError(err).Error("Giving up on DHCP, couldn't write resolv.conf")
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (c *cmdForknet) installDefaultRouteV4(iface string, gw net.IP) error {
+	// List all IPv4 routes in the main table; we'll filter default routes (Dst == nil) locally.
+	routes, err := (&ip.Route{
+		Family: ip.FamilyV4,
+		Table:  "main",
+	}).List()
+	if err != nil {
+		return err
+	}
+
+	var currentOwnerIf string
+	var currentOwnerGw net.IP
+
+	for _, r := range routes {
+		// Only consider default routes (no destination)
+		if r.Route != nil {
+			continue
+		}
+
+		// r.DevName may be empty if not resolvable; skip such entries
+		if r.DevName == "" {
+			continue
+		}
+
+		if currentOwnerIf == "" || r.DevName < currentOwnerIf {
+			currentOwnerIf = r.DevName
+			currentOwnerGw = r.Via
+		}
+	}
+
+	// Decide based on lexical order.
+	switch {
+	case currentOwnerIf == "":
+		// No default route yet; we can install ours.
+
+	case currentOwnerIf == iface:
+		// We already own the default; if gateway unchanged, nothing to do.
+		if currentOwnerGw != nil && gw != nil && currentOwnerGw.Equal(gw) {
+			return nil
+		}
+
+	case iface < currentOwnerIf:
+		// We win; replace the current default with ours.
+
+	default:
+		// We lose; keep existing default route.
+		return nil
+	}
+
+	defRoute := &ip.Route{
+		DevName: iface,
+		Route:   nil,
+		Via:     gw,
+		Family:  ip.FamilyV4,
+		Proto:   "dhcp",
+	}
+
+	err = defRoute.Replace()
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
**Problem**

  When multiple DHCP clients attempt to install an IPv4 default route into the main table, netlink.RouteAdd can fail with EEXIST. This leads to noisy errors and nondeterministic behavior regarding which interface "owns" the default route.

**Summary of changes**

1. internal/server/ip:
  - Made Route.List device-optional: when DevName is empty or unresolved, the OIF filter is cleared and routes across all devices are returned.
  - Introduced a single builder netlinkRoute(mode) to construct netlink.Route for both apply (add/replace/delete) and query (list) paths.
2. incus/dhcp (DHCPv4 path in main_forknet.go):
  - Introduce a policy to keep a single default route in the main table, owned by the lexicographically smallest interface name among candidates.
  - Inspect current main table routes using ip.Route.List to find the current default route owner.
  - If the new interface name sorts before the current owner (or there is no owner), install/replace the default route via ip.Route.Replace. Otherwise, skip installing the default route for this interface.
  - Mark installed routes with Proto="dhcp".
  - Use Replace rather than Add to make route installation idempotent across renewals and avoid EEXIST.

**Behavioral impact**

  - Route.List now returns routes across all devices when DevName is empty (previously, it always filtered by device).
  - Add, Replace, Delete, and Flush continue to require a valid device and behave as before.
  
This PR resolves #2403 