### PR TITLE
'dns.mode' implementation for the OVN driver

### DIFF
--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -2379,7 +2379,7 @@ func (o *NB) CleanupLogicalSwitchPort(ctx context.Context, portName OVNSwitchPor
 
 	// Remove DNS records.
 	if dnsUUID != "" {
-		deleteOps, err := o.logicalSwitchPortDeleteDNSOperations(ctx, switchName, dnsUUID, false)
+		deleteOps, err := o.logicalSwitchPortDeleteDNSOperations(ctx, switchName, dnsUUID, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
1. Adds support for `dns.mode` to OVN network
2. Fixes issue with managing DNS records when instance stops/restart.
    `CleanupLogicalSwitchPort` runs when an instance stops and detaches the DNS record
from the switch. This also deletes the record from the Southbound DB. The
Northbound DB entry remains, causing issues on the next start because it is not
replicated to the Southbound DB. This change ensures the entry is removed from
the Northbound DB as well.

Closes: #2479