### PR TITLE
incus export. Fail fast if [target] is a directory

### DIFF
--- a/cmd/incus/export.go
+++ b/cmd/incus/export.go
@@ -67,6 +67,18 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	var targetName string
+	if len(args) > 1 {
+		targetName = args[1]
+	} else {
+		targetName = name + ".backup"
+	}
+
+	// Test if target is a directory and fail if so
+	if fi, err := os.Stat(targetName); err == nil && fi.IsDir() {
+		return fmt.Errorf("Target path %q is a directory; please provide a file name", targetName)
+	}
+
 	instanceOnly := c.flagInstanceOnly
 
 	req := api.InstanceBackupsPost{
@@ -127,13 +139,6 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 			_ = op.Wait()
 		}
 	}()
-
-	var targetName string
-	if len(args) > 1 {
-		targetName = args[1]
-	} else {
-		targetName = name + ".backup"
-	}
 
 	var target *os.File
 	if targetName == "-" {


### PR DESCRIPTION
I ran the command 

`incus export INSTANCE /path/to/dir/  --instance-only --optimized-storage`

which then ran the backup 

```
Backing up instance: ###.##MB (###MB/s)
```

and then after much waiting for the backup to complete  ... incus failed with the error

```
Error: open /path/to/dir/: is a directory
```

I would have preferred that it fail immediately instead of doing the backup and then failing for lack of a filename. 

This makes `incus export` fail immediately if [target] is a directory. 

For future use, it might be good to be able to specify [target] as a directory and then autoname the backup files, check for disk space, etc. 