### PR TITLE
github: Remove XFS tools

### DIFF
--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -57,6 +57,11 @@ test_migration() {
                 continue
             fi
 
+            if [ "${fs}" = "xfs" ] && grep -q noble /etc/os-release; then
+                echo "==> SKIP: Skipping block mode test on ${fs} due to broken OS tools."
+                continue
+            fi
+
             # shellcheck disable=2039,3043
             local storage_pool1 storage_pool2
             # shellcheck disable=2153

--- a/test/suites/storage_driver_zfs.sh
+++ b/test/suites/storage_driver_zfs.sh
@@ -198,6 +198,11 @@ do_storage_driver_zfs() {
         return
     fi
 
+    if [ "${filesystem}" = "xfs" ] && grep -q noble /etc/os-release; then
+        echo "==> SKIP: Skipping block mode test on ${filesystem} due to broken OS tools."
+        return
+    fi
+
     # shellcheck disable=2039,3043
     local INCUS_STORAGE_DIR incus_backend
 


### PR DESCRIPTION
xfsprogs in Ubuntu 24.04 seems to have some weird initialization issues. Remove the package to skip those tests. We still have daily tests validating XFS anyway.