### PR TITLE
docs: Fix markdown linting issues for tables

### DIFF
--- a/doc/architectures.md
+++ b/doc/architectures.md
@@ -8,23 +8,23 @@ Some entities in Incus are tied to an architecture, for example, the instances, 
 The following table lists all supported architectures including their unique identifier and the name used to refer to them.
 The architecture names are typically aligned with the Linux kernel architecture names.
 
-ID    | Kernel name   | Description                     | Personalities
-:---  | :---          | :----                           | :------------
-1     | `i686`        | 32bit Intel x86                 |
-2     | `x86_64`      | 64bit Intel x86                 | `x86`
-3     | `armv7l`      | 32bit ARMv7 little-endian       |
-4     | `aarch64`     | 64bit ARMv8 little-endian       | `armv7l` (optional)
-5     | `ppc`         | 32bit PowerPC big-endian        |
-6     | `ppc64`       | 64bit PowerPC big-endian        | `powerpc`
-7     | `ppc64le`     | 64bit PowerPC little-endian     |
-8     | `s390x`       | 64bit ESA/390 big-endian        |
-9     | `mips`        | 32bit MIPS                      |
-10    | `mips64`      | 64bit MIPS                      | `mips`
-11    | `riscv32`     | 32bit RISC-V little-endian      |
-12    | `riscv64`     | 64bit RISC-V little-endian      |
-13    | `armv6l`      | 32bit ARMv6 little-endian       |
-14    | `armv8l`      | 32bit ARMv8 little-endian       |
-15    | `loongarch64` | 64bit Loongarch                 |
+| ID   | Kernel name   | Description                 | Personalities       |
+| :--- | :---          | :---                        | :---                |
+| 1    | `i686`        | 32bit Intel x86             |                     |
+| 2    | `x86_64`      | 64bit Intel x86             | `x86`               |
+| 3    | `armv7l`      | 32bit ARMv7 little-endian   |                     |
+| 4    | `aarch64`     | 64bit ARMv8 little-endian   | `armv7l` (optional) |
+| 5    | `ppc`         | 32bit PowerPC big-endian    |                     |
+| 6    | `ppc64`       | 64bit PowerPC big-endian    | `powerpc`           |
+| 7    | `ppc64le`     | 64bit PowerPC little-endian |                     |
+| 8    | `s390x`       | 64bit ESA/390 big-endian    |                     |
+| 9    | `mips`        | 32bit MIPS                  |                     |
+| 10   | `mips64`      | 64bit MIPS                  | `mips`              |
+| 11   | `riscv32`     | 32bit RISC-V little-endian  |                     |
+| 12   | `riscv64`     | 64bit RISC-V little-endian  |                     |
+| 13   | `armv6l`      | 32bit ARMv6 little-endian   |                     |
+| 14   | `armv8l`      | 32bit ARMv8 little-endian   |                     |
+| 15   | `loongarch64` | 64bit Loongarch             |                     |
 
 ```{note}
 Incus cares only about the kernel architecture, not the particular userspace flavor as determined by the toolchain.

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -5,39 +5,39 @@ the user's environment and to turn some advanced features on and off.
 
 ## Common
 
-Name                            | Description
-:---                            | :----
-`INCUS_DIR`                     | The Incus data directory
-`INCUS_INSECURE_TLS`            | If set to true, allows all default Go ciphers both for client <-> server communication and server <-> image servers (server <-> server and clustering are not affected)
-`PATH`                          | List of paths to look into when resolving binaries
-`http_proxy`                    | Proxy server URL for HTTP
-`https_proxy`                   | Proxy server URL for HTTPS
-`no_proxy`                      | List of domains, IP addresses or CIDR ranges that don't require the use of a proxy
+| Name                 | Description                                                                        |
+| :---                 | :---                                                                               |
+| `INCUS_DIR`          | The Incus data directory                                                           |
+| `INCUS_INSECURE_TLS` | If set to true, allows all default Go ciphers both for client <-> server communication and server <-> image servers (server <-> server and clustering are not affected) |
+| `PATH`               | List of paths to look into when resolving binaries                                 |
+| `http_proxy`         | Proxy server URL for HTTP                                                          |
+| `https_proxy`        | Proxy server URL for HTTPS                                                         |
+| `no_proxy`           | List of domains, IP addresses or CIDR ranges that don't require the use of a proxy |
 
 ## Client environment variable
 
-Name                            | Description
-:---                            | :----
-`EDITOR`                        | What text editor to use
-`INCUS_CONF`                    | Path to the client configuration directory
-`INCUS_GLOBAL_CONF`             | Path to the global client configuration directory
-`INCUS_PROJECT`                 | Name of the project to use (overrides configured default project)
-`INCUS_REMOTE`                  | Name of the remote to use (overrides configured default remote)
-`VISUAL`                        | What text editor to use (if `EDITOR` isn't set)
+| Name                | Description                                                       |
+| :---                | :---                                                              |
+| `EDITOR`            | What text editor to use                                           |
+| `INCUS_CONF`        | Path to the client configuration directory                        |
+| `INCUS_GLOBAL_CONF` | Path to the global client configuration directory                 |
+| `INCUS_PROJECT`     | Name of the project to use (overrides configured default project) |
+| `INCUS_REMOTE`      | Name of the remote to use (overrides configured default remote)   |
+| `VISUAL`            | What text editor to use (if `EDITOR` isn't set)                   |
 
 ## Server environment variable
 
-Name                            | Description
-:---                            | :----
-`INCUS_AGENT_PATH`              | Path to the directory including the `incus-agent` builds
-`INCUS_CLUSTER_UPDATE`          | Script to call on a cluster update
-`INCUS_DEVMONITOR_DIR`          | Path to be monitored by the device monitor. This is primarily for testing
-`INCUS_DOCUMENTATION`           | Path to the documentation to serve through the web server
-`INCUS_EDK2_PATH`               | Path to EDK2 firmware build including `*_CODE.fd` and `*_VARS.fd`
-`INCUS_EXEC_PATH`               | Full path to the Incus binary (used when forking subcommands)
-`INCUS_IDMAPPED_MOUNTS_DISABLE` | Disable idmapped mounts support (useful when testing traditional UID shifting)
-`INCUS_LXC_TEMPLATE_CONFIG`     | Path to the LXC template configuration directory
-`INCUS_SECURITY_APPARMOR`       | If set to `false`, forces AppArmor off
-`INCUS_SKIP_INSTANCE_TYPES`     | If set to `true`, skip downloading instance type definitions
-`INCUS_UI`                      | Path to the web UI to serve through the web server
-`INCUS_USBIDS_PATH`             | Path to the hwdata `usb.ids` file
+| Name                            | Description                                                                    |
+| :---                            | :---                                                                           |
+| `INCUS_AGENT_PATH`              | Path to the directory including the `incus-agent` builds                       |
+| `INCUS_CLUSTER_UPDATE`          | Script to call on a cluster update                                             |
+| `INCUS_DEVMONITOR_DIR`          | Path to be monitored by the device monitor. This is primarily for testing      |
+| `INCUS_DOCUMENTATION`           | Path to the documentation to serve through the web server                      |
+| `INCUS_EDK2_PATH`               | Path to EDK2 firmware build including `*_CODE.fd` and `*_VARS.fd`              |
+| `INCUS_EXEC_PATH`               | Full path to the Incus binary (used when forking subcommands)                  |
+| `INCUS_IDMAPPED_MOUNTS_DISABLE` | Disable idmapped mounts support (useful when testing traditional UID shifting) |
+| `INCUS_LXC_TEMPLATE_CONFIG`     | Path to the LXC template configuration directory                               |
+| `INCUS_SECURITY_APPARMOR`       | If set to `false`, forces AppArmor off                                         |
+| `INCUS_SKIP_INSTANCE_TYPES`     | If set to `true`, skip downloading instance type definitions                   |
+| `INCUS_UI`                      | Path to the web UI to serve through the web server                             |
+| `INCUS_USBIDS_PATH`             | Path to the hwdata `usb.ids` file                                              |

--- a/doc/explanation/containers_and_vms.md
+++ b/doc/explanation/containers_and_vms.md
@@ -7,14 +7,14 @@ Incus uses features of the Linux kernel (such as `namespaces` and `cgroups`) in 
 
 When running a virtual machine, Incus uses hardware features of the the host system as a way to isolate and restrict a running virtual machine. Therefore, virtual machines can be used to run, for example, different operating systems than the host system.
 
-| Virtual Machines                  | Application Containers      | System Containers                 |
-| :--:                              | :--:                        | :--:                              |
-| Uses a dedicated kernel           | Uses the kernel of the host | Uses the kernel of the host       |
-| Can host different types of OS    | Can only host Linux         | Can only host Linux               |
-| Uses more resources               | Uses less resources         | Uses less resources               |
-| Requires hardware virtualization  | Software-only               | Software-only                     |
-| Can host multiple applications    | Can host a single app       | Can host multiple applications    |
-| Supported by Incus                | Supported by Docker         | Supported by Incus                |
+| Virtual Machines                 | Application Containers      | System Containers              |
+| :---                             | :---                        | :---                           |
+| Uses a dedicated kernel          | Uses the kernel of the host | Uses the kernel of the host    |
+| Can host different types of OS   | Can only host Linux         | Can only host Linux            |
+| Uses more resources              | Uses less resources         | Uses less resources            |
+| Requires hardware virtualization | Software-only               | Software-only                  |
+| Can host multiple applications   | Can host a single app       | Can host multiple applications |
+| Supported by Incus               | Supported by Docker         | Supported by Incus             |
 
 ## Application containers vs. system containers
 

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -112,11 +112,11 @@ These NIC settings should be added to the profile that the instance is using, or
 
 The following security features are available for bridged NICs:
 
-Key                      | Type      | Default           | Required  | Description
-:--                      | :--       | :--               | :--       | :--
-`security.mac_filtering` | bool      | `false`           | no        | Prevent the instance from spoofing another instance's MAC address
-`security.ipv4_filtering`| bool      | `false`           | no        | Prevent the instance from spoofing another instance's IPv4 address (enables `mac_filtering`)
-`security.ipv6_filtering`| bool      | `false`           | no        | Prevent the instance from spoofing another instance's IPv6 address (enables `mac_filtering`)
+| Key                       | Type | Default | Required  | Description                                                                                  |
+| :---                      | :--- | :---    | :---      | :---                                                                                         |
+| `security.mac_filtering`  | bool | `false` | no        | Prevent the instance from spoofing another instance's MAC address                            |
+| `security.ipv4_filtering` | bool | `false` | no        | Prevent the instance from spoofing another instance's IPv4 address (enables `mac_filtering`) |
+| `security.ipv6_filtering` | bool | `false` | no        | Prevent the instance from spoofing another instance's IPv6 address (enables `mac_filtering`) |
 
 One can override the default bridged NIC settings from the profile on a per-instance basis using:
 

--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -38,12 +38,12 @@ See the following how-to guides for additional information:
 Where the Incus data is stored depends on the configuration and the selected storage driver.
 Depending on the storage driver that is used, Incus can either share the file system with its host or keep its data separate.
 
-Storage location         | Directory | Btrfs    | LVM (all) | ZFS      | Ceph (all) | LINSTOR  |
-:---                     | :-:       | :-:      | :-:       | :-:      | :-:        | :-:      |
-Shared with the host     | &#x2713;  | &#x2713; | -         | &#x2713; | -          | -        |
-Dedicated disk/partition | -         | &#x2713; | &#x2713;  | &#x2713; | -          | &#x2713; |
-Loop disk                | -         | &#x2713; | &#x2713;  | &#x2713; | -          | &#x2713; |
-Remote storage           | -         | -        | &#x2713;  | -        | &#x2713;   | &#x2713; |
+| Storage location         | Directory | Btrfs    | LVM (all) | ZFS      | Ceph (all) | LINSTOR  |
+| :---                     | :---      | :---     | :---      | :---     | :---       | :---     |
+| Shared with the host     | &#x2713;  | &#x2713; | -         | &#x2713; | -          | -        |
+| Dedicated disk/partition | -         | &#x2713; | &#x2713;  | &#x2713; | -          | &#x2713; |
+| Loop disk                | -         | &#x2713; | &#x2713;  | &#x2713; | -          | &#x2713; |
+| Remote storage           | -         | -        | &#x2713;  | -        | &#x2713;   | &#x2713; |
 
 #### Shared with the host
 

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -35,13 +35,13 @@ Valid network ACL names must adhere to the following rules:
 
 ACLs have the following properties:
 
-Property         | Type       | Required | Description
-:--              | :--        | :--      | :--
-`name`           | string     | yes      | Unique name of the network ACL in the project
-`description`    | string     | no       | Description of the network ACL
-`ingress`        | rule list  | no       | Ingress traffic rules
-`egress`         | rule list  | no       | Egress traffic rules
-`config`         | string set | no       | Configuration options as key/value pairs (only `user.*` custom keys supported)
+| Property      | Type       | Required | Description                                                                    |
+| :---          | :---       | :---     | :---                                                                           |
+| `name`        | string     | yes      | Unique name of the network ACL in the project                                  |
+| `description` | string     | no       | Description of the network ACL                                                 |
+| `ingress`     | rule list  | no       | Ingress traffic rules                                                          |
+| `egress`      | rule list  | no       | Egress traffic rules                                                           |
+| `config`      | string set | no       | Configuration options as key/value pairs (only `user.*` custom keys supported) |
 
 (network-acls-rules)=
 ## Add or remove rules
@@ -88,18 +88,18 @@ If one of the rules in the ACLs matches, the action for that rule is taken and n
 
 ACL rules have the following properties:
 
-Property          | Type       | Required | Description
-:--               | :--        | :--      | :--
-`action`          | string     | yes      | Action to take for matching traffic (`allow`, `allow-stateless`, `reject`, or `drop`)
-`state`           | string     | yes      | State of the rule (`enabled`, `disabled` or `logged`), defaulting to `enabled` if not specified
-`description`     | string     | no       | Description of the rule
-`source`          | string     | no       | Comma-separated list of CIDR or IP ranges, source subject name selectors (for ingress rules), or empty for any
-`destination`     | string     | no       | Comma-separated list of CIDR or IP ranges, destination subject name selectors (for egress rules), or empty for any
-`protocol`        | string     | no       | Protocol to match (`icmp4`, `icmp6`, `tcp`, `udp`) or empty for any
-`source_port`     | string     | no       | If protocol is `udp` or `tcp`, then a comma-separated list of ports or port ranges (start-end inclusive), or empty for any
-`destination_port`| string     | no       | If protocol is `udp` or `tcp`, then a comma-separated list of ports or port ranges (start-end inclusive), or empty for any
-`icmp_type`       | string     | no       | If protocol is `icmp4` or `icmp6`, then ICMP type number, or empty for any
-`icmp_code`       | string     | no       | If protocol is `icmp4` or `icmp6`, then ICMP code number, or empty for any
+| Property           | Type   | Required | Description                                                                                                                |
+| :---               | :---   | :---     | :---                                                                                                                       |
+| `action`           | string | yes      | Action to take for matching traffic (`allow`, `allow-stateless`, `reject`, or `drop`)                                      |
+| `state`            | string | yes      | State of the rule (`enabled`, `disabled` or `logged`), defaulting to `enabled` if not specified                            |
+| `description`      | string | no       | Description of the rule                                                                                                    |
+| `source`           | string | no       | Comma-separated list of CIDR or IP ranges, source subject name selectors (for ingress rules), or empty for any             |
+| `destination`      | string | no       | Comma-separated list of CIDR or IP ranges, destination subject name selectors (for egress rules), or empty for any         |
+| `protocol`         | string | no       | Protocol to match (`icmp4`, `icmp6`, `tcp`, `udp`) or empty for any                                                        |
+| `source_port`      | string | no       | If protocol is `udp` or `tcp`, then a comma-separated list of ports or port ranges (start-end inclusive), or empty for any |
+| `destination_port` | string | no       | If protocol is `udp` or `tcp`, then a comma-separated list of ports or port ranges (start-end inclusive), or empty for any |
+| `icmp_type`        | string | no       | If protocol is `icmp4` or `icmp6`, then ICMP type number, or empty for any                                                 |
+| `icmp_code`        | string | no       | If protocol is `icmp4` or `icmp6`, then ICMP code number, or empty for any                                                 |
 
 (network-acls-selectors)=
 ### Use selectors in rules

--- a/doc/howto/network_address_sets.md
+++ b/doc/howto/network_address_sets.md
@@ -11,11 +11,11 @@ Network address sets are a list of either IPv4, IPv6 addresses with or without C
 
 Address sets have the following properties:
 
-Property         | Type         | Required | Description
-:--              | :--          | :--      | :--
-`name`           | string       | yes      | Name of the network address set
-`description`    | string       | no       | Description of the network address set
-`addresses`      | string list  | no       | Ingress traffic rules
+| Property      | Type        | Required | Description                            |
+| :---          | :---        | :---     | :---                                   |
+| `name`        | string      | yes      | Name of the network address set        |
+| `description` | string      | no       | Description of the network address set |
+| `addresses`   | string list | no       | Ingress traffic rules                  |
 
 ## Address set configuration options
 

--- a/doc/howto/network_forwards.md
+++ b/doc/howto/network_forwards.md
@@ -34,12 +34,12 @@ Note that this target address must be within the same subnet as the network that
 
 Network forwards have the following properties:
 
-Property         | Type       | Required | Description
-:--              | :--        | :--      | :--
-`listen_address` | string     | yes      | IP address to listen on
-`description`    | string     | no       | Description of the network forward
-`config`         | string set | no       | See table below
-`ports`          | port list  | no       | List of {ref}`port specifications <network-forwards-port-specifications>`
+| Property         | Type       | Required | Description                                                               |
+| :---             | :---       | :---     | :---                                                                      |
+| `listen_address` | string     | yes      | IP address to listen on                                                   |
+| `description`    | string     | no       | Description of the network forward                                        |
+| `config`         | string set | no       | See table below                                                           |
+| `ports`          | port list  | no       | List of {ref}`port specifications <network-forwards-port-specifications>` |
 
 ### Forward configuration
 
@@ -89,14 +89,14 @@ If you want to forward the traffic to different ports, you have two options:
 
 Network forward ports have the following properties:
 
-Property          | Type       | Required | Description
-:--               | :--        | :--      | :--
-`protocol`        | string     | yes      | Protocol for the port(s) (`tcp` or `udp`)
-`listen_port`     | string     | yes      | Listen port(s) (e.g. `80,90-100`)
-`target_address`  | string     | yes      | IP address to forward to
-`target_port`     | string     | no       | Target port(s) (e.g. `70,80-90` or `90`), same as `listen_port` if empty
-`description`     | string     | no       | Description of port(s)
-`snat`            | bool       | no       | Whether to place a matching SNAT rule to rewrite any new traffic coming from the target
+| Property         | Type   | Required | Description                                                                             |
+| :---             | :---   | :---     | :---                                                                                    |
+| `protocol`       | string | yes      | Protocol for the port(s) (`tcp` or `udp`)                                               |
+| `listen_port`    | string | yes      | Listen port(s) (e.g. `80,90-100`)                                                       |
+| `target_address` | string | yes      | IP address to forward to                                                                |
+| `target_port`    | string | no       | Target port(s) (e.g. `70,80-90` or `90`), same as `listen_port` if empty                |
+| `description`    | string | no       | Description of port(s)                                                                  |
+| `snat`           | bool   | no       | Whether to place a matching SNAT rule to rewrite any new traffic coming from the target |
 
 ```{note}
 The `snat` property is currently only supported on managed `bridge` networks and with the `nftables` firewall driver.

--- a/doc/howto/network_integrations.md
+++ b/doc/howto/network_integrations.md
@@ -51,11 +51,11 @@ incus network peer create default region ovn-region --type=remote
 
 Address sets have the following properties:
 
-Property         | Type     | Required | Description
-:--              | :--      | :--      | :--
-`name`           | string   | yes      | Name of the network integration
-`description`    | string   | no       | Description of the network integration
-`type`           | string   | yes      | Type of network integration (currently only `ovn`)
+| Property      | Type     | Required | Description                                        |
+| :---          | :---     | :---     | :---                                               |
+| `name`        | string   | yes      | Name of the network integration                    |
+| `description` | string   | no       | Description of the network integration             |
+| `type`        | string   | yes      | Type of network integration (currently only `ovn`) |
 
 ## Integration configuration options
 

--- a/doc/howto/network_load_balancers.md
+++ b/doc/howto/network_load_balancers.md
@@ -30,13 +30,13 @@ It requires a single external listen address (see {ref}`network-load-balancers-l
 
 Network load balancers have the following properties:
 
-Property         | Type         | Required | Description
-:--              | :--          | :--      | :--
-`listen_address` | string       | yes      | IP address to listen on
-`description`    | string       | no       | Description of the network load balancer
-`config`         | string set   | no       | Configuration options as key/value pairs (see below)
-`backends`       | backend list | no       | List of {ref}`backend specifications <network-load-balancers-backend-specifications>`
-`ports`          | port list    | no       | List of {ref}`port specifications <network-load-balancers-port-specifications>`
+| Property         | Type         | Required | Description                                                                           |
+| :---             | :---         | :---     | :---                                                                                  |
+| `listen_address` | string       | yes      | IP address to listen on                                                               |
+| `description`    | string       | no       | Description of the network load balancer                                              |
+| `config`         | string set   | no       | Configuration options as key/value pairs (see below)                                  |
+| `backends`       | backend list | no       | List of {ref}`backend specifications <network-load-balancers-backend-specifications>` |
+| `ports`          | port list    | no       | List of {ref}`port specifications <network-load-balancers-port-specifications>`       |
 
 ### Configuration options
 
@@ -80,12 +80,12 @@ If you want to forward the traffic to different ports, you have two options:
 
 Network load balancer backends have the following properties:
 
-Property          | Type       | Required | Description
-:--               | :--        | :--      | :--
-`name`            | string     | yes      | Name of the backend
-`target_address`  | string     | yes      | IP address to forward to
-`target_port`     | string     | no       | Target port(s) (e.g. `70,80-90` or `90`), same as the {ref}`port <network-load-balancers-port-specifications>`'s `listen_port` if empty
-`description`     | string     | no       | Description of backend
+| Property         | Type   | Required | Description                                                                                                                             |
+| :---             | :---   | :---     | :---                                                                                                                                    |
+| `name`           | string | yes      | Name of the backend                                                                                                                     |
+| `target_address` | string | yes      | IP address to forward to                                                                                                                |
+| `target_port`    | string | no       | Target port(s) (e.g. `70,80-90` or `90`), same as the {ref}`port <network-load-balancers-port-specifications>`'s `listen_port` if empty |
+| `description`    | string | no       | Description of backend                                                                                                                  |
 
 (network-load-balancers-port-specifications)=
 ## Configure ports
@@ -105,12 +105,12 @@ The backend(s) specified must have target port(s) settings compatible with the p
 
 Network load balancer ports have the following properties:
 
-Property          | Type         | Required | Description
-:--               | :--          | :--      | :--
-`protocol`        | string       | yes      | Protocol for the port(s) (`tcp` or `udp`)
-`listen_port`     | string       | yes      | Listen port(s) (e.g. `80,90-100`)
-`target_backend`  | backend list | yes      | Backend name(s) to forward to
-`description`     | string       | no       | Description of port(s)
+| Property         | Type         | Required | Description                               |
+| :---             | :---         | :---     | :---                                      |
+| `protocol`       | string       | yes      | Protocol for the port(s) (`tcp` or `udp`) |
+| `listen_port`    | string       | yes      | Listen port(s) (e.g. `80,90-100`)         |
+| `target_backend` | backend list | yes      | Backend name(s) to forward to             |
+| `description`    | string       | no       | Description of port(s)                    |
 
 ## Edit a network load balancer
 

--- a/doc/howto/network_ovn_peers.md
+++ b/doc/howto/network_ovn_peers.md
@@ -42,15 +42,15 @@ This behavior prevents users in a different project from discovering whether a p
 
 Peer routing relationships have the following properties:
 
-Property             | Type       | Required | Description
-:--                  | :--        | :--      | :--
-`name`               | string     | yes      | Name of the network peering on the local network
-`description`        | string     | no       | Description of the network peering
-`config`             | string set | no       | Configuration options as key/value pairs (only `user.*` custom keys supported)
-`target_integration` | string     | no       | Name of the integration (required at create time for remote peers)
-`target_project`     | string     | yes      | Which project the target network exists in (required at create time for local peers)
-`target_network`     | string     | yes      | Which network to create a peering with (required at create time for local peers)
-`status`             | string     | --       | Status indicating if pending or created (mutual peering exists with the target network)
+| Property             | Type       | Required | Description                                                                             |
+| :---                 | :---       | :---     | :---                                                                                    |
+| `name`               | string     | yes      | Name of the network peering on the local network                                        |
+| `description`        | string     | no       | Description of the network peering                                                      |
+| `config`             | string set | no       | Configuration options as key/value pairs (only `user.*` custom keys supported)          |
+| `target_integration` | string     | no       | Name of the integration (required at create time for remote peers)                      |
+| `target_project`     | string     | yes      | Which project the target network exists in (required at create time for local peers)    |
+| `target_network`     | string     | yes      | Which network to create a peering with (required at create time for local peers)        |
+| `status`             | string     | --       | Status indicating if pending or created (mutual peering exists with the target network) |
 
 ## List routing relationships
 

--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -198,12 +198,12 @@ This command creates an empty record without entries and adds it to a network zo
 
 Records have the following properties:
 
-Property          | Type       | Required | Description
-:--               | :--        | :--      | :--
-`name`            | string     | yes      | Unique name of the record
-`description`     | string     | no       | Description of the record
-`entries`         | entry list | no       | A list of DNS entries
-`config`          | string set | no       | Configuration options as key/value pairs (only `user.*` custom keys supported)
+| Property      | Type       | Required | Description                                                                    |
+| :---          | :---       | :---     | :---                                                                           |
+| `name`        | string     | yes      | Unique name of the record                                                      |
+| `description` | string     | no       | Description of the record                                                      |
+| `entries`     | entry list | no       | A list of DNS entries                                                          |
+| `config`      | string set | no       | Configuration options as key/value pairs (only `user.*` custom keys supported) |
 
 ### Add or remove entries
 

--- a/doc/reference/server_settings.md
+++ b/doc/reference/server_settings.md
@@ -7,16 +7,16 @@ The `Value` column contains the suggested value for each parameter.
 
 ## `/etc/security/limits.conf`
 
-Domain  | Type  | Item      | Value       | Default   | Description
-:-----  | :---  | :----     | :---------- | :-------- | :----------
-`*`     | soft  | `nofile`  | `1048576`   | unset     | Maximum number of open files
-`*`     | hard  | `nofile`  | `1048576`   | unset     | Maximum number of open files
-`root`  | soft  | `nofile`  | `1048576`   | unset     | Maximum number of open files
-`root`  | hard  | `nofile`  | `1048576`   | unset     | Maximum number of open files
-`*`     | soft  | `memlock` | `unlimited` | unset     | Maximum locked-in-memory address space (KB)
-`*`     | hard  | `memlock` | `unlimited` | unset     | Maximum locked-in-memory address space (KB)
-`root`  | soft  | `memlock` | `unlimited` | unset     | Maximum locked-in-memory address space (KB), only need with `bpf` syscall supervision
-`root`  | hard  | `memlock` | `unlimited` | unset     | Maximum locked-in-memory address space (KB), only need with `bpf` syscall supervision
+| Domain | Type | Item      | Value       | Default | Description                                                                           |
+| :---   | :--- | :---      | :---        | :---    | :---                                                                                  |
+| `*`    | soft | `nofile`  | `1048576`   | unset   | Maximum number of open files                                                          |
+| `*`    | hard | `nofile`  | `1048576`   | unset   | Maximum number of open files                                                          |
+| `root` | soft | `nofile`  | `1048576`   | unset   | Maximum number of open files                                                          |
+| `root` | hard | `nofile`  | `1048576`   | unset   | Maximum number of open files                                                          |
+| `*`    | soft | `memlock` | `unlimited` | unset   | Maximum locked-in-memory address space (KB)                                           |
+| `*`    | hard | `memlock` | `unlimited` | unset   | Maximum locked-in-memory address space (KB)                                           |
+| `root` | soft | `memlock` | `unlimited` | unset   | Maximum locked-in-memory address space (KB), only need with `bpf` syscall supervision |
+| `root` | hard | `memlock` | `unlimited` | unset   | Maximum locked-in-memory address space (KB), only need with `bpf` syscall supervision |
 
 ## `/etc/sysctl.conf`
 
@@ -24,16 +24,16 @@ Domain  | Type  | Item      | Value       | Default   | Description
 Reboot the server after changing any of these parameters.
 ```
 
-Parameter                           | Value      | Default   | Description
-:-----                              | :---       | :---      | :---
-`fs.aio-max-nr`                     | `524288`   | `65536`   | Maximum number of concurrent asynchronous I/O operations (you might need to increase this limit further if you have a lot of workloads that use the AIO subsystem, for example, MySQL)
-`fs.inotify.max_queued_events`      | `1048576`  | `16384`   | Upper limit on the number of events that can be queued to the corresponding `inotify` instance (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))
-`fs.inotify.max_user_instances`     | `1048576`  | `128`     | Upper limit on the number of `inotify` instances that can be created per real user ID (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))
-`fs.inotify.max_user_watches`       | `1048576`  | `8192`    | Upper limit on the number of watches that can be created per real user ID (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))
-`kernel.dmesg_restrict`             | `1`        | `0`       | Whether to deny container access to the messages in the kernel ring buffer (note that this will also deny access to non-root users on the host system)
-`kernel.keys.maxbytes`              | `2000000`  | `20000`   | Maximum size of the key ring that non-root users can use
-`kernel.keys.maxkeys`               | `2000`     | `200`     | Maximum number of keys that a non-root user can use (the value should be higher than the number of instances)
-`net.core.bpf_jit_limit`            | `1000000000` | varies  | Limit on the size of eBPF JIT allocations (on kernels < 5.15 that are compiled with `CONFIG_BPF_JIT_ALWAYS_ON=y`, this value might limit the amount of instances that can be created)
-`net.ipv4.neigh.default.gc_thresh3` | `8192`     | `1024`    | Maximum number of entries in the IPv4 ARP table (increase this value if you plan to create over 1024 instances - otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and the instances cannot get a network configuration; see [`ip-sysctl`](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt))
-`net.ipv6.neigh.default.gc_thresh3` | `8192`     | `1024`    | Maximum number of entries in IPv6 ARP table (increase this value if you plan to create over 1024 instances - otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and the instances cannot get a network configuration; see [`ip-sysctl`](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt))
-`vm.max_map_count`                  | `262144`   | `65530`   | Maximum number of memory map areas a process may have (memory map areas are used as a side-effect of calling `malloc`, directly by `mmap` and `mprotect`, and also when loading shared libraries)
+| Parameter                           | Value        | Default | Description                                                                                                                                                                                       |
+| :---                                | :---         | :---    | :---                                                                                                                                                                                              |
+| `fs.aio-max-nr`                     | `524288`     | `65536` | Maximum number of concurrent asynchronous I/O operations (you might need to increase this limit further if you have a lot of workloads that use the AIO subsystem, for example, MySQL)            |
+| `fs.inotify.max_queued_events`      | `1048576`    | `16384` | Upper limit on the number of events that can be queued to the corresponding `inotify` instance (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))                            |
+| `fs.inotify.max_user_instances`     | `1048576`    | `128`   | Upper limit on the number of `inotify` instances that can be created per real user ID (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))                                     |
+| `fs.inotify.max_user_watches`       | `1048576`    | `8192`  | Upper limit on the number of watches that can be created per real user ID (see [`inotify`](https://man7.org/linux/man-pages/man7/inotify.7.html))                                                 |
+| `kernel.dmesg_restrict`             | `1`          | `0`     | Whether to deny container access to the messages in the kernel ring buffer (note that this will also deny access to non-root users on the host system)                                            |
+| `kernel.keys.maxbytes`              | `2000000`    | `20000` | Maximum size of the key ring that non-root users can use                                                                                                                                          |
+| `kernel.keys.maxkeys`               | `2000`       | `200`   | Maximum number of keys that a non-root user can use (the value should be higher than the number of instances)                                                                                     |
+| `net.core.bpf_jit_limit`            | `1000000000` | varies  | Limit on the size of eBPF JIT allocations (on kernels < 5.15 that are compiled with `CONFIG_BPF_JIT_ALWAYS_ON=y`, this value might limit the amount of instances that can be created)             |
+| `net.ipv4.neigh.default.gc_thresh3` | `8192`       | `1024`  | Maximum number of entries in the IPv4 ARP table (increase this value if you plan to create over 1024 instances - otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and the instances cannot get a network configuration; see [`ip-sysctl`](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt)) |
+| `net.ipv6.neigh.default.gc_thresh3` | `8192`       | `1024`  | Maximum number of entries in IPv6 ARP table (increase this value if you plan to create over 1024 instances - otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and the instances cannot get a network configuration; see [`ip-sysctl`](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt)) |
+| `vm.max_map_count`                  | `262144`     | `65530` | Maximum number of memory map areas a process may have (memory map areas are used as a side-effect of calling `malloc`, directly by `mmap` and `mprotect`, and also when loading shared libraries) |

--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -59,30 +59,30 @@ The following configuration options are available for storage pools that use the
 (storage-btrfs-pool-config)=
 ### Storage pool configuration
 
-Key                             | Type      | Default                    | Description
-:--                             | :---      | :------                    | :----------
-`btrfs.mount_options`           | string    | `user_subvol_rm_allowed`   | Mount options for block devices
-`size`                          | string    | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool)
-`source`                        | string    | -                          | Path to an existing block device, loop file or Btrfs subvolume
-`source.wipe`                   | bool      | `false`                    | Wipe the block device specified in `source` prior to creating the storage pool
+| Key                   | Type   | Default                                               | Description                                                                                                                   |
+| :---                  | :---   | :---                                                  | :---                                                                                                                          |
+| `btrfs.mount_options` | string | `user_subvol_rm_allowed`                              | Mount options for block devices                                                                                               |
+| `size`                | string | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool) |
+| `source`              | string | -                                                     | Path to an existing block device, loop file or Btrfs subvolume                                                                |
+| `source.wipe`         | bool   | `false`                                               | Wipe the block device specified in `source` prior to creating the storage pool                                                |
 
 {{volume_configuration}}
 
 ### Storage volume configuration
 
-Key                         | Type      | Condition                 | Default                                       | Description
-:--                         | :---      | :--------                 | :------                                       | :----------
-`initial.gid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.uid` or `0`           | GID of the volume owner in the instance
-`initial.mode`              | int       | custom volume with content type `filesystem`  | same as `volume.initial.mode` or `711`        | Mode  of the volume in the instance
-`initial.uid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.gid` or `0`           | UID of the volume owner in the instance
-`security.shared`           | bool      | custom block volume       | same as `volume.security.shared` or `false`   | Enable sharing the volume across multiple instances
-`security.shifted`          | bool      | custom volume             | same as `volume.security.shifted` or `false`  | {{enable_ID_shifting}}
-`security.unmapped`         | bool      | custom volume             | same as `volume.security.unmapped` or `false` | Disable ID mapping for the volume
-`size`                      | string    | appropriate driver        | same as `volume.size`                         | Size/quota of the storage volume
-`snapshots.expiry`          | string    | custom volume             | same as `volume.snapshots.expiry`             | {{snapshot_expiry_format}}
-`snapshots.expiry.manual`   | string    | custom volume             | same as `volume.snapshots.expiry.manual`      | {{snapshot_expiry_format}}
-`snapshots.pattern`         | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d`| {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`        | string    | custom volume             | same as `volume.snapshots.schedule`           | {{snapshot_schedule_format}}
+| Key                       | Type   | Condition                                    | Default                                       | Description                                         |
+| :---                      | :---   | :---                                         | :---                                          | :---                                                |
+| `initial.gid`             | int    | custom volume with content type `filesystem` | same as `volume.initial.uid` or `0`           | GID of the volume owner in the instance             |
+| `initial.mode`            | int    | custom volume with content type `filesystem` | same as `volume.initial.mode` or `711`        | Mode  of the volume in the instance                 |
+| `initial.uid`             | int    | custom volume with content type `filesystem` | same as `volume.initial.gid` or `0`           | UID of the volume owner in the instance             |
+| `security.shared`         | bool   | custom block volume                          | same as `volume.security.shared` or `false`   | Enable sharing the volume across multiple instances |
+| `security.shifted`        | bool   | custom volume                                | same as `volume.security.shifted` or `false`  | {{enable_ID_shifting}}                              |
+| `security.unmapped`       | bool   | custom volume                                | same as `volume.security.unmapped` or `false` | Disable ID mapping for the volume                   |
+| `size`                    | string | appropriate driver                           | same as `volume.size`                         | Size/quota of the storage volume                    |
+| `snapshots.expiry`        | string | custom volume                                | same as `volume.snapshots.expiry`             | {{snapshot_expiry_format}}                          |
+| `snapshots.expiry.manual` | string | custom volume                                | same as `volume.snapshots.expiry.manual`      | {{snapshot_expiry_format}}                          |
+| `snapshots.pattern`       | string | custom volume                                | same as `volume.snapshots.pattern` or `snap%d`| {{snapshot_pattern_format}} [^*]                    |
+| `snapshots.schedule`      | string | custom volume                                | same as `volume.snapshots.schedule`           | {{snapshot_schedule_format}}                        |
 
 [^*]: {{snapshot_pattern_detail}}
 
@@ -90,6 +90,6 @@ Key                         | Type      | Condition                 | Default   
 
 To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage bucket
+| Key    | Type   | Condition          | Default               | Description                      |
+| :---   | :---   | :---               | :---                  | :---                             |
+| `size` | string | appropriate driver | same as `volume.size` | Size/quota of the storage bucket |

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -78,38 +78,38 @@ The following configuration options are available for storage pools that use the
 (storage-ceph-pool-config)=
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`ceph.cluster_name`           | string                        | `ceph`                                  | Name of the Ceph cluster in which to create new storage pools
-`ceph.osd.data_pool_name`     | string                        | -                                       | Name of the OSD data pool
-`ceph.osd.pg_num`             | string                        | `32`                                    | Number of placement groups for the OSD storage pool
-`ceph.osd.pool_name`          | string                        | name of the pool                        | Name of the OSD storage pool
-`ceph.rbd.clone_copy`         | bool                          | `true`                                  | Whether to use RBD lightweight clones rather than full dataset copies
-`ceph.rbd.du`                 | bool                          | `true`                                  | Whether to use RBD `du` to obtain disk usage data for stopped instances
-`ceph.rbd.features`           | string                        | `layering`                              | Comma-separated list of RBD features to enable on the volumes
-`ceph.user.name`              | string                        | `admin`                                 | The Ceph user to use when creating storage pools and volumes
-`source`                      | string                        | -                                       | Existing OSD storage pool to use
-`volatile.pool.pristine`      | string                        | `true`                                  | Whether the pool was empty on creation time
+| Key                       | Type   | Default          | Description                                                             |
+| :---                      | :---   | :---             | :---                                                                    |
+| `ceph.cluster_name`       | string | `ceph`           | Name of the Ceph cluster in which to create new storage pools           |
+| `ceph.osd.data_pool_name` | string | -                | Name of the OSD data pool                                               |
+| `ceph.osd.pg_num`         | string | `32`             | Number of placement groups for the OSD storage pool                     |
+| `ceph.osd.pool_name`      | string | name of the pool | Name of the OSD storage pool                                            |
+| `ceph.rbd.clone_copy`     | bool   | `true`           | Whether to use RBD lightweight clones rather than full dataset copies   |
+| `ceph.rbd.du`             | bool   | `true`           | Whether to use RBD `du` to obtain disk usage data for stopped instances |
+| `ceph.rbd.features`       | string | `layering`       | Comma-separated list of RBD features to enable on the volumes           |
+| `ceph.user.name`          | string | `admin`          | The Ceph user to use when creating storage pools and volumes            |
+| `source`                  | string | -                | Existing OSD storage pool to use                                        |
+| `volatile.pool.pristine`  | string | `true`           | Whether the pool was empty on creation time                             |
 
 {{volume_configuration}}
 
 (storage-ceph-vol-config)=
 ### Storage volume configuration
 
-Key                         | Type      | Condition                 | Default                                        | Description
-:--                         | :---      | :--------                 | :------                                        | :----------
-`block.filesystem`          | string    | block-based volume with content type `filesystem` | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`       | string    | block-based volume with content type `filesystem` | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
-`initial.gid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.uid` or `0`           | GID of the volume owner in the instance
-`initial.mode`              | int       | custom volume with content type `filesystem`  | same as `volume.initial.mode` or `711`        | Mode of the volume in the instance
-`initial.uid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.gid` or `0`           | UID of the volume owner in the instance
-`security.shared`           | bool      | custom block volume       | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances
-`security.shifted`          | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`         | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                      | string    |                           | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`          | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.expiry.manual`   | string    | custom volume             | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}
-`snapshots.pattern`         | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`        | string    | custom volume             | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
+| Key                       | Type   | Condition                                         | Default                                        | Description                                         |
+| :---                      | :---   | :---                                              | :---                                           | :---                                                |
+| `block.filesystem`        | string | block-based volume with content type `filesystem` | same as `volume.block.filesystem`              | {{block_filesystem}}                                |
+| `block.mount_options`     | string | block-based volume with content type `filesystem` | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes  |
+| `initial.gid`             | int    | custom volume with content type `filesystem`      | same as `volume.initial.uid` or `0`            | GID of the volume owner in the instance             |
+| `initial.mode`            | int    | custom volume with content type `filesystem`      | same as `volume.initial.mode` or `711`         | Mode of the volume in the instance                  |
+| `initial.uid`             | int    | custom volume with content type `filesystem`      | same as `volume.initial.gid` or `0`            | UID of the volume owner in the instance             |
+| `security.shared`         | bool   | custom block volume                               | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances |
+| `security.shifted`        | bool   | custom volume                                     | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}                              |
+| `security.unmapped`       | bool   | custom volume                                     | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume                   |
+| `size`                    | string |                                                   | same as `volume.size`                          | Size/quota of the storage volume                    |
+| `snapshots.expiry`        | string | custom volume                                     | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}                          |
+| `snapshots.expiry.manual` | string | custom volume                                     | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}                          |
+| `snapshots.pattern`       | string | custom volume                                     | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]                    |
+| `snapshots.schedule`      | string | custom volume                                     | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}                        |
 
 [^*]: {{snapshot_pattern_detail}}

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -58,35 +58,35 @@ The following configuration options are available for storage pools that use the
 (storage-cephfs-pool-config)=
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`cephfs.cluster_name`         | string                        | `ceph`                                  | Name of the Ceph cluster that contains the CephFS file system
-`cephfs.create_missing`       | bool                          | `false`                                 | Create the file system and the missing data and metadata OSD pools
-`cephfs.data_pool`            | string                        | -                                       | Data OSD pool name to create for the file system
-`cephfs.fscache`              | bool                          | `false`                                 | Enable use of kernel `fscache` and `cachefilesd`
-`cephfs.meta_pool`            | string                        | -                                       | Metadata OSD pool name to create for the file system
-`cephfs.osd_pg_num`           | string                        | -                                       | OSD pool `pg_num` to use when creating missing OSD pools
-`cephfs.path`                 | string                        | `/`                                     | The base path for the CephFS mount
-`cephfs.user.name`            | string                        | `admin`                                 | The Ceph user to use
-`source`                      | string                        | -                                       | Existing CephFS file system or file system path to use
-`volatile.pool.pristine`      | string                        | `true`                                  | Whether the CephFS file system was empty on creation time
+| Key                      | Type   | Default | Description                                                        |
+| :---                     | :---   | :---    | :---                                                               |
+| `cephfs.cluster_name`    | string | `ceph`  | Name of the Ceph cluster that contains the CephFS file system      |
+| `cephfs.create_missing`  | bool   | `false` | Create the file system and the missing data and metadata OSD pools |
+| `cephfs.data_pool`       | string | -       | Data OSD pool name to create for the file system                   |
+| `cephfs.fscache`         | bool   | `false` | Enable use of kernel `fscache` and `cachefilesd`                   |
+| `cephfs.meta_pool`       | string | -       | Metadata OSD pool name to create for the file system               |
+| `cephfs.osd_pg_num`      | string | -       | OSD pool `pg_num` to use when creating missing OSD pools           |
+| `cephfs.path`            | string | `/`     | The base path for the CephFS mount                                 |
+| `cephfs.user.name`       | string | `admin` | The Ceph user to use                                               |
+| `source`                 | string | -       | Existing CephFS file system or file system path to use             |
+| `volatile.pool.pristine` | string | `true`  | Whether the CephFS file system was empty on creation time          |
 
 {{volume_configuration}}
 
 ### Storage volume configuration
 
-Key                         | Type      | Condition                 | Default                                        | Description
-:--                         | :---      | :--------                 | :------                                        | :----------
-`initial.gid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.uid` or `0`           | GID of the volume owner in the instance
-`initial.mode`              | int       | custom volume with content type `filesystem`  | same as `volume.initial.mode` or `711`        | Mode  of the volume in the instance
-`initial.uid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.gid` or `0`           | UID of the volume owner in the instance
-`security.shared`           | bool      | custom block volume       | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances
-`security.shifted`          | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`         | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                      | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`          | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.expiry.manual`   | string    | custom volume             | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}
-`snapshots.pattern`         | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`        | string    | custom volume             | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
+| Key                       | Type   | Condition                                    | Default                                        | Description                                         |
+| :---                      | :---   | :---                                         | :---                                           | :---                                                |
+| `initial.gid`             | int    | custom volume with content type `filesystem` | same as `volume.initial.uid` or `0`            | GID of the volume owner in the instance             |
+| `initial.mode`            | int    | custom volume with content type `filesystem` | same as `volume.initial.mode` or `711`         | Mode  of the volume in the instance                 |
+| `initial.uid`             | int    | custom volume with content type `filesystem` | same as `volume.initial.gid` or `0`            | UID of the volume owner in the instance             |
+| `security.shared`         | bool   | custom block volume                          | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances |
+| `security.shifted`        | bool   | custom volume                                | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}                              |
+| `security.unmapped`       | bool   | custom volume                                | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume                   |
+| `size`                    | string | appropriate driver                           | same as `volume.size`                          | Size/quota of the storage volume                    |
+| `snapshots.expiry`        | string | custom volume                                | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}                          |
+| `snapshots.expiry.manual` | string | custom volume                                | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}                          |
+| `snapshots.pattern`       | string | custom volume                                | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]                    |
+| `snapshots.schedule`      | string | custom volume                                | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}                        |
 
 [^*]: {{snapshot_pattern_detail}}

--- a/doc/reference/storage_cephobject.md
+++ b/doc/reference/storage_cephobject.md
@@ -60,17 +60,17 @@ The following configuration options are available for storage pools that use the
 (storage-cephobject-pool-config)=
 ### Storage pool configuration
 
-Key                                      | Type                          | Default | Description
-:--                                      | :---                          | :------ | :----------
-`cephobject.bucket.name_prefix`          | string                        | -       | Prefix to add to bucket names in Ceph
-`cephobject.cluster_name`                | string                        | `ceph`  | The Ceph cluster to use
-`cephobject.radosgw.endpoint`            | string                        | -       | URL of the `radosgw` gateway process
-`cephobject.radosgw.endpoint_cert_file`  | string                        | -       | Path to the file containing the TLS client certificate to use for endpoint communication
-`cephobject.user.name`                   | string                        | `admin` | The Ceph user to use
-`volatile.pool.pristine`                 | string                        | `true`  | Whether the `radosgw` `incus-admin` user existed at creation time
+| Key                                     | Type   | Default | Description                                                                              |
+| :---                                    | :---   | :---    | :---                                                                                     |
+| `cephobject.bucket.name_prefix`         | string | -       | Prefix to add to bucket names in Ceph                                                    |
+| `cephobject.cluster_name`               | string | `ceph`  | The Ceph cluster to use                                                                  |
+| `cephobject.radosgw.endpoint`           | string | -       | URL of the `radosgw` gateway process                                                     |
+| `cephobject.radosgw.endpoint_cert_file` | string | -       | Path to the file containing the TLS client certificate to use for endpoint communication |
+| `cephobject.user.name`                  | string | `admin` | The Ceph user to use                                                                     |
+| `volatile.pool.pristine`                | string | `true`  | Whether the `radosgw` `incus-admin` user existed at creation time                        |
 
 ### Storage bucket configuration
 
-Key    | Type   | Default                | Description
-:--    | :---   | :------                | :----------
-`size` | string | -                      | Quota of the storage bucket
+| Key    | Type   | Default | Description                 |
+| :---   | :---   | :---    | :---                        |
+| `size` | string | -       | Quota of the storage bucket |

--- a/doc/reference/storage_dir.md
+++ b/doc/reference/storage_dir.md
@@ -25,29 +25,29 @@ The following configuration options are available for storage pools that use the
 
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`rsync.bwlimit`               | string                        | `0` (no limit)                          | The upper limit to be placed on the socket I/O when `rsync` must be used to transfer storage entities
-`rsync.compression`           | bool                          | `true`                                  | Whether to use compression while migrating storage pools
-`source`                      | string                        | -                                       | Path to an existing directory
+| Key                 | Type   | Default        | Description                                                                                           |
+| :---                | :---   | :---           | :---                                                                                                  |
+| `rsync.bwlimit`     | string | `0` (no limit) | The upper limit to be placed on the socket I/O when `rsync` must be used to transfer storage entities |
+| `rsync.compression` | bool   | `true`         | Whether to use compression while migrating storage pools                                              |
+| `source`            | string | -              | Path to an existing directory                                                                         |
 
 {{volume_configuration}}
 
 ### Storage volume configuration
 
-Key                         | Type      | Condition                 | Default                                        | Description
-:--                         | :---      | :--------                 | :------                                        | :----------
-`initial.gid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.uid` or `0`           | GID of the volume owner in the instance
-`initial.mode`              | int       | custom volume with content type `filesystem`  | same as `volume.initial.mode` or `711`        | Mode  of the volume in the instance
-`initial.uid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.gid` or `0`           | UID of the volume owner in the instance
-`security.shared`           | bool      | custom block volume       | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances
-`security.shifted`          | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`         | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                      | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`          | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.expiry.manual`   | string    | custom volume             | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}
-`snapshots.pattern`         | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`        | string    | custom volume             | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
+| Key                       | Type   | Condition                                    | Default                                        | Description                                         |
+| :---                      | :---   | :---                                         | :---                                           | :---                                                |
+| `initial.gid`             | int    | custom volume with content type `filesystem` | same as `volume.initial.uid` or `0`            | GID of the volume owner in the instance             |
+| `initial.mode`            | int    | custom volume with content type `filesystem` | same as `volume.initial.mode` or `711`         | Mode  of the volume in the instance                 |
+| `initial.uid`             | int    | custom volume with content type `filesystem` | same as `volume.initial.gid` or `0`            | UID of the volume owner in the instance             |
+| `security.shared`         | bool   | custom block volume                          | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances |
+| `security.shifted`        | bool   | custom volume                                | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}                              |
+| `security.unmapped`       | bool   | custom volume                                | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume                   |
+| `size`                    | string | appropriate driver                           | same as `volume.size`                          | Size/quota of the storage volume                    |
+| `snapshots.expiry`        | string | custom volume                                | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}                          |
+| `snapshots.expiry.manual` | string | custom volume                                | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}                          |
+| `snapshots.pattern`       | string | custom volume                                | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]                    |
+| `snapshots.schedule`      | string | custom volume                                | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}                        |
 
 [^*]: {{snapshot_pattern_detail}}
 

--- a/doc/reference/storage_drivers.md
+++ b/doc/reference/storage_drivers.md
@@ -24,21 +24,21 @@ See the corresponding pages for driver-specific information and configuration op
 
 Where possible, Incus uses the advanced features of each storage system to optimize operations.
 
-Feature                                     | Directory | Btrfs | LVM   | ZFS     | Ceph RBD | CephFS | Ceph Object | LINSTOR | TRUENAS
-:---                                        | :---      | :---  | :---  | :---    | :---     | :---   | :---        | :--     | :--
-{ref}`storage-optimized-image-storage`      | no        | yes   | yes   | yes     | yes      | n/a    | n/a         | yes     | yes
-Optimized instance creation                 | no        | yes   | yes   | yes     | yes      | n/a    | n/a         | yes     | yes
-Optimized snapshot creation                 | no        | yes   | yes   | yes     | yes      | yes    | n/a         | yes     | yes
-Optimized image transfer                    | no        | yes   | no    | yes     | yes      | n/a    | n/a         | no      | no
-{ref}`storage-optimized-volume-transfer`    | no        | yes   | no    | yes     | yes      | n/a    | n/a         | no      | no
-Copy on write                               | no        | yes   | yes   | yes     | yes      | yes    | n/a         | yes     | yes
-Block based                                 | no        | no    | yes   | no      | yes      | no     | n/a         | yes     | yes
-Instant cloning                             | no        | yes   | yes   | yes     | yes      | yes    | n/a         | yes     | yes
-Storage driver usable inside a container    | yes       | yes   | no    | yes[^1] | no       | n/a    | n/a         | no      | no
-Restore from older snapshots (not latest)   | yes       | yes   | yes   | no      | yes      | yes    | n/a         | no      | no
-Storage quotas                              | yes[^2]   | yes   | yes   | yes     | yes      | yes    | yes         | yes     | yes
-Available on `incus admin init`             | yes       | yes   | yes   | yes     | yes      | no     | no          | no      | no
-Object storage                              | yes       | yes   | yes   | yes     | no       | no     | yes         | no      | no
+| Feature                                   | Directory | Btrfs | LVM   | ZFS     | Ceph RBD | CephFS | Ceph Object | LINSTOR | TRUENAS |
+| :---                                      | :---      | :---  | :---  | :---    | :---     | :---   | :---        | :---    | :---    |
+| {ref}`storage-optimized-image-storage`    | no        | yes   | yes   | yes     | yes      | n/a    | n/a         | yes     | yes     |
+| Optimized instance creation               | no        | yes   | yes   | yes     | yes      | n/a    | n/a         | yes     | yes     |
+| Optimized snapshot creation               | no        | yes   | yes   | yes     | yes      | yes    | n/a         | yes     | yes     |
+| Optimized image transfer                  | no        | yes   | no    | yes     | yes      | n/a    | n/a         | no      | no      |
+| {ref}`storage-optimized-volume-transfer`  | no        | yes   | no    | yes     | yes      | n/a    | n/a         | no      | no      |
+| Copy on write                             | no        | yes   | yes   | yes     | yes      | yes    | n/a         | yes     | yes     |
+| Block based                               | no        | no    | yes   | no      | yes      | no     | n/a         | yes     | yes     |
+| Instant cloning                           | no        | yes   | yes   | yes     | yes      | yes    | n/a         | yes     | yes     |
+| Storage driver usable inside a container  | yes       | yes   | no    | yes[^1] | no       | n/a    | n/a         | no      | no      |
+| Restore from older snapshots (not latest) | yes       | yes   | yes   | no      | yes      | yes    | n/a         | no      | no      |
+| Storage quotas                            | yes[^2]   | yes   | yes   | yes     | yes      | yes    | yes         | yes     | yes     |
+| Available on `incus admin init`           | yes       | yes   | yes   | yes     | yes      | no     | no          | no      | no      |
+| Object storage                            | yes       | yes   | yes   | yes     | no       | no     | yes         | no      | no      |
 
 [^1]: Requires [`zfs.delegate`](storage-zfs-vol-config) to be enabled.
 [^2]: % Include content from [storage_dir.md](storage_dir.md)

--- a/doc/reference/storage_linstor.md
+++ b/doc/reference/storage_linstor.md
@@ -29,11 +29,11 @@ This driver also behaves differently than other drivers in that it can provide b
 
 The `linstor` driver in Incus uses resource groups to manage and spawn resources. The following table describes the mapping between Incus and LINSTOR concepts:
 
-Incus concept | LINSTOR concept
-:--           | :--
-Storage pool  | Resource group
-Volume        | Resource definition
-Snapshot      | Snapshot
+| Incus concept | LINSTOR concept     |
+| :---          | :---                |
+| Storage pool  | Resource group      |
+| Volume        | Resource definition |
+| Snapshot      | Snapshot            |
 
 Incus assumes that it has full control over the LINSTOR resource group.
 Therefore, you should never maintain any entities that are not owned by Incus in an Incus LINSTOR resource group, because Incus might delete them.
@@ -67,40 +67,40 @@ The following configuration options are available for storage pools that use the
 (storage-linstor-pool-config)=
 ### Storage pool configuration
 
-Key                                   | Type           | Default           | Description
-:--                                   | :---           | :------           | :----------
-`linstor.resource_group.name`         | string         | `incus`           | Name of the LINSTOR resource group that will be used for the storage pool
-`linstor.resource_group.place_count`  | int            | 2                 | Number of diskful replicas that should be created for resources in the resource group. Increasing the value of this option on a pool that already has volumes will result in LINSTOR creating new diskful replicas for all existing resources to match the new value
-`linstor.resource_group.storage_pool` | string         | -                 | The storage pool name in which resources should be placed on satellite nodes
-`linstor.volume.prefix`               | string         | `incus-volume-`   | The prefix to use for the internal names of LINSTOR-managed volumes. Cannot be updated after the storage pool is created
-`drbd.on_no_quorum`                   | string         | -                 | The DRBD policy to use on resources when quorum is lost (applied to the resource group)
-`drbd.auto_diskful`                   | string         | -                 | A duration string describing the time after which a primary diskless resource can be converted to diskful if storage is available on the node (applied to the resource group)
-`drbd.auto_add_quorum_tiebreaker`     | bool           | `true`            | Whether to allow LINSTOR to automatically create diskless resources to act as quorum tiebreakers if needed (applied to the resource group)
+| Key                                   | Type   | Default         | Description                                                                                                                                                                    |
+| :---                                  | :---   | :------         | :----------                                                                                                                                                                    |
+| `linstor.resource_group.name`         | string | `incus`         | Name of the LINSTOR resource group that will be used for the storage pool                                                                                                      |
+| `linstor.resource_group.place_count`  | int    | 2               | Number of diskful replicas that should be created for resources in the resource group. Increasing the value of this option on a pool that already has volumes will result in LINSTOR creating new diskful replicas for all existing resources to match the new value |
+| `linstor.resource_group.storage_pool` | string | -               | The storage pool name in which resources should be placed on satellite nodes                                                                                                   |
+| `linstor.volume.prefix`               | string | `incus-volume-` | The prefix to use for the internal names of LINSTOR-managed volumes. Cannot be updated after the storage pool is created                                                       |
+| `drbd.on_no_quorum`                   | string | -               | The DRBD policy to use on resources when quorum is lost (applied to the resource group)                                                                                        |
+| `drbd.auto_diskful`                   | string | -               | A duration string describing the time after which a primary diskless resource can be converted to diskful if storage is available on the node (applied to the resource group)  |
+| `drbd.auto_add_quorum_tiebreaker`     | bool   | `true`          | Whether to allow LINSTOR to automatically create diskless resources to act as quorum tiebreakers if needed (applied to the resource group)                                     |
 
 {{volume_configuration}}
 
 (storage-linstor-vol-config)=
 ### Storage volume configuration
 
-Key                               | Type      | Condition                                         | Default                                        | Description
-:--                               | :---      | :--------                                         | :------                                        | :----------
-`block.filesystem`                | string    | block-based volume with content type `filesystem` | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`             | string    | block-based volume with content type `filesystem` | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
-`initial.gid`                     | int       | custom volume with content type `filesystem`      | same as `volume.initial.uid` or `0`            | GID of the volume owner in the instance
-`initial.mode`                    | int       | custom volume with content type `filesystem`      | same as `volume.initial.mode` or `711`         | Mode of the volume in the instance
-`initial.uid`                     | int       | custom volume with content type `filesystem`      | same as `volume.initial.gid` or `0`            | UID of the volume owner in the instance
-`security.shared`                 | bool      | custom block volume                               | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances
-`security.shifted`                | bool      | custom volume                                     | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`               | bool      | custom volume                                     | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                            | string    |                                                   | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`                | string    | custom volume                                     | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.expiry.manual`         | string    | custom volume                                     | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}
-`snapshots.pattern`               | string    | custom volume                                     | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`              | string    | custom volume                                     | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
-`drbd.on_no_quorum`               | string    |                                                   | -                                              | The DRBD policy to use on resources when quorum is lost (applied to the resource definition)
-`drbd.auto_diskful`               | string    |                                                   | -                                              | A duration string describing the time after which a primary diskless resource can be converted to diskful if storage is available on the node (applied to the resource definition)
-`drbd.auto_add_quorum_tiebreaker` | bool      |                                                   | `true`                                         | Whether to allow LINSTOR to automatically create diskless resources to act as quorum tiebreakers if needed (applied to the resource definition)
-`linstor.remove_snapshots`        | bool      |                                                   | same as `volume.linstor.remove_snapshots` or `false` | Remove snapshots as needed
+| Key                               | Type   | Condition                                         | Default                                              | Description                                                                                  |
+| :---                              | :---   | :---                                              | :---                                                 | :---                                                                                         |
+| `block.filesystem`                | string | block-based volume with content type `filesystem` | same as `volume.block.filesystem`                    | {{block_filesystem}}                                                                         |
+| `block.mount_options`             | string | block-based volume with content type `filesystem` | same as `volume.block.mount_options`                 | Mount options for block-backed file system volumes                                           |
+| `initial.gid`                     | int    | custom volume with content type `filesystem`      | same as `volume.initial.uid` or `0`                  | GID of the volume owner in the instance                                                      |
+| `initial.mode`                    | int    | custom volume with content type `filesystem`      | same as `volume.initial.mode` or `711`               | Mode of the volume in the instance                                                           |
+| `initial.uid`                     | int    | custom volume with content type `filesystem`      | same as `volume.initial.gid` or `0`                  | UID of the volume owner in the instance                                                      |
+| `security.shared`                 | bool   | custom block volume                               | same as `volume.security.shared` or `false`          | Enable sharing the volume across multiple instances                                          |
+| `security.shifted`                | bool   | custom volume                                     | same as `volume.security.shifted` or `false`         | {{enable_ID_shifting}}                                                                       |
+| `security.unmapped`               | bool   | custom volume                                     | same as `volume.security.unmapped` or `false`        | Disable ID mapping for the volume                                                            |
+| `size`                            | string |                                                   | same as `volume.size`                                | Size/quota of the storage volume                                                             |
+| `snapshots.expiry`                | string | custom volume                                     | same as `volume.snapshots.expiry`                    | {{snapshot_expiry_format}}                                                                   |
+| `snapshots.expiry.manual`         | string | custom volume                                     | same as `volume.snapshots.expiry.manual`             | {{snapshot_expiry_format}}                                                                   |
+| `snapshots.pattern`               | string | custom volume                                     | same as `volume.snapshots.pattern` or `snap%d`       | {{snapshot_pattern_format}} [^*]                                                             |
+| `snapshots.schedule`              | string | custom volume                                     | same as `volume.snapshots.schedule`                  | {{snapshot_schedule_format}}                                                                 |
+| `drbd.on_no_quorum`               | string |                                                   | -                                                    | The DRBD policy to use on resources when quorum is lost (applied to the resource definition) |
+| `drbd.auto_diskful`               | string |                                                   | -                                                    | A duration string describing the time after which a primary diskless resource can be converted to diskful if storage is available on the node (applied to the resource definition) |
+| `drbd.auto_add_quorum_tiebreaker` | bool   |                                                   | `true`                                               | Whether to allow LINSTOR to automatically create diskless resources to act as quorum tiebreakers if needed (applied to the resource definition) |
+| `linstor.remove_snapshots`        | bool   |                                                   | same as `volume.linstor.remove_snapshots` or `false` | Remove snapshots as needed                                                                   |
 
 [^*]: {{snapshot_pattern_detail}}
 

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -62,42 +62,42 @@ The following configuration options are available for storage pools that use the
 (storage-lvm-pool-config)=
 ### Storage pool configuration
 
-Key                          | Type   | Driver       | Default                                               | Description
-:--                          | :---   | :-----       | :------                                               | :----------
-`lvm.thinpool_name`          | string | `lvm`        | `IncusThinPool`                                       | Thin pool where volumes are created
-`lvm.thinpool_metadata_size` | string | `lvm`        |`0` (auto)                                             | The size of the thin pool metadata volume (the default is to let LVM calculate an appropriate size)
-`lvm.metadata_size`          | string | `lvm`        |`0` (auto)                                             | The size of the metadata space for the physical volume
-`lvm.use_thinpool`           | bool   | `lvm`        | `true`                                                | Whether the storage pool uses a thin pool for logical volumes
-`lvm.vg.force_reuse`         | bool   | `lvm`        | `false`                                               | Force using an existing non-empty volume group
-`lvm.vg_name`                | string | all          | name of the pool                                      | Name of the volume group to create
-`rsync.bwlimit`              | string | all          | `0` (no limit)                                        | The upper limit to be placed on the socket I/O when `rsync` must be used to transfer storage entities
-`rsync.compression`          | bool   | all          | `true`                                                | Whether to use compression while migrating storage pools
-`size`                       | string | `lvm`        | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool)
-`source`                     | string | all          | -                                                     | Path to an existing block device, loop file or LVM volume group
-`source.wipe`                | bool   | `lvm`        | `false`                                               | Wipe the block device specified in `source` prior to creating the storage pool
+| Key                          | Type   | Driver | Default                                               | Description                                                                                                                   |
+| :---                         | :---   | :---   | :---                                                  | :---                                                                                                                          |
+| `lvm.thinpool_name`          | string | `lvm`  | `IncusThinPool`                                       | Thin pool where volumes are created                                                                                           |
+| `lvm.thinpool_metadata_size` | string | `lvm`  |`0` (auto)                                             | The size of the thin pool metadata volume (the default is to let LVM calculate an appropriate size)                           |
+| `lvm.metadata_size`          | string | `lvm`  |`0` (auto)                                             | The size of the metadata space for the physical volume                                                                        |
+| `lvm.use_thinpool`           | bool   | `lvm`  | `true`                                                | Whether the storage pool uses a thin pool for logical volumes                                                                 |
+| `lvm.vg.force_reuse`         | bool   | `lvm`  | `false`                                               | Force using an existing non-empty volume group                                                                                |
+| `lvm.vg_name`                | string | all    | name of the pool                                      | Name of the volume group to create                                                                                            |
+| `rsync.bwlimit`              | string | all    | `0` (no limit)                                        | The upper limit to be placed on the socket I/O when `rsync` must be used to transfer storage entities                         |
+| `rsync.compression`          | bool   | all    | `true`                                                | Whether to use compression while migrating storage pools                                                                      |
+| `size`                       | string | `lvm`  | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool) |
+| `source`                     | string | all    | -                                                     | Path to an existing block device, loop file or LVM volume group                                                               |
+| `source.wipe`                | bool   | `lvm`  | `false`                                               | Wipe the block device specified in `source` prior to creating the storage pool                                                |
 
 {{volume_configuration}}
 
 (storage-lvm-vol-config)=
 ### Storage volume configuration
 
-Key                         | Type   | Condition                                         | Default                                        | Description
-:--                         | :---   | :------                                           | :------                                        | :----------
-`block.filesystem`          | string | block-based volume with content type `filesystem` | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`       | string | block-based volume with content type `filesystem` | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
-`initial.gid`               | int    | custom volume with content type `filesystem`      | same as `volume.initial.uid` or `0`            | GID of the volume owner in the instance
-`initial.mode`              | int    | custom volume with content type `filesystem`      | same as `volume.initial.mode` or `711`         | Mode  of the volume in the instance
-`initial.uid`               | int    | custom volume with content type `filesystem`      | same as `volume.initial.gid` or `0`            | UID of the volume owner in the instance
-`lvm.stripes`               | string |                                                   | same as `volume.lvm.stripes`                   | Number of stripes to use for new volumes (or thin pool volume)
-`lvm.stripes.size`          | string |                                                   | same as `volume.lvm.stripes.size`              | Size of stripes to use (at least 4096 bytes and multiple of 512 bytes)
-`security.shifted`          | bool   | custom volume                                     | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`         | bool   | custom volume                                     | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`security.shared`           | bool   | custom block volume                               | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances
-`size`                      | string |                                                   | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`          | string | custom volume                                     | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.expiry.manual`   | string | custom volume                                     | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}
-`snapshots.pattern`         | string | custom volume                                     | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`        | string | custom volume                                     | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
+| Key                       | Type   | Condition                                         | Default                                        | Description                                                            |
+| :---                      | :---   | :---                                              | :---                                           | :---                                                                   |
+| `block.filesystem`        | string | block-based volume with content type `filesystem` | same as `volume.block.filesystem`              | {{block_filesystem}}                                                   |
+| `block.mount_options`     | string | block-based volume with content type `filesystem` | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes                     |
+| `initial.gid`             | int    | custom volume with content type `filesystem`      | same as `volume.initial.uid` or `0`            | GID of the volume owner in the instance                                |
+| `initial.mode`            | int    | custom volume with content type `filesystem`      | same as `volume.initial.mode` or `711`         | Mode  of the volume in the instance                                    |
+| `initial.uid`             | int    | custom volume with content type `filesystem`      | same as `volume.initial.gid` or `0`            | UID of the volume owner in the instance                                |
+| `lvm.stripes`             | string |                                                   | same as `volume.lvm.stripes`                   | Number of stripes to use for new volumes (or thin pool volume)         |
+| `lvm.stripes.size`        | string |                                                   | same as `volume.lvm.stripes.size`              | Size of stripes to use (at least 4096 bytes and multiple of 512 bytes) |
+| `security.shifted`        | bool   | custom volume                                     | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}                                                 |
+| `security.unmapped`       | bool   | custom volume                                     | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume                                      |
+| `security.shared`         | bool   | custom block volume                               | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances                    |
+| `size`                    | string |                                                   | same as `volume.size`                          | Size/quota of the storage volume                                       |
+| `snapshots.expiry`        | string | custom volume                                     | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}                                             |
+| `snapshots.expiry.manual` | string | custom volume                                     | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}                                             |
+| `snapshots.pattern`       | string | custom volume                                     | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]                                       |
+| `snapshots.schedule`      | string | custom volume                                     | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}                                           |
 
 [^*]: {{snapshot_pattern_detail}}
 
@@ -105,6 +105,6 @@ Key                         | Type   | Condition                                
 
 To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
-Key    | Type   | Condition          | Default               | Description
-:--    | :---   | :--------          | :------               | :----------
-`size` | string | appropriate driver | same as `volume.size` | Size/quota of the storage bucket
+| Key    | Type   | Condition          | Default               | Description                      |
+| :---   | :---   | :---               | :---                  | :---                             |
+| `size` | string | appropriate driver | same as `volume.size` | Size/quota of the storage bucket |

--- a/doc/reference/storage_truenas.md
+++ b/doc/reference/storage_truenas.md
@@ -76,36 +76,36 @@ The following configuration options are available for storage pools that use the
 (storage-truenas-pool-config)=
 ### Storage pool configuration
 
-Key                         | Type      | Default   | Description
-:--                         | :---      | :------   | :----------
-`source`                    | string    | -         | ZFS dataset to use on the remote TrueNAS host. Format: `[<host>:]<pool>[/<dataset>][/]`. If `host` is omitted here, it must be set via `truenas.host`.
-`truenas.allow_insecure`    | boolean   | false     | If set to `true`, allows insecure (non-TLS) connections to the TrueNAS API.
-`truenas.api_key`           | string    | -         | API key used to authenticate with the TrueNAS host.
-`truenas.dataset`           | string    | -         | Remote dataset name. Typically inferred from `source`, but can be overridden.
-`truenas.host`              | string    | -         | Hostname or IP address of the remote TrueNAS system. Optional if included in the `source`, or a configuration is used.
-`truenas.initiator`         | string    | -         | iSCSI initiator name used during block volume attachment.
-`truenas.portal`            | string    | -         | iSCSI portal address to use for block volume connections.
+| Key                      | Type    | Default | Description                                                                                                                                            |
+| :---                     | :---    | :---    | :---                                                                                                                                                   |
+| `source`                 | string  | -       | ZFS dataset to use on the remote TrueNAS host. Format: `[<host>:]<pool>[/<dataset>][/]`. If `host` is omitted here, it must be set via `truenas.host`. |
+| `truenas.allow_insecure` | boolean | false   | If set to `true`, allows insecure (non-TLS) connections to the TrueNAS API.                                                                            |
+| `truenas.api_key`        | string  | -       | API key used to authenticate with the TrueNAS host.                                                                                                    |
+| `truenas.dataset`        | string  | -       | Remote dataset name. Typically inferred from `source`, but can be overridden.                                                                          |
+| `truenas.host`           | string  | -       | Hostname or IP address of the remote TrueNAS system. Optional if included in the `source`, or a configuration is used.                                 |
+| `truenas.initiator`      | string  | -       | iSCSI initiator name used during block volume attachment.                                                                                              |
+| `truenas.portal`         | string  | -       | iSCSI portal address to use for block volume connections.                                                                                              |
 
 {{volume_configuration}}
 
 (storage-truenas-vol-config)=
 ### Storage volume configuration
 
-Key                         | Type      | Condition                                     | Default                                               | Description
-:--                         | :---      | :--------                                     | :------                                               | :----------
-`block.filesystem`          | string    |                                               | same as `volume.block.filesystem`                     | {{block_filesystem}}
-`block.mount_options`       | string    |                                               | same as `volume.block.mount_options`                  | Mount options for block-backed file system volumes
-`initial.gid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.uid` or `0`                   | GID of the volume owner in the instance
-`initial.mode`              | int       | custom volume with content type `filesystem`  | same as `volume.initial.mode` or `711`                | Mode  of the volume in the instance
-`initial.uid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.gid` or `0`                   | UID of the volume owner in the instance
-`security.shared`           | bool      | custom block volume                           | same as `volume.security.shared` or `false`           | Enable sharing the volume across multiple instances
-`security.shifted`          | bool      | custom volume                                 | same as `volume.security.shifted` or `false`          | {{enable_ID_shifting}}
-`security.unmapped`         | bool      | custom volume                                 | same as `volume.security.unmapped` or `false`         | Disable ID mapping for the volume
-`size`                      | string    |                                               | same as `volume.size`                                 | Size/quota of the storage volume
-`snapshots.expiry`          | string    | custom volume                                 | same as `volume.snapshots.expiry`                     | {{snapshot_expiry_format}}
-`snapshots.expiry.manual`   | string    | custom volume                                 | same as `volume.snapshots.expiry.manual`              | {{snapshot_expiry_format}}
-`snapshots.pattern`         | string    | custom volume                                 | same as `volume.snapshots.pattern` or `snap%d`        | {{snapshot_pattern_format}}
-`snapshots.schedule`        | string    | custom volume                                 | same as `snapshots.schedule`                          | {{snapshot_schedule_format}}
-`truenas.blocksize`         | string    |                                               | same as `volume.truenas.blocksize`                    | Size of the ZFS block in range from 512 bytes to 16 MiB (must be power of 2) - for block volume, a maximum value of 128 KiB will be used even if a higher value is set
-`truenas.remove_snapshots`  | bool      |                                               | same as `volume.truenas.remove_snapshots` or `false`  | Remove snapshots as needed
-`truenas.use_refquota`      | bool      |                                               | same as `volume.truenas.use_refquota` or `false`      | Use `refquota` instead of `quota` for space
+| Key                        | Type   | Condition                                    | Default                                              | Description                                         |
+| :---                       | :---   | :---                                         | :---                                                 | :---                                                |
+| `block.filesystem`         | string |                                              | same as `volume.block.filesystem`                    | {{block_filesystem}}                                |
+| `block.mount_options`      | string |                                              | same as `volume.block.mount_options`                 | Mount options for block-backed file system volumes  |
+| `initial.gid`              | int    | custom volume with content type `filesystem` | same as `volume.initial.uid` or `0`                  | GID of the volume owner in the instance             |
+| `initial.mode`             | int    | custom volume with content type `filesystem` | same as `volume.initial.mode` or `711`               | Mode  of the volume in the instance                 |
+| `initial.uid`              | int    | custom volume with content type `filesystem` | same as `volume.initial.gid` or `0`                  | UID of the volume owner in the instance             |
+| `security.shared`          | bool   | custom block volume                          | same as `volume.security.shared` or `false`          | Enable sharing the volume across multiple instances |
+| `security.shifted`         | bool   | custom volume                                | same as `volume.security.shifted` or `false`         | {{enable_ID_shifting}}                              |
+| `security.unmapped`        | bool   | custom volume                                | same as `volume.security.unmapped` or `false`        | Disable ID mapping for the volume                   |
+| `size`                     | string |                                              | same as `volume.size`                                | Size/quota of the storage volume                    |
+| `snapshots.expiry`         | string | custom volume                                | same as `volume.snapshots.expiry`                    | {{snapshot_expiry_format}}                          |
+| `snapshots.expiry.manual`  | string | custom volume                                | same as `volume.snapshots.expiry.manual`             | {{snapshot_expiry_format}}                          |
+| `snapshots.pattern`        | string | custom volume                                | same as `volume.snapshots.pattern` or `snap%d`       | {{snapshot_pattern_format}}                         |
+| `snapshots.schedule`       | string | custom volume                                | same as `snapshots.schedule`                         | {{snapshot_schedule_format}}                        |
+| `truenas.blocksize`        | string |                                              | same as `volume.truenas.blocksize`                   | Size of the ZFS block in range from 512 bytes to 16 MiB (must be power of 2) - for block volume, a maximum value of 128 KiB will be used even if a higher value is set |
+| `truenas.remove_snapshots` | bool   |                                              | same as `volume.truenas.remove_snapshots` or `false` | Remove snapshots as needed                          |
+| `truenas.use_refquota`     | bool   |                                              | same as `volume.truenas.use_refquota` or `false`     | Use `refquota` instead of `quota` for space         |

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -91,41 +91,41 @@ The following configuration options are available for storage pools that use the
 (storage-zfs-pool-config)=
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`size`                        | string                        | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool)
-`source`                      | string                        | -                                       | Path to existing block device(s), loop file or ZFS dataset/pool. Multiple block devices should be separated by `,`. When listing block devices, you can also prefix them with `vdev` type. To specify a `vdev` type, use an `=` sign between the `vdev` type and the block devices (e.g., `mirror=/dev/sda,/dev/sdb`). Only `stripe`, `mirror`, `raidz1` and `raidz2` `vdev` types are supported.
-`source.wipe`                 | bool                          | `false`                                 | Wipe the block device specified in `source` prior to creating the storage pool
-`zfs.clone_copy`              | string                        | `true`                                  | Whether to use ZFS lightweight clones rather than full {spellexception}`dataset` copies (Boolean), or `rebase` to copy based on the initial image
-`zfs.export`                  | bool                          | `true`                                  | Disable zpool export while unmount performed
-`zfs.pool_name`               | string                        | name of the pool                        | Name of the zpool
+| Key              | Type   | Default                                               | Description                                                                                                                   |
+| :---             | :---   | :---                                                  | :---                                                                                                                          |
+| `size`           | string | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool) |
+| `source`         | string | -                                                     | Path to existing block device(s), loop file or ZFS dataset/pool. Multiple block devices should be separated by `,`. When listing block devices, you can also prefix them with `vdev` type. To specify a `vdev` type, use an `=` sign between the `vdev` type and the block devices (e.g., `mirror=/dev/sda,/dev/sdb`). Only `stripe`, `mirror`, `raidz1` and `raidz2` `vdev` types are supported. |
+| `source.wipe`    | bool   | `false`                                               | Wipe the block device specified in `source` prior to creating the storage pool                                                |
+| `zfs.clone_copy` | string | `true`                                                | Whether to use ZFS lightweight clones rather than full {spellexception}`dataset` copies (Boolean), or `rebase` to copy based on the initial image |
+| `zfs.export`     | bool   | `true`                                                | Disable zpool export while unmount performed                                                                                  |
+| `zfs.pool_name`  | string | name of the pool                                      | Name of the zpool                                                                                                             |
 
 {{volume_configuration}}
 
 (storage-zfs-vol-config)=
 ### Storage volume configuration
 
-Key                         | Type      | Condition                 | Default                                        | Description
-:--                         | :---      | :--------                 | :------                                        | :----------
-`block.filesystem`          | string    | block-based volume with content type `filesystem` (`zfs.block_mode` enabled) | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`       | string    | block-based volume with content type `filesystem` (`zfs.block_mode` enabled) | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
-`initial.gid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.uid` or `0`           | GID of the volume owner in the instance
-`initial.mode`              | int       | custom volume with content type `filesystem`  | same as `volume.initial.mode` or `711`        | Mode  of the volume in the instance
-`initial.uid`               | int       | custom volume with content type `filesystem`  | same as `volume.initial.gid` or `0`           | UID of the volume owner in the instance
-`security.shared`           | bool      | custom block volume       | same as `volume.security.shared` or `false`    | Enable sharing the volume across multiple instances
-`security.shifted`          | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`         | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                      | string    |                           | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`          | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.expiry.manual`   | string    | custom volume             | same as `volume.snapshots.expiry.manual`       | {{snapshot_expiry_format}}
-`snapshots.pattern`         | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`        | string    | custom volume             | same as `snapshots.schedule`                   | {{snapshot_schedule_format}}
-`zfs.blocksize`             | string    |                           | same as `volume.zfs.blocksize`                 | Size of the ZFS block in range from 512 bytes to 16 MiB (must be power of 2) - for block volume, a maximum value of 128 KiB will be used even if a higher value is set
-`zfs.block_mode`            | bool      |                           | same as `volume.zfs.block_mode`                | Whether to use a formatted `zvol` rather than a {spellexception}`dataset` (`zfs.block_mode` can be set only for custom storage volumes; use `volume.zfs.block_mode` to enable ZFS block mode for all storage volumes in the pool, including instance volumes)
-`zfs.delegate`              | bool      | ZFS 2.2 or higher         | same as `volume.zfs.delegate`                  | Controls whether to delegate the ZFS dataset and anything underneath it to the container(s) using it. Allows the use of the `zfs` command in the container.
-`zfs.remove_snapshots`      | bool      |                           | same as `volume.zfs.remove_snapshots` or `false` | Remove snapshots as needed
-`zfs.use_refquota`          | bool      |                           | same as `volume.zfs.use_refquota` or `false`   | Use `refquota` instead of `quota` for space
-`zfs.reserve_space`         | bool      |                           | same as `volume.zfs.reserve_space` or `false`  | Use `reservation`/`refreservation` along with `quota`/`refquota`
+| Key                       | Type   | Condition                                                                    | Default                                          | Description                                                      |
+| :---                      | :---   | :---                                                                         | :---                                             | :---                                                             |
+| `block.filesystem`        | string | block-based volume with content type `filesystem` (`zfs.block_mode` enabled) | same as `volume.block.filesystem`                | {{block_filesystem}}                                             |
+| `block.mount_options`     | string | block-based volume with content type `filesystem` (`zfs.block_mode` enabled) | same as `volume.block.mount_options`             | Mount options for block-backed file system volumes               |
+| `initial.gid`             | int    | custom volume with content type `filesystem`                                 | same as `volume.initial.uid` or `0`              | GID of the volume owner in the instance                          |
+| `initial.mode`            | int    | custom volume with content type `filesystem`                                 | same as `volume.initial.mode` or `711`           | Mode  of the volume in the instance                              |
+| `initial.uid`             | int    | custom volume with content type `filesystem`                                 | same as `volume.initial.gid` or `0`              | UID of the volume owner in the instance                          |
+| `security.shared`         | bool   | custom block volume                                                          | same as `volume.security.shared` or `false`      | Enable sharing the volume across multiple instances              |
+| `security.shifted`        | bool   | custom volume                                                                | same as `volume.security.shifted` or `false`     | {{enable_ID_shifting}}                                           |
+| `security.unmapped`       | bool   | custom volume                                                                | same as `volume.security.unmapped` or `false`    | Disable ID mapping for the volume                                |
+| `size`                    | string |                                                                              | same as `volume.size`                            | Size/quota of the storage volume                                 |
+| `snapshots.expiry`        | string | custom volume                                                                | same as `volume.snapshots.expiry`                | {{snapshot_expiry_format}}                                       |
+| `snapshots.expiry.manual` | string | custom volume                                                                | same as `volume.snapshots.expiry.manual`         | {{snapshot_expiry_format}}                                       |
+| `snapshots.pattern`       | string | custom volume                                                                | same as `volume.snapshots.pattern` or `snap%d`   | {{snapshot_pattern_format}} [^*]                                 |
+| `snapshots.schedule`      | string | custom volume                                                                | same as `snapshots.schedule`                     | {{snapshot_schedule_format}}                                     |
+| `zfs.blocksize`           | string |                                                                              | same as `volume.zfs.blocksize`                   | Size of the ZFS block in range from 512 bytes to 16 MiB (must be power of 2) - for block volume, a maximum value of 128 KiB will be used even if a higher value is set |
+| `zfs.block_mode`          | bool   |                                                                              | same as `volume.zfs.block_mode`                  | Whether to use a formatted `zvol` rather than a {spellexception}`dataset` (`zfs.block_mode` can be set only for custom storage volumes; use `volume.zfs.block_mode` to enable ZFS block mode for all storage volumes in the pool, including instance volumes) |
+| `zfs.delegate`            | bool   | ZFS 2.2 or higher                                                            | same as `volume.zfs.delegate`                    | Controls whether to delegate the ZFS dataset and anything underneath it to the container(s) using it. Allows the use of the `zfs` command in the container. |
+| `zfs.remove_snapshots`    | bool   |                                                                              | same as `volume.zfs.remove_snapshots` or `false` | Remove snapshots as needed                                       |
+| `zfs.use_refquota`        | bool   |                                                                              | same as `volume.zfs.use_refquota` or `false`     | Use `refquota` instead of `quota` for space                      |
+| `zfs.reserve_space`       | bool   |                                                                              | same as `volume.zfs.reserve_space` or `false`    | Use `reservation`/`refreservation` along with `quota`/`refquota` |
 
 [^*]: {{snapshot_pattern_detail}}
 
@@ -133,6 +133,6 @@ Key                         | Type      | Condition                 | Default   
 
 To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage bucket
+| Key    | Type   | Condition          | Default               | Description                      |
+| :---   | :---   | :---               | :---                  | :---                             |
+| `size` | string | appropriate driver | same as `volume.size` | Size/quota of the storage bucket |

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -132,25 +132,25 @@ The codes are always 3 digits, with the following ranges:
 
 ### List of current status codes
 
-Code  | Meaning
-:---  | :------
-100   | Operation created
-101   | Started
-102   | Stopped
-103   | Running
-104   | Canceling
-105   | Pending
-106   | Starting
-107   | Stopping
-108   | Aborting
-109   | Freezing
-110   | Frozen
-111   | Thawed
-112   | Error
-113   | Ready
-200   | Success
-400   | Failure
-401   | Canceled
+| Code  | Meaning           |
+| :---  | :---              |
+| 100   | Operation created |
+| 101   | Started           |
+| 102   | Stopped           |
+| 103   | Running           |
+| 104   | Canceling         |
+| 105   | Pending           |
+| 106   | Starting          |
+| 107   | Stopping          |
+| 108   | Aborting          |
+| 109   | Freezing          |
+| 110   | Frozen            |
+| 111   | Thawed            |
+| 112   | Error             |
+| 113   | Ready             |
+| 200   | Success           |
+| 400   | Failure           |
+| 401   | Canceled          |
 
 (rest-api-recursion)=
 ## Recursion


### PR DESCRIPTION
* MD055 Table row doesn't begin/end with pipes
* MD057 Table has missing or invalid header separation (second row)

General alignment of the columns.