### PR TITLE
Change snapshot deletion command to `storage volume snapshot delete`

### DIFF
--- a/doc/howto/storage_backup_volume.md
+++ b/doc/howto/storage_backup_volume.md
@@ -73,7 +73,7 @@ To edit a snapshot (for example, to add a description or change the expiry date)
 
 To delete a snapshot, use the following command:
 
-    incus storage volume delete <pool_name> <volume_name>/<snapshot_name>
+    incus storage volume snapshot delete <pool_name> <volume_name> <snapshot_name>
 
 ### Schedule snapshots of a custom storage volume
 


### PR DESCRIPTION
The current command doesn't work for me on incus 6.16.  The error message is `Error: Invalid storage volume "<volume name>/<snapshot name>"`.  It seems like the command should be `storage volume snapshot delete` rather than `storage volume delete` for a snapshot.

Please correct me if I'm wrong.