### PR TITLE
lxd-to-incus: Handle typo in trigger name

### DIFF
--- a/cmd/lxd-to-incus/main.go
+++ b/cmd/lxd-to-incus/main.go
@@ -439,6 +439,7 @@ DROP TRIGGER IF EXISTS on_image_delete;
 DROP TRIGGER IF EXISTS on_instance_backup_delete;
 DROP TRIGGER IF EXISTS on_instance_delete;
 DROP TRIGGER IF EXISTS on_instance_snapshot_delete;
+DROP TRIGGER IF EXISTS on_instance_snaphot_delete;
 DROP TRIGGER IF EXISTS on_network_acl_delete;
 DROP TRIGGER IF EXISTS on_network_delete;
 DROP TRIGGER IF EXISTS on_network_zone_delete;


### PR DESCRIPTION
Some LXD DB schemas seem to have a typo in one of the triggers, handle it.

Closes #2410