### PR TITLE
Use 'Patch' method for PATCH requests

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -673,7 +673,12 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 				return fmt.Errorf("Failed to load node config: %w", err)
 			}
 
-			_, err = newNodeConfig.Replace(nodeValues)
+			if patch {
+				_, err = newNodeConfig.Patch(nodeValues)
+			} else {
+				_, err = newNodeConfig.Replace(nodeValues)
+			}
+
 			if err != nil {
 				return fmt.Errorf("Failed updating node config: %w", err)
 			}
@@ -734,7 +739,12 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 				return fmt.Errorf("Failed to load cluster config: %w", err)
 			}
 
-			_, err = newClusterConfig.Replace(req.Config)
+			if patch {
+				_, err = newClusterConfig.Patch(req.Config)
+			} else {
+				_, err = newClusterConfig.Replace(req.Config)
+			}
+
 			if err != nil {
 				return fmt.Errorf("Failed updating cluster config: %w", err)
 			}


### PR DESCRIPTION
For PATCH requests use the `Patch` method. `Replace` method expects all keys and missing keys are filled with default values.

In this specific case, on a revert attempt (when we get an error for any reason) the node-specific keys/values are lost, since the `Replace` method overwrites missing keys/values with defaults.