### PR TITLE
Fix logic for UsedByInstanceDevices

### DIFF
--- a/internal/server/network/network_utils.go
+++ b/internal/server/network/network_utils.go
@@ -108,7 +108,7 @@ func UsedByInstanceDevices(s *state.State, networkProjectName string, networkNam
 
 		// Skip instances who's effective network project doesn't match this Network's project.
 		if instNetworkProject != networkProjectName {
-			return nil
+			continue
 		}
 
 		// Look for NIC devices using this network.


### PR DESCRIPTION
The current logic is incorrect. If any instance meets the condition `instNetworkProject != networkProjectName`, the function stops execution without processing the other instances, which may also satisfy this condition. As a result, not all instances are processed and some may be skipped.