### PR TITLE
Cleanup disk attached logic

### DIFF
--- a/internal/server/device/config/device_runconfig.go
+++ b/internal/server/device/config/device_runconfig.go
@@ -31,7 +31,6 @@ type MountEntryItem struct {
 	OwnerShift string      // Ownership shifting mode, use constants MountOwnerShiftNone, MountOwnerShiftStatic or MountOwnerShiftDynamic.
 	Limits     *DiskLimits // Disk limits.
 	Size       int64       // Expected disk size in bytes.
-	Attached   bool        // Whether the disk is attached
 }
 
 // RootFSEntryItem represents the root filesystem options for an Instance.

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -1222,6 +1222,11 @@ func (d *disk) setBus(entry *deviceConfig.MountEntryItem) error {
 
 // startVM starts the disk device for a virtual machine instance.
 func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
+	// Ignore detached disks.
+	if !util.IsTrueOrEmpty(d.config["attached"]) {
+		return nil, nil
+	}
+
 	runConf := deviceConfig.RunConfig{}
 
 	reverter := revert.New()
@@ -1239,9 +1244,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 	if d.config["wwn"] != "" {
 		opts = append(opts, fmt.Sprintf("wwn=%s", d.config["wwn"]))
 	}
-
-	// Setup the attached status.
-	attached := util.IsTrueOrEmpty(d.config["attached"])
 
 	// Add I/O limits if set.
 	var diskLimits *deviceConfig.DiskLimits
@@ -1306,7 +1308,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 			DevName:  d.name,
 			FSType:   "iso9660",
 			Opts:     opts,
-			Attached: attached,
 		}
 
 		err = d.setBus(&mount)
@@ -1341,7 +1342,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 			DevName:  d.name,
 			FSType:   "iso9660",
 			Opts:     opts,
-			Attached: attached,
 		}
 
 		err = d.setBus(&mount)
@@ -1364,7 +1364,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				DevName:  d.name,
 				Opts:     opts,
 				Limits:   diskLimits,
-				Attached: attached,
 			}
 
 			err := d.setBus(&mount)
@@ -1380,7 +1379,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				DevName:  d.name,
 				Opts:     opts,
 				Limits:   diskLimits,
-				Attached: attached,
 			}
 
 			err := d.setBus(&mount)
@@ -1443,7 +1441,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						DevName:  d.name,
 						Opts:     opts,
 						Limits:   diskLimits,
-						Attached: attached,
 					}
 
 					err = d.setBus(&mount)

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -711,11 +711,7 @@ func (m *Monitor) AddObject(args map[string]any) error {
 }
 
 // AddBlockDevice adds a block device.
-func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]any, attached bool, usb bool) error {
-	if !attached {
-		return nil
-	}
-
+func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]any, usb bool) error {
 	reverter := revert.New()
 	defer reverter.Fail()
 


### PR DESCRIPTION
When I initially worked on #2282, I made a few assumptions that ended up invalid and a few design choices that changed mid-PR. This PR removes all handling of the attached status (except during ejection) by the QEMU driver, to handle it as early as possible, like in #2530. #2531 turned out to be just the tip of the iceberg, sorry for the oversight.