### PR TITLE
incusd/network: Exclude physical networks with parent=none from OVN chassis enablement

### DIFF
--- a/internal/server/network/driver_physical.go
+++ b/internal/server/network/driver_physical.go
@@ -324,7 +324,7 @@ func (n *physical) setup(oldConfig map[string]string) error {
 	reverter := revert.New()
 	defer reverter.Fail()
 
-	if !InterfaceExists(n.config["parent"]) {
+	if !InterfaceExists(n.config["parent"]) && n.config["parent"] != "none" {
 		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
 	}
 


### PR DESCRIPTION
- Updated OVN uplink and chassis detection logic to skip networks of type "physical" with parent set to "none".
- Ensured physical network driver setup permits parent="none" and checks interface existence accordingly.
- Nodes with physical uplinks that specify a valid parent (not "none") will participate in the OVN HA chassis group; nodes with parent="none" will be excluded.
- Behaviour tested by creating network with both parent=enp6s0 and parent=none on multiple nodes using Incus deploy.
- Only nodes with a valid physical uplink parent are added to the HA group, matching expected OVN behaviour.