### PR TITLE
incusd/device/disk: Remove dead code

### DIFF
--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -1773,20 +1773,6 @@ func (d *disk) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 					Limits:  diskLimits,
 				})
 			}
-
-			oldAttached := util.IsTrueOrEmpty(oldDevices[d.name]["attached"])
-			newAttached := util.IsTrueOrEmpty(expandedDevices[d.name]["attached"])
-			if !oldAttached && newAttached {
-				runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-					DevName:  d.name,
-					Attached: true,
-				})
-			} else if oldAttached && !newAttached {
-				runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-					DevName:  d.name,
-					Attached: false,
-				})
-			}
 		}
 
 		err := d.inst.DeviceEventHandler(&runConf)


### PR DESCRIPTION
This commit removes dead code introduced in eef7275. Because `attached` is never declared in `UpdatableFields`, `Update` could never be able to catch changes for this key.