### PR TITLE
incusd/auth: log the error if getting the oidc provider fails

### DIFF
--- a/internal/server/auth/oidc/oidc.go
+++ b/internal/server/auth/oidc/oidc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
 
+	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/util"
 )
 
@@ -159,6 +160,8 @@ func (o *Verifier) Login(w http.ResponseWriter, r *http.Request) {
 	// Get the provider.
 	provider, err := o.getProvider(r)
 	if err != nil {
+		logger.Error("Failed to get OIDC provider", logger.Ctx{"err": err})
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -223,6 +226,8 @@ func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
 	// Get the provider.
 	provider, err := o.getProvider(r)
 	if err != nil {
+		logger.Error("Failed to get OIDC provider", logger.Ctx{"err": err})
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
At the moment if getting the oidc provider fails (e.g. because it is not reachable) the `/oidc/login` endpoint just returns an empty 200 response and ignores the error. This change logs the error and returns a 500 response with the error message.