### PR TITLE
Fix behavior when ACL name is used as match source

### DIFF
--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -3971,6 +3971,8 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 
 					acl.OVNPortGroupInstanceNICSchedule(portUUID, addChangeSet, egressPortGroupName)
 					n.logger.Debug("Scheduled logical port for ACL port group addition", logger.Ctx{"networkACL": addedACL, "portGroup": egressPortGroupName, "port": instancePortName})
+					acl.OVNPortGroupInstanceNICSchedule(portUUID, addChangeSet, directionalPortGroups.All)
+					n.logger.Debug("Scheduled logical port for ACL port group addition", logger.Ctx{"networkACL": addedACL, "portGroup": directionalPortGroups.All, "port": instancePortName})
 				}
 
 				// Check whether we need to remove any of the removed ACLs from the NIC.
@@ -4892,6 +4894,9 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 				acl.OVNPortGroupInstanceNICSchedule(portUUID, addChangeSet, egressPortGroupName)
 				n.logger.Debug("Scheduled logical port for ACL port group addition", logger.Ctx{"networkACL": aclName, "portGroup": egressPortGroupName, "port": instancePortName})
+
+				acl.OVNPortGroupInstanceNICSchedule(portUUID, addChangeSet, directionalPortGroups.All)
+				n.logger.Debug("Scheduled logical port for ACL port group addition", logger.Ctx{"networkACL": aclName, "portGroup": directionalPortGroups.All, "port": instancePortName})
 			}
 		}
 


### PR DESCRIPTION
#2372 introduced a bug that causes incorrect behavior when an ACL name is used as a source.  
Previously, the match expression was generated in the following format:

```
(outport == @incus_acl13_ingress_reversed) &&
(inport == @incus_acl13_ingress ||
 inport == @incus_acl13_ingress_reversed ||
 inport == @incus_acl13_egress ||
 inport == @incus_acl13_egress_reversed)
```
However, this fails if any of the port groups are empty, since OVN does not copy empty port groups between the Northbound and Southbound databases. This results in a parsing error in the match expression.  

This PR introduces a new port group that aggregates all ports assigned to the ACL, ensuring the match expression remains valid

