### PR TITLE
Rework cluster internal certificate validation

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -53,6 +53,9 @@ type ConnectionArgs struct {
 	// Controls whether a client verifies the server's certificate chain and host name.
 	InsecureSkipVerify bool
 
+	// Controls whether to perform an exact certificate match (will ignore expiry).
+	IdenticalCertificate bool
+
 	// Cookie jar
 	CookieJar http.CookieJar
 
@@ -289,7 +292,7 @@ func ConnectSimpleStreams(uri string, args *ConnectionArgs) (ImageServer, error)
 	}
 
 	// Setup the HTTP client
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy, args.TransportWrapper)
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.IdenticalCertificate, args.Proxy, args.TransportWrapper)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +355,7 @@ func ConnectOCI(uri string, args *ConnectionArgs) (ImageServer, error) {
 	}
 
 	// Setup the HTTP client
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy, args.TransportWrapper)
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.IdenticalCertificate, args.Proxy, args.TransportWrapper)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +399,7 @@ func httpsIncus(ctx context.Context, requestURL string, args *ConnectionArgs) (I
 	}
 
 	// Setup the HTTP client
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy, args.TransportWrapper)
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.IdenticalCertificate, args.Proxy, args.TransportWrapper)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/cluster/connect.go
+++ b/internal/server/cluster/connect.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -295,6 +294,7 @@ func UpdateTrust(serverCert *localtls.CertInfo, serverName string, targetAddress
 
 // HasConnectivity probes the member with the given address for connectivity.
 func HasConnectivity(networkCert *localtls.CertInfo, serverCert *localtls.CertInfo, address string, apiCheck bool) bool {
+	// Check if the main server endpoint is functional.
 	if apiCheck {
 		c, err := Connect(address, networkCert, serverCert, nil, true)
 		if err != nil {
@@ -305,14 +305,19 @@ func HasConnectivity(networkCert *localtls.CertInfo, serverCert *localtls.CertIn
 		return err == nil
 	}
 
-	config, err := tlsClientConfig(networkCert, serverCert)
+	// Get the transport.
+	transport, cleanup, err := tlsTransport(networkCert, serverCert)
 	if err != nil {
 		return false
 	}
 
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	var conn net.Conn
-	dialer := &net.Dialer{Timeout: time.Second}
-	conn, err = tls.DialWithDialer(dialer, "tcp", address, config)
+	conn, err = transport.DialTLSContext(ctx, "tcp", address)
 	if err == nil {
 		_ = conn.Close()
 		return true

--- a/internal/server/cluster/connect.go
+++ b/internal/server/cluster/connect.go
@@ -44,12 +44,13 @@ func Connect(address string, networkCert *localtls.CertInfo, serverCert *localtl
 	}
 
 	args := &incus.ConnectionArgs{
-		TLSServerCert: string(networkCert.PublicKey()),
-		TLSClientCert: string(serverCert.PublicKey()),
-		TLSClientKey:  string(serverCert.PrivateKey()),
-		SkipGetServer: true,
-		SkipGetEvents: true,
-		UserAgent:     version.UserAgent,
+		IdenticalCertificate: true,
+		TLSServerCert:        string(networkCert.PublicKey()),
+		TLSClientCert:        string(serverCert.PublicKey()),
+		TLSClientKey:         string(serverCert.PrivateKey()),
+		SkipGetServer:        true,
+		SkipGetEvents:        true,
+		UserAgent:            version.UserAgent,
 	}
 
 	if notify {

--- a/internal/server/cluster/heartbeat.go
+++ b/internal/server/cluster/heartbeat.go
@@ -527,15 +527,16 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 func HeartbeatNode(taskCtx context.Context, address string, networkCert *localtls.CertInfo, serverCert *localtls.CertInfo, heartbeatData *APIHeartbeat) error {
 	logger.Debug("Sending heartbeat request", logger.Ctx{"address": address})
 
-	config, err := tlsClientConfig(networkCert, serverCert)
+	timeout := 2 * time.Second
+	url := fmt.Sprintf("https://%s%s", address, databaseEndpoint)
+
+	transport, cleanup, err := tlsTransport(networkCert, serverCert)
 	if err != nil {
 		return err
 	}
 
-	timeout := 2 * time.Second
-	url := fmt.Sprintf("https://%s%s", address, databaseEndpoint)
-	transport, cleanup := tlsTransport(config)
 	defer cleanup()
+
 	client := &http.Client{
 		Transport: transport,
 		Timeout:   timeout,


### PR DESCRIPTION
Occasionally a server will have its certificate expire.
This is particularly common when using ACME/Let's Encrypt and somehow failing renewal.

In that scenario, the cluster should keep operating mostly normally until the user updates the certificate with a newer one.

Prior to this, the cluster would fail all internal connections and would completely deadlock should servers get restarted, more importantly, the API used to update the certificate would also fail in that scenario.

Closes #2498 