### PR TITLE
incusd/instance_patch: Fix description field not respecting PATCH semantics

### DIFF
--- a/cmd/incusd/instance_patch.go
+++ b/cmd/incusd/instance_patch.go
@@ -138,6 +138,12 @@ func instancePatch(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
+	// Check if description was passed
+	_, err = reqRaw.GetString("description")
+	if err != nil {
+		req.Description = c.Description()
+	}
+
 	// Check if ephemeral was passed
 	_, err = reqRaw.GetBool("ephemeral")
 	if err != nil {


### PR DESCRIPTION
* PATCH requests should preserve existing description when the field is omitted, but this wasn't implemented.
* Fix missing description field handling in instance patch endpoint(PATCH `/1.0/instances/{instance}`).