### PR TITLE
Replace map[string]string with ConfigMap for more user friendly handling of bool and numbers (with defaults)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,10 @@ linters:
       - linters:
           - staticcheck
         text: "ST1005:"
+      - linters:
+          - godot
+        text: "Comment should end in a period"
+        source: '^// Example:'
     paths:
       - third_party$
       - builtin$

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -270,8 +270,6 @@ definitions:
     ClusterGroup:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Cluster group configuration map
                 example:
                     user.mykey: foo
@@ -312,8 +310,6 @@ definitions:
     ClusterGroupPut:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Cluster group configuration map
                 example:
                     user.mykey: foo
@@ -339,8 +335,6 @@ definitions:
     ClusterGroupsPost:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Cluster group configuration map
                 example:
                     user.mykey: foo
@@ -376,8 +370,6 @@ definitions:
                 type: string
                 x-go-name: Architecture
             config:
-                additionalProperties:
-                    type: string
                 description: Additional configuration information
                 example:
                     scheduler.instance: all
@@ -522,8 +514,6 @@ definitions:
         description: ClusterMemberPut represents the modifiable fields of a cluster member
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Additional configuration information
                 example:
                     scheduler.instance: all
@@ -678,6 +668,15 @@ definitions:
                 type: string
                 x-go-name: ServerName
         title: ClusterPut represents the fields required to bootstrap or join a cluster.
+        type: object
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    ConfigMap:
+        additionalProperties:
+            type: string
+        description: |-
+            ConfigMap type is used to hold incus config. In contrast to plain
+            map[string]string it provides unmarshal methods for JSON and YAML, which
+            gracefully handle numbers and bools.
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
     Event:
@@ -1283,8 +1282,6 @@ definitions:
                 type: array
                 x-go-name: Certificates
             config:
-                additionalProperties:
-                    type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
@@ -1335,8 +1332,6 @@ definitions:
                 example: '"default"'
                 type: string
             config:
-                additionalProperties:
-                    type: string
                 description: Network configuration map (refer to doc/networks.md)
                 example:
                     ipv4.address: 10.0.0.1/24
@@ -1378,8 +1373,6 @@ definitions:
                 example: '"default"'
                 type: string
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration map (refer to doc/instances.md)
                 example:
                     limits.cpu: "4"
@@ -1427,8 +1420,6 @@ definitions:
                 example: '"default"'
                 type: string
             config:
-                additionalProperties:
-                    type: string
                 description: Storage volume configuration map (refer to doc/storage.md)
                 example:
                     size: 50GiB
@@ -1473,8 +1464,6 @@ definitions:
                 type: string
                 x-go-name: Architecture
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration (see doc/instances.md)
                 example:
                     security.nesting: "true"
@@ -1510,8 +1499,6 @@ definitions:
                 type: boolean
                 x-go-name: Ephemeral
             expanded_config:
-                additionalProperties:
-                    type: string
                 description: Expanded configuration (all profiles and local config merged)
                 example:
                     security.nesting: "true"
@@ -1764,8 +1751,6 @@ definitions:
                 type: array
                 x-go-name: Backups
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration (see doc/instances.md)
                 example:
                     security.nesting: "true"
@@ -1801,8 +1786,6 @@ definitions:
                 type: boolean
                 x-go-name: Ephemeral
             expanded_config:
-                additionalProperties:
-                    type: string
                 description: Expanded configuration (all profiles and local config merged)
                 example:
                     security.nesting: "true"
@@ -1886,8 +1869,6 @@ definitions:
     InstancePost:
         properties:
             Config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration file.
                 example:
                     security.nesting: "true"
@@ -1983,8 +1964,6 @@ definitions:
                 type: string
                 x-go-name: Architecture
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration (see doc/instances.md)
                 example:
                     security.nesting: "true"
@@ -2049,8 +2028,6 @@ definitions:
                 type: string
                 x-go-name: Architecture
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration (see doc/instances.md)
                 example:
                     security.nesting: "true"
@@ -2086,8 +2063,6 @@ definitions:
                 type: boolean
                 x-go-name: Ephemeral
             expanded_config:
-                additionalProperties:
-                    type: string
                 description: Expanded configuration (all profiles and local config merged)
                 example:
                     security.nesting: "true"
@@ -2616,8 +2591,6 @@ definitions:
                 type: string
                 x-go-name: Architecture
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration (see doc/instances.md)
                 example:
                     security.nesting: "true"
@@ -2776,8 +2749,6 @@ definitions:
         description: Network represents a network
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Network configuration map (refer to doc/networks.md)
                 example:
                     ipv4.address: 10.0.0.1/24
@@ -2845,8 +2816,6 @@ definitions:
     NetworkACL:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: ACL configuration map (refer to doc/network-acls.md)
                 example:
                     user.mykey: foo
@@ -2906,8 +2875,6 @@ definitions:
     NetworkACLPut:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: ACL configuration map (refer to doc/network-acls.md)
                 example:
                     user.mykey: foo
@@ -2992,8 +2959,6 @@ definitions:
     NetworkACLsPost:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: ACL configuration map (refer to doc/network-acls.md)
                 example:
                     user.mykey: foo
@@ -3037,8 +3002,6 @@ definitions:
                 type: array
                 x-go-name: Addresses
             config:
-                additionalProperties:
-                    type: string
                 description: Address set configuration map (refer to doc/network-address-sets.md)
                 example:
                     user.mykey: foo
@@ -3095,8 +3058,6 @@ definitions:
                 type: array
                 x-go-name: Addresses
             config:
-                additionalProperties:
-                    type: string
                 description: Address set configuration map (refer to doc/network-address-sets.md)
                 example:
                     user.mykey: foo
@@ -3122,8 +3083,6 @@ definitions:
                 type: array
                 x-go-name: Addresses
             config:
-                additionalProperties:
-                    type: string
                 description: Address set configuration map (refer to doc/network-address-sets.md)
                 example:
                     user.mykey: foo
@@ -3173,8 +3132,6 @@ definitions:
     NetworkForward:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Forward configuration map (refer to doc/network-forwards.md)
                 example:
                     user.mykey: foo
@@ -3243,8 +3200,6 @@ definitions:
         description: NetworkForwardPut represents the modifiable fields of a network address forward
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Forward configuration map (refer to doc/network-forwards.md)
                 example:
                     user.mykey: foo
@@ -3267,8 +3222,6 @@ definitions:
         description: NetworkForwardsPost represents the fields of a new network address forward
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Forward configuration map (refer to doc/network-forwards.md)
                 example:
                     user.mykey: foo
@@ -3295,8 +3248,6 @@ definitions:
     NetworkIntegration:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Integration configuration map (refer to doc/network-integrations.md)
                 example:
                     user.mykey: foo
@@ -3344,8 +3295,6 @@ definitions:
         description: NetworkIntegrationPut represents the modifiable fields of a network integration
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Integration configuration map (refer to doc/network-integrations.md)
                 example:
                     user.mykey: foo
@@ -3362,8 +3311,6 @@ definitions:
         description: NetworkIntegrationsPost represents the fields of a new network integration
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Integration configuration map (refer to doc/network-integrations.md)
                 example:
                     user.mykey: foo
@@ -3426,8 +3373,6 @@ definitions:
                 type: array
                 x-go-name: Backends
             config:
-                additionalProperties:
-                    type: string
                 description: Load balancer configuration map (refer to doc/network-load-balancers.md)
                 example:
                     user.mykey: foo
@@ -3520,8 +3465,6 @@ definitions:
                 type: array
                 x-go-name: Backends
             config:
-                additionalProperties:
-                    type: string
                 description: Load balancer configuration map (refer to doc/network-load-balancers.md)
                 example:
                     user.mykey: foo
@@ -3588,8 +3531,6 @@ definitions:
                 type: array
                 x-go-name: Backends
             config:
-                additionalProperties:
-                    type: string
                 description: Load balancer configuration map (refer to doc/network-load-balancers.md)
                 example:
                     user.mykey: foo
@@ -3616,8 +3557,6 @@ definitions:
     NetworkPeer:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Peer configuration map (refer to doc/network-peers.md)
                 example:
                     user.mykey: foo
@@ -3679,8 +3618,6 @@ definitions:
         description: NetworkPeerPut represents the modifiable fields of a network peering
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Peer configuration map (refer to doc/network-peers.md)
                 example:
                     user.mykey: foo
@@ -3697,8 +3634,6 @@ definitions:
         description: NetworkPeersPost represents the fields of a new network peering
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Peer configuration map (refer to doc/network-peers.md)
                 example:
                     user.mykey: foo
@@ -3750,8 +3685,6 @@ definitions:
         description: NetworkPut represents the modifiable fields of a network
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Network configuration map (refer to doc/networks.md)
                 example:
                     ipv4.address: 10.0.0.1/24
@@ -3999,8 +3932,6 @@ definitions:
     NetworkZone:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Zone configuration map (refer to doc/network-zones.md)
                 example:
                     user.mykey: foo
@@ -4038,8 +3969,6 @@ definitions:
         description: NetworkZonePut represents the modifiable fields of a network zone
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Zone configuration map (refer to doc/network-zones.md)
                 example:
                     user.mykey: foo
@@ -4055,8 +3984,6 @@ definitions:
     NetworkZoneRecord:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Advanced configuration for the record
                 example:
                     user.mykey: foo
@@ -4106,8 +4033,6 @@ definitions:
         description: NetworkZoneRecordPut represents the modifiable fields of a network zone record
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Advanced configuration for the record
                 example:
                     user.mykey: foo
@@ -4130,8 +4055,6 @@ definitions:
         description: NetworkZoneRecordsPost represents the fields of a new network zone record
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Advanced configuration for the record
                 example:
                     user.mykey: foo
@@ -4159,8 +4082,6 @@ definitions:
         description: NetworkZonesPost represents the fields of a new network zone
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Zone configuration map (refer to doc/network-zones.md)
                 example:
                     user.mykey: foo
@@ -4182,8 +4103,6 @@ definitions:
         description: NetworksPost represents the fields of a new network
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Network configuration map (refer to doc/networks.md)
                 example:
                     ipv4.address: 10.0.0.1/24
@@ -4295,8 +4214,6 @@ definitions:
         description: Profile represents a profile
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration map (refer to doc/instances.md)
                 example:
                     limits.cpu: "4"
@@ -4362,8 +4279,6 @@ definitions:
         description: ProfilePut represents the modifiable fields of a profile
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration map (refer to doc/instances.md)
                 example:
                     limits.cpu: "4"
@@ -4398,8 +4313,6 @@ definitions:
         description: ProfilesPost represents the fields of a new profile
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Instance configuration map (refer to doc/instances.md)
                 example:
                     limits.cpu: "4"
@@ -4439,8 +4352,6 @@ definitions:
         description: Project represents a project
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Project configuration map (refer to doc/projects.md)
                 example:
                     features.networks: "false"
@@ -4487,8 +4398,6 @@ definitions:
         description: ProjectPut represents the modifiable fields of a project
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Project configuration map (refer to doc/projects.md)
                 example:
                     features.networks: "false"
@@ -4540,8 +4449,6 @@ definitions:
         description: ProjectsPost represents the fields of a new project
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Project configuration map (refer to doc/projects.md)
                 example:
                     features.networks: "false"
@@ -5895,8 +5802,6 @@ definitions:
                 type: string
                 x-go-name: AuthUserName
             config:
-                additionalProperties:
-                    type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
@@ -6061,8 +5966,6 @@ definitions:
         description: ServerPut represents the modifiable fields of a server configuration
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
@@ -6130,8 +6033,6 @@ definitions:
                 type: array
                 x-go-name: AuthMethods
             config:
-                additionalProperties:
-                    type: string
                 description: Server configuration map (refer to doc/server.md)
                 example:
                     core.https_address: :8443
@@ -6154,8 +6055,6 @@ definitions:
         description: StorageBucket represents the fields of a storage pool bucket
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage bucket configuration map
                 example:
                     size: 50GiB
@@ -6329,8 +6228,6 @@ definitions:
         description: StorageBucketPut represents the modifiable fields of a storage pool bucket
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage bucket configuration map
                 example:
                     size: 50GiB
@@ -6347,8 +6244,6 @@ definitions:
         description: StorageBucketsPost represents the fields of a new storage pool bucket
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage bucket configuration map
                 example:
                     size: 50GiB
@@ -6369,8 +6264,6 @@ definitions:
     StoragePool:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage pool configuration map (refer to doc/storage.md)
                 example:
                     volume.block.filesystem: ext4
@@ -6424,8 +6317,6 @@ definitions:
     StoragePoolPut:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage pool configuration map (refer to doc/storage.md)
                 example:
                     volume.block.filesystem: ext4
@@ -6453,8 +6344,6 @@ definitions:
         description: StoragePoolsPost represents the fields of a new storage pool
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage pool configuration map (refer to doc/storage.md)
                 example:
                     volume.block.filesystem: ext4
@@ -6481,8 +6370,6 @@ definitions:
     StorageVolume:
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage volume configuration map (refer to doc/storage.md)
                 example:
                     size: 50GiB
@@ -6677,8 +6564,6 @@ definitions:
         description: StorageVolumePut represents the modifiable fields of a storage volume
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage volume configuration map (refer to doc/storage.md)
                 example:
                     size: 50GiB
@@ -6701,8 +6586,6 @@ definitions:
         description: StorageVolumeSnapshot represents a storage volume snapshot
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage volume configuration map (refer to doc/storage.md)
                 example:
                     size: 50GiB
@@ -6883,8 +6766,6 @@ definitions:
         description: StorageVolumesPost represents the fields of a new storage pool volume
         properties:
             config:
-                additionalProperties:
-                    type: string
                 description: Storage volume configuration map (refer to doc/storage.md)
                 example:
                     size: 50GiB

--- a/internal/filter/value.go
+++ b/internal/filter/value.go
@@ -3,6 +3,8 @@ package filter
 import (
 	"reflect"
 	"strings"
+
+	"github.com/lxc/incus/v6/shared/api"
 )
 
 // DotPrefixMatch finds the shortest unambiguous identifier for a given namespace.
@@ -35,7 +37,14 @@ func ValueOf(obj any, field string) any {
 	if value.Kind() == reflect.Map {
 		switch reflect.TypeOf(obj).Elem().Kind() {
 		case reflect.String:
-			m := value.Interface().(map[string]string)
+			m := map[string]string{}
+			switch mm := value.Interface().(type) {
+			case map[string]string:
+				m = mm
+			case api.ConfigMap:
+				m = mm
+			}
+
 			for k, v := range m {
 				if DotPrefixMatch(field, k) {
 					return v

--- a/internal/server/db/storage_pools_test.go
+++ b/internal/server/db/storage_pools_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lxc/incus/v6/internal/server/db"
 	"github.com/lxc/incus/v6/internal/server/response"
+	"github.com/lxc/incus/v6/shared/api"
 )
 
 func init() {
@@ -186,7 +187,7 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 		return nil
 	})
 
-	config := map[string]string{"k": "v"}
+	config := api.ConfigMap{"k": "v"}
 	var volumeID int64
 
 	_ = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -215,7 +215,7 @@ type ClusterMemberPut struct {
 	// Example: {"scheduler.instance": "all"}
 	//
 	// API extension: clustering_config
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// List of cluster groups this member belongs to
 	// Example: ["group1", "group2"]
@@ -308,7 +308,7 @@ type ClusterGroupPut struct {
 	// Example: {"user.mykey": "foo"}
 	//
 	// API extension: clustering_groups_config.
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // Writable converts a full ClusterGroup struct into a ClusterGroupPut struct (filters read-only fields).

--- a/shared/api/config.go
+++ b/shared/api/config.go
@@ -47,11 +47,14 @@ func (m *ConfigMap) UnmarshalYAML(unmarshal func(any) error) error {
 
 func (m *ConfigMap) fromMapStringAny(raw map[string]any) error {
 	if raw == nil {
-		*m = nil
 		return nil
 	}
 
-	result := make(ConfigMap, len(raw))
+	result := *m
+	if result == nil {
+		result = make(ConfigMap, len(raw))
+	}
+
 	for k, v := range raw {
 		switch val := v.(type) {
 		case string:

--- a/shared/api/config.go
+++ b/shared/api/config.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// ConfigMap type is used to hold incus config. In contrast to plain
+// map[string]string it provides unmarshal methods for JSON and YAML, which
+// gracefully handle numbers and bools.
+//
+// swagger:model
+// swagger:type object
+//
+// Example: {"user.mykey": "foo"}
+type ConfigMap map[string]string
+
+// Backwards compatibility tests.
+var (
+	_ map[string]string = ConfigMap{}
+	_ ConfigMap         = map[string]string{}
+)
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (m *ConfigMap) UnmarshalJSON(data []byte) error {
+	var raw map[string]any
+
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return fmt.Errorf("JSON data not valid for ConfigMap: %w", err)
+	}
+
+	return m.fromMapStringAny(raw)
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler interface.
+func (m *ConfigMap) UnmarshalYAML(unmarshal func(any) error) error {
+	var raw map[string]any
+	err := unmarshal(&raw)
+	if err != nil {
+		return fmt.Errorf("YAML data not valid for ConfigMap: %w", err)
+	}
+
+	return m.fromMapStringAny(raw)
+}
+
+func (m *ConfigMap) fromMapStringAny(raw map[string]any) error {
+	if raw == nil {
+		*m = nil
+		return nil
+	}
+
+	result := make(ConfigMap, len(raw))
+	for k, v := range raw {
+		switch val := v.(type) {
+		case string:
+			result[k] = val
+
+		case int:
+			result[k] = strconv.FormatInt(int64(val), 10)
+
+		case uint64:
+			result[k] = strconv.FormatUint(val, 10)
+
+		case float64:
+			if val == float64(int64(val)) {
+				result[k] = strconv.FormatInt(int64(val), 10)
+			} else {
+				result[k] = strconv.FormatFloat(val, 'g', -1, 64)
+			}
+
+		case bool:
+			result[k] = strconv.FormatBool(val)
+
+		case nil:
+			result[k] = ""
+
+		default:
+			return fmt.Errorf("type %T is not supported in %T", v, m)
+		}
+	}
+
+	*m = result
+
+	return nil
+}

--- a/shared/api/config_test.go
+++ b/shared/api/config_test.go
@@ -1,0 +1,230 @@
+package api_test
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
+	"github.com/lxc/incus/v6/shared/api"
+)
+
+func TestConfigMap_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+
+		assertErr require.ErrorAssertionFunc
+		want      api.ConfigMap
+	}{
+		{
+			name:  "nil",
+			input: nil,
+
+			assertErr: require.NoError,
+			want:      nil,
+		},
+		{
+			name:  "empty",
+			input: map[string]any{},
+
+			assertErr: require.NoError,
+			want:      api.ConfigMap{},
+		},
+		{
+			name: "only string",
+			input: map[string]any{
+				"string":  "string",
+				"int":     "5",
+				"float64": "5.4",
+				"bool":    "true",
+				"empty":   "",
+				"null":    "null",
+			},
+
+			assertErr: require.NoError,
+			want: api.ConfigMap{
+				"string":  "string",
+				"int":     "5",
+				"float64": "5.4",
+				"bool":    "true",
+				"empty":   "",
+				"null":    "null",
+			},
+		},
+		{
+			name: "mixed",
+			input: map[string]any{
+				"string":     "string",
+				"int":        5,
+				"uint":       uint64(math.MaxUint64),
+				"float64":    5.4,
+				"float64max": math.MaxFloat64,
+				"bool":       true,
+				"empty":      "",
+				"null":       nil,
+			},
+
+			assertErr: require.NoError,
+			want: api.ConfigMap{
+				"string":     "string",
+				"int":        "5",
+				"uint":       "1.8446744073709552e+19",
+				"float64":    "5.4",
+				"float64max": "1.7976931348623157e+308",
+				"bool":       "true",
+				"empty":      "",
+				"null":       "",
+			},
+		},
+
+		// errors
+		{
+			name: "error - unsupported type object",
+			input: map[string]any{
+				"invalid": map[string]any{ // invalid
+					"inner": "value",
+				},
+			},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+		{
+			name: "error - unsupported type array",
+			input: map[string]any{
+				"invalid": []string{ // invalid
+					"inner", "value",
+				},
+			},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+
+			var got api.ConfigMap
+
+			err = json.Unmarshal(in, &got)
+			tc.assertErr(t, err)
+
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestConfigMap_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+
+		assertErr require.ErrorAssertionFunc
+		want      api.ConfigMap
+	}{
+		{
+			name:  "nil",
+			input: nil,
+
+			assertErr: require.NoError,
+			want:      api.ConfigMap{},
+		},
+		{
+			name:  "empty",
+			input: map[string]any{},
+
+			assertErr: require.NoError,
+			want:      api.ConfigMap{},
+		},
+		{
+			name: "only string",
+			input: map[string]any{
+				"string":  "string",
+				"int":     "5",
+				"float64": "5.4",
+				"bool":    "true",
+				"empty":   "",
+				"null":    "null",
+			},
+
+			assertErr: require.NoError,
+			want: api.ConfigMap{
+				"string":  "string",
+				"int":     "5",
+				"float64": "5.4",
+				"bool":    "true",
+				"empty":   "",
+				"null":    "null",
+			},
+		},
+		{
+			name: "mixed",
+			input: map[string]any{
+				"string":     "string",
+				"int":        5,
+				"uint":       uint64(math.MaxUint64),
+				"float64":    5.4,
+				"float64max": math.MaxFloat64,
+				"bool":       true,
+				"empty":      "",
+				"null":       nil,
+			},
+
+			assertErr: require.NoError,
+			want: api.ConfigMap{
+				"string":     "string",
+				"int":        "5",
+				"uint":       "18446744073709551615",
+				"float64":    "5.4",
+				"float64max": "1.7976931348623157e+308",
+				"bool":       "true",
+				"empty":      "",
+				"null":       "",
+			},
+		},
+
+		// errors
+		{
+			name: "error - unsupported type object",
+			input: map[string]any{
+				"invalid": map[string]any{ // invalid
+					"inner": "value",
+				},
+			},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+		{
+			name: "error - unsupported type array",
+			input: map[string]any{
+				"invalid": []string{ // invalid
+					"inner", "value",
+				},
+			},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in, err := yaml.Marshal(tc.input)
+			require.NoError(t, err)
+
+			var got api.ConfigMap
+
+			err = yaml.Unmarshal(in, &got)
+			tc.assertErr(t, err)
+
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -114,7 +114,7 @@ type InstancePost struct {
 	// Example: {"security.nesting": "true"}
 	//
 	// API extension: instance_move_config
-	Config map[string]string
+	Config ConfigMap
 
 	// Instance devices.
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}
@@ -160,7 +160,7 @@ type InstancePut struct {
 
 	// Instance configuration (see doc/instances.md)
 	// Example: {"security.nesting": "true"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Instance devices (see doc/instances.md)
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}
@@ -211,7 +211,7 @@ type Instance struct {
 
 	// Expanded configuration (all profiles and local config merged)
 	// Example: {"security.nesting": "true"}
-	ExpandedConfig map[string]string `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
+	ExpandedConfig ConfigMap `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
 
 	// Expanded devices (all profiles and local devices merged)
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}

--- a/shared/api/instance_snapshot.go
+++ b/shared/api/instance_snapshot.go
@@ -72,7 +72,7 @@ type InstanceSnapshot struct {
 
 	// Instance configuration (see doc/instances.md)
 	// Example: {"security.nesting": "true"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Instance creation timestamp
 	// Example: 2021-03-23T20:00:00-04:00
@@ -92,7 +92,7 @@ type InstanceSnapshot struct {
 
 	// Expanded configuration (all profiles and local config merged)
 	// Example: {"security.nesting": "true"}
-	ExpandedConfig map[string]string `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
+	ExpandedConfig ConfigMap `json:"expanded_config,omitempty" yaml:"expanded_config,omitempty"`
 
 	// Expanded devices (all profiles and local devices merged)
 	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -36,7 +36,7 @@ type NetworkPost struct {
 type NetworkPut struct {
 	// Network configuration map (refer to doc/networks.md)
 	// Example: {"ipv4.address": "10.0.0.1/24", "ipv4.nat": "true", "ipv6.address": "none"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the profile
 	// Example: My new bridge

--- a/shared/api/network_acl.go
+++ b/shared/api/network_acl.go
@@ -123,7 +123,7 @@ type NetworkACLPut struct {
 
 	// ACL configuration map (refer to doc/network-acls.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkACL used for displaying an ACL.

--- a/shared/api/network_address_set.go
+++ b/shared/api/network_address_set.go
@@ -27,7 +27,7 @@ type NetworkAddressSetPut struct {
 
 	// Address set configuration map (refer to doc/network-address-sets.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config,omitempty" yaml:"config,omitempty"`
+	Config ConfigMap `json:"config,omitempty" yaml:"config,omitempty"`
 
 	// Description of the address set
 	// Example: Web servers

--- a/shared/api/network_forward.go
+++ b/shared/api/network_forward.go
@@ -101,7 +101,7 @@ type NetworkForwardPut struct {
 
 	// Forward configuration map (refer to doc/network-forwards.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Port forwards (optional)
 	Ports []NetworkForwardPort `json:"ports" yaml:"ports"`

--- a/shared/api/network_integration.go
+++ b/shared/api/network_integration.go
@@ -29,7 +29,7 @@ type NetworkIntegrationPut struct {
 
 	// Integration configuration map (refer to doc/network-integrations.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkIntegration represents a network integration.

--- a/shared/api/network_load_balancer.go
+++ b/shared/api/network_load_balancer.go
@@ -109,7 +109,7 @@ type NetworkLoadBalancerPut struct {
 
 	// Load balancer configuration map (refer to doc/network-load-balancers.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Backends (optional)
 	Backends []NetworkLoadBalancerBackend `json:"backends" yaml:"backends"`

--- a/shared/api/network_peer.go
+++ b/shared/api/network_peer.go
@@ -45,7 +45,7 @@ type NetworkPeerPut struct {
 
 	// Peer configuration map (refer to doc/network-peers.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkPeer used for displaying a network peering.

--- a/shared/api/network_zone.go
+++ b/shared/api/network_zone.go
@@ -25,7 +25,7 @@ type NetworkZonePut struct {
 
 	// Zone configuration map (refer to doc/network-zones.md)
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkZone represents a network zone (DNS).
@@ -85,7 +85,7 @@ type NetworkZoneRecordPut struct {
 
 	// Advanced configuration for the record
 	// Example: {"user.mykey": "foo"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // NetworkZoneRecordEntry represents the fields in a record entry

--- a/shared/api/profile.go
+++ b/shared/api/profile.go
@@ -26,7 +26,7 @@ type ProfilePost struct {
 type ProfilePut struct {
 	// Instance configuration map (refer to doc/instances.md)
 	// Example: {"limits.cpu": "4", "limits.memory": "4GiB"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the profile
 	// Example: Medium size instances

--- a/shared/api/project.go
+++ b/shared/api/project.go
@@ -35,7 +35,7 @@ type ProjectPost struct {
 type ProjectPut struct {
 	// Project configuration map (refer to doc/projects.md)
 	// Example: {"features.profiles": "true", "features.networks": "false"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the project
 	// Example: My new project

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -148,7 +148,7 @@ type ServerStorageDriverInfo struct {
 type ServerPut struct {
 	// Server configuration map (refer to doc/server.md)
 	// Example: {"core.https_address": ":8443"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 }
 
 // ServerUntrusted represents a server configuration for an untrusted client

--- a/shared/api/storage_pool.go
+++ b/shared/api/storage_pool.go
@@ -75,7 +75,7 @@ type StoragePool struct {
 type StoragePoolPut struct {
 	// Storage pool configuration map (refer to doc/storage.md)
 	// Example: {"volume.block.filesystem": "ext4", "volume.size": "50GiB"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the storage pool
 	// Example: Local SSD pool

--- a/shared/api/storage_pool_bucket.go
+++ b/shared/api/storage_pool_bucket.go
@@ -25,7 +25,7 @@ type StorageBucketPut struct {
 	// Example: {"size": "50GiB"}
 	//
 	// API extension: storage_buckets
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the storage bucket
 	// Example: My custom bucket

--- a/shared/api/storage_pool_volume.go
+++ b/shared/api/storage_pool_volume.go
@@ -162,7 +162,7 @@ func (v *StorageVolume) URL(apiVersion string, poolName string) *URL {
 type StorageVolumePut struct {
 	// Storage volume configuration map (refer to doc/storage.md)
 	// Example: {"zfs.remove_snapshots": "true", "size": "50GiB"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// Description of the storage volume
 	// Example: My custom volume

--- a/shared/api/storage_pool_volume_snapshot.go
+++ b/shared/api/storage_pool_volume_snapshot.go
@@ -57,7 +57,7 @@ type StorageVolumeSnapshot struct {
 
 	// Storage volume configuration map (refer to doc/storage.md)
 	// Example: {"zfs.remove_snapshots": "true", "size": "50GiB"}
-	Config map[string]string `json:"config" yaml:"config"`
+	Config ConfigMap `json:"config" yaml:"config"`
 
 	// The content type (filesystem or block)
 	// Example: filesystem


### PR DESCRIPTION
If we agree to continue with this approach, the same might be applied to the `map[string]map[string]string` used for devices.

Continuation of #2940