### PR TITLE
client/oci: Allow OCI image names with a pinned hash

### DIFF
--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -395,6 +395,13 @@ func (r *ProtocolOCI) runSkopeo(action string, image string, args ...string) (st
 
 // GetImageAlias returns an existing alias as an ImageAliasesEntry struct.
 func (r *ProtocolOCI) GetImageAlias(name string) (*api.ImageAliasesEntry, string, error) {
+	// If image name is "IMAGE:TAG@HASH", drop ":TAG" so that skopeo uses the pinned hash instead.
+	imageWithoutHash, hash, hasHash := strings.Cut(name, "@")
+	if hasHash {
+		imageWithoutTag, _, _ := strings.Cut(imageWithoutHash, ":")
+		name = fmt.Sprintf("%s@%s", imageWithoutTag, hash)
+	}
+
 	// Get the image information from skopeo.
 	stdout, err := r.runSkopeo("inspect", name)
 	if err != nil {


### PR DESCRIPTION
## Summary

Enables specifying OCI images as `IMAGE:TAG@HASH`

## Changes

Previously, attempting to launch an OCI instance with:

```bash
$ incus launch docker:kindest/node:v1.33.0@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2 test
Error: Failed instance creation: Image not found
```

and incus logs printed 

```
Sep 06 17:50:37 zs-builder incusd[671766]: time="2025-09-06T17:50:37Z" level=debug msg="Error getting image alias" name="kindest/node:v1.33.0@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2" stderr="Failed to run: skopeo inspect docker://kindest/node:v1.33.0@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2: exit status 1 (time=\"2025-09-06T17:50:37Z\" level=fatal msg=\"Error parsing image name \\\"docker://kindest/node:v1.33.0@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2\\\": Docker references with both a tag and digest are currently not supported\")" stdout=
```

Update incus client logic so that the tag is ignored if a pinned hash is specified, same as `docker` does in this situation

After this change, the instance is launched:

```
$ incus launch docker:kindest/node:v1.33.0@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2 test
Launching test

$ incus image show 91e9ed777db8
auto_update: true
properties:
  architecture: x86_64
  description: docker.io/kindest/node (OCI)
  id: kindest/node@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2
  type: oci
...
```