### PR TITLE
Replace map[string]string with ConfigMap for more user friendly handling of bool and numbers

### DIFF
--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -215,7 +215,7 @@ type ClusterMemberPut struct {
 	// Example: {"scheduler.instance": "all"}
 	//
 	// API extension: clustering_config
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// List of cluster groups this member belongs to
 	// Example: ["group1", "group2"]
@@ -308,7 +308,7 @@ type ClusterGroupPut struct {
 	// Example: {"user.mykey": "foo"}
 	//
 	// API extension: clustering_groups_config.
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // Writable converts a full ClusterGroup struct into a ClusterGroupPut struct (filters read-only fields).

--- a/shared/api/config.go
+++ b/shared/api/config.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type ConfigMap map[string]string
+
+// Backwards compatibility tests.
+var (
+	_ map[string]string = ConfigMap{}
+	_ ConfigMap         = map[string]string{}
+)
+
+func (m *ConfigMap) UnmarshalJSON(data []byte) error {
+	var raw map[string]any
+
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return fmt.Errorf("JSON data not valid for ConfigMap: %w", err)
+	}
+
+	return m.fromMapStringAny(raw)
+}
+
+func (m *ConfigMap) UnmarshalYAML(unmarshal func(any) error) error {
+	var raw map[string]any
+	err := unmarshal(&raw)
+	if err != nil {
+		return fmt.Errorf("YAML data not valid for ConfigMap: %w", err)
+	}
+
+	return m.fromMapStringAny(raw)
+}
+
+func (m *ConfigMap) fromMapStringAny(raw map[string]any) error {
+	if raw == nil {
+		*m = nil
+		return nil
+	}
+
+	result := make(ConfigMap, len(raw))
+	for k, v := range raw {
+		switch val := v.(type) {
+		case string:
+			result[k] = val
+
+		case int:
+			result[k] = strconv.FormatInt(int64(val), 10)
+
+		case uint64:
+			result[k] = strconv.FormatUint(val, 10)
+
+		case float64:
+			if val == float64(int64(val)) {
+				result[k] = strconv.FormatInt(int64(val), 10)
+			} else {
+				result[k] = strconv.FormatFloat(val, 'g', -1, 64)
+			}
+
+		case bool:
+			result[k] = strconv.FormatBool(val)
+
+		case nil:
+			result[k] = ""
+
+		default:
+			return fmt.Errorf("type %T is not supported in %T", v, result)
+
+		}
+	}
+
+	*m = result
+
+	return nil
+}

--- a/shared/api/config_test.go
+++ b/shared/api/config_test.go
@@ -1,0 +1,230 @@
+package api_test
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
+	"github.com/lxc/incus/v6/shared/api"
+)
+
+func TestConfigMap_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+
+		assertErr require.ErrorAssertionFunc
+		want      api.ConfigMap
+	}{
+		{
+			name:  "nil",
+			input: nil,
+
+			assertErr: require.NoError,
+			want:      nil,
+		},
+		{
+			name:  "empty",
+			input: map[string]any{},
+
+			assertErr: require.NoError,
+			want:      api.ConfigMap{},
+		},
+		{
+			name: "only string",
+			input: map[string]any{
+				"string":  "string",
+				"int":     "5",
+				"float64": "5.4",
+				"bool":    "true",
+				"empty":   "",
+				"null":    "null",
+			},
+
+			assertErr: require.NoError,
+			want: api.ConfigMap{
+				"string":  "string",
+				"int":     "5",
+				"float64": "5.4",
+				"bool":    "true",
+				"empty":   "",
+				"null":    "null",
+			},
+		},
+		{
+			name: "mixed",
+			input: map[string]any{
+				"string":     "string",
+				"int":        5,
+				"uint":       uint64(math.MaxUint64),
+				"float64":    5.4,
+				"float64max": math.MaxFloat64,
+				"bool":       true,
+				"empty":      "",
+				"null":       nil,
+			},
+
+			assertErr: require.NoError,
+			want: api.ConfigMap{
+				"string":     "string",
+				"int":        "5",
+				"uint":       "1.8446744073709552e+19",
+				"float64":    "5.4",
+				"float64max": "1.7976931348623157e+308",
+				"bool":       "true",
+				"empty":      "",
+				"null":       "",
+			},
+		},
+
+		// errors
+		{
+			name: "error - unsupported type object",
+			input: map[string]any{
+				"invalid": map[string]any{ // invalid
+					"inner": "value",
+				},
+			},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+		{
+			name: "error - unsupported type array",
+			input: map[string]any{
+				"invalid": []string{ // invalid
+					"inner", "value",
+				},
+			},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+
+			var got api.ConfigMap
+
+			err = json.Unmarshal(in, &got)
+			tc.assertErr(t, err)
+
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestConfigMap_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+
+		assertErr require.ErrorAssertionFunc
+		want      api.ConfigMap
+	}{
+		{
+			name:  "nil",
+			input: nil,
+
+			assertErr: require.NoError,
+			want:      api.ConfigMap{},
+		},
+		{
+			name:  "empty",
+			input: map[string]any{},
+
+			assertErr: require.NoError,
+			want:      api.ConfigMap{},
+		},
+		{
+			name: "only string",
+			input: map[string]any{
+				"string":  "string",
+				"int":     "5",
+				"float64": "5.4",
+				"bool":    "true",
+				"empty":   "",
+				"null":    "null",
+			},
+
+			assertErr: require.NoError,
+			want: api.ConfigMap{
+				"string":  "string",
+				"int":     "5",
+				"float64": "5.4",
+				"bool":    "true",
+				"empty":   "",
+				"null":    "null",
+			},
+		},
+		{
+			name: "mixed",
+			input: map[string]any{
+				"string":     "string",
+				"int":        5,
+				"uint":       uint64(math.MaxUint64),
+				"float64":    5.4,
+				"float64max": math.MaxFloat64,
+				"bool":       true,
+				"empty":      "",
+				"null":       nil,
+			},
+
+			assertErr: require.NoError,
+			want: api.ConfigMap{
+				"string":     "string",
+				"int":        "5",
+				"uint":       "18446744073709551615",
+				"float64":    "5.4",
+				"float64max": "1.7976931348623157e+308",
+				"bool":       "true",
+				"empty":      "",
+				"null":       "",
+			},
+		},
+
+		// errors
+		{
+			name: "error - unsupported type object",
+			input: map[string]any{
+				"invalid": map[string]any{ // invalid
+					"inner": "value",
+				},
+			},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+		{
+			name: "error - unsupported type array",
+			input: map[string]any{
+				"invalid": []string{ // invalid
+					"inner", "value",
+				},
+			},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in, err := yaml.Marshal(tc.input)
+			require.NoError(t, err)
+
+			var got api.ConfigMap
+
+			err = yaml.Unmarshal(in, &got)
+			tc.assertErr(t, err)
+
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -114,7 +114,7 @@ type InstancePost struct {
 	// Example: {"security.nesting": "true"}
 	//
 	// API extension: instance_move_config
-	Config map[string]string
+	Config ConfigMap
 
 	// Instance devices.
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}
@@ -160,7 +160,7 @@ type InstancePut struct {
 
 	// Instance configuration (see doc/instances.md)
 	// Example: {"security.nesting": "true"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Instance devices (see doc/instances.md)
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}
@@ -211,7 +211,7 @@ type Instance struct {
 
 	// Expanded configuration (all profiles and local config merged)
 	// Example: {"security.nesting": "true"}
-	ExpandedConfig map[string]string `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
+	ExpandedConfig ConfigMap `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
 
 	// Expanded devices (all profiles and local devices merged)
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}

--- a/shared/api/instance_snapshot.go
+++ b/shared/api/instance_snapshot.go
@@ -72,7 +72,7 @@ type InstanceSnapshot struct {
 
 	// Instance configuration (see doc/instances.md)
 	// Example: {"security.nesting": "true"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Instance creation timestamp
 	// Example: 2021-03-23T20:00:00-04:00
@@ -92,7 +92,7 @@ type InstanceSnapshot struct {
 
 	// Expanded configuration (all profiles and local config merged)
 	// Example: {"security.nesting": "true"}
-	ExpandedConfig map[string]string `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
+	ExpandedConfig ConfigMap `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
 
 	// Expanded devices (all profiles and local devices merged)
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -36,7 +36,7 @@ type NetworkPost struct {
 type NetworkPut struct {
 	// Network configuration map (refer to doc/networks.md)
 	// Example: {"ipv4.address": "10.0.0.1/24", "ipv4.nat": "true", "ipv6.address": "none"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the profile
 	// Example: My new bridge

--- a/shared/api/network_acl.go
+++ b/shared/api/network_acl.go
@@ -123,7 +123,7 @@ type NetworkACLPut struct {
 
 	// ACL configuration map (refer to doc/network-acls.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkACL used for displaying an ACL.

--- a/shared/api/network_address_set.go
+++ b/shared/api/network_address_set.go
@@ -27,7 +27,7 @@ type NetworkAddressSetPut struct {
 
 	// Address set configuration map (refer to doc/network-address-sets.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config,omitempty" yaml:"config,omitempty"`
+	Config ConfigMap `json:"config,omitempty" yaml:"config,omitempty"`
 
 	// Description of the address set
 	// Example: Web servers

--- a/shared/api/network_forward.go
+++ b/shared/api/network_forward.go
@@ -101,7 +101,7 @@ type NetworkForwardPut struct {
 
 	// Forward configuration map (refer to doc/network-forwards.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Port forwards (optional)
 	Ports []NetworkForwardPort `json:"ports" yaml:"ports"`

--- a/shared/api/network_integration.go
+++ b/shared/api/network_integration.go
@@ -29,7 +29,7 @@ type NetworkIntegrationPut struct {
 
 	// Integration configuration map (refer to doc/network-integrations.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkIntegration represents a network integration.

--- a/shared/api/network_load_balancer.go
+++ b/shared/api/network_load_balancer.go
@@ -109,7 +109,7 @@ type NetworkLoadBalancerPut struct {
 
 	// Load balancer configuration map (refer to doc/network-load-balancers.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Backends (optional)
 	Backends []NetworkLoadBalancerBackend `json:"backends" yaml:"backends"`

--- a/shared/api/network_peer.go
+++ b/shared/api/network_peer.go
@@ -45,7 +45,7 @@ type NetworkPeerPut struct {
 
 	// Peer configuration map (refer to doc/network-peers.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkPeer used for displaying a network peering.

--- a/shared/api/network_zone.go
+++ b/shared/api/network_zone.go
@@ -25,7 +25,7 @@ type NetworkZonePut struct {
 
 	// Zone configuration map (refer to doc/network-zones.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkZone represents a network zone (DNS).
@@ -85,7 +85,7 @@ type NetworkZoneRecordPut struct {
 
 	// Advanced configuration for the record
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkZoneRecordEntry represents the fields in a record entry

--- a/shared/api/profile.go
+++ b/shared/api/profile.go
@@ -26,7 +26,7 @@ type ProfilePost struct {
 type ProfilePut struct {
 	// Instance configuration map (refer to doc/instances.md)
 	// Example: {"limits.cpu": "4", "limits.memory": "4GiB"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the profile
 	// Example: Medium size instances

--- a/shared/api/project.go
+++ b/shared/api/project.go
@@ -35,7 +35,7 @@ type ProjectPost struct {
 type ProjectPut struct {
 	// Project configuration map (refer to doc/projects.md)
 	// Example: {"features.profiles": "true", "features.networks": "false"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the project
 	// Example: My new project

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -148,7 +148,7 @@ type ServerStorageDriverInfo struct {
 type ServerPut struct {
 	// Server configuration map (refer to doc/server.md)
 	// Example: {"core.https_address": ":8443"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // ServerUntrusted represents a server configuration for an untrusted client

--- a/shared/api/storage_pool.go
+++ b/shared/api/storage_pool.go
@@ -75,7 +75,7 @@ type StoragePool struct {
 type StoragePoolPut struct {
 	// Storage pool configuration map (refer to doc/storage.md)
 	// Example: {"volume.block.filesystem": "ext4", "volume.size": "50GiB"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the storage pool
 	// Example: Local SSD pool

--- a/shared/api/storage_pool_bucket.go
+++ b/shared/api/storage_pool_bucket.go
@@ -25,7 +25,7 @@ type StorageBucketPut struct {
 	// Example: {"size": "50GiB"}
 	//
 	// API extension: storage_buckets
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the storage bucket
 	// Example: My custom bucket

--- a/shared/api/storage_pool_volume.go
+++ b/shared/api/storage_pool_volume.go
@@ -162,7 +162,7 @@ func (v *StorageVolume) URL(apiVersion string, poolName string) *URL {
 type StorageVolumePut struct {
 	// Storage volume configuration map (refer to doc/storage.md)
 	// Example: {"zfs.remove_snapshots": "true", "size": "50GiB"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the storage volume
 	// Example: My custom volume

--- a/shared/api/storage_pool_volume_snapshot.go
+++ b/shared/api/storage_pool_volume_snapshot.go
@@ -57,7 +57,7 @@ type StorageVolumeSnapshot struct {
 
 	// Storage volume configuration map (refer to doc/storage.md)
 	// Example: {"zfs.remove_snapshots": "true", "size": "50GiB"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// The content type (filesystem or block)
 	// Example: filesystem


### PR DESCRIPTION
If we agree to continue with this approach, the same might be applied to the `map[string]map[string]string` used for `devices`.