### PR TITLE
incusd/instance_exec: Relax connection timeout

### DIFF
--- a/cmd/incusd/instance_exec.go
+++ b/cmd/incusd/instance_exec.go
@@ -184,7 +184,7 @@ func (s *execWs) do(op *operations.Operation) error {
 	select {
 	case <-s.waitRequiredConnected.Done():
 		break
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 10):
 		return errors.New("Timed out waiting for websockets to connect")
 	}
 


### PR DESCRIPTION
Non-interactive exec sessions need all 4 websockets connected within the timeout. Those are typically connected sequentially, so the 5s timeout may be tight on very high latency links.