### PR TITLE
incusd/instance/utils: Don't fail instance startup due to incomplete …

### DIFF
--- a/internal/server/instance/drivers/util.go
+++ b/internal/server/instance/drivers/util.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lxc/incus/v6/internal/server/state"
 	internalUtil "github.com/lxc/incus/v6/internal/util"
 	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/resources"
 	"github.com/lxc/incus/v6/shared/units"
 )
@@ -52,7 +53,8 @@ func GetClusterCPUFlags(ctx context.Context, s *state.State, servers []string, a
 		// Get node resources.
 		res, err := getNodeResources(s, node.Name, node.Address)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get resources for %s: %w", node.Name, err)
+			logger.Errorf("Failed to get resources for CPU baseline on %q: %v", node.Name, err)
+			continue
 		}
 
 		// Skip if not the correct architecture.


### PR DESCRIPTION
…CPU baseline

If a server is temporarily unresponsive or unable to provide its CPU information, we should just skip it during baseline calculation, not completely fail the instance startup because of it.