### PR TITLE
shared/idmap: Skip xattrs on EINVAL

### DIFF
--- a/shared/idmap/internal_linux.go
+++ b/shared/idmap/internal_linux.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/pkg/xattr"
 	"golang.org/x/sys/unix"
+
+	"github.com/lxc/incus/v6/shared/logger"
 )
 
 // The functions below are verbatim copies of the functions found in the internal package.
@@ -33,6 +35,11 @@ func getAllXattr(path string) (map[string]string, error) {
 	for _, xattrName := range xattrNames {
 		value, err := xattr.LGet(path, xattrName)
 		if err != nil {
+			if errors.Is(err, unix.EINVAL) {
+				logger.Warn("Skipping unreadable xattr during shift", logger.Ctx{"path": path, "xattr": xattrName})
+				continue
+			}
+
 			return nil, fmt.Errorf("Failed getting %q extended attribute from %q: %w", xattrName, path, err)
 		}
 


### PR DESCRIPTION
When parsing extended attributes, we may be getting EINVAL when run on ZFS.

This appears to be when dealing with ZFS namespaced xattrs and despite being real root with all capabilities, there appears to be no way to read or even clear those attributes.

So instead of crashing mid-shift, let's just log them and move on.


Sponsored-by: https://webdock.io