### PR TITLE
incusd/console: Close remote connection on console disconnect

### DIFF
--- a/cmd/incusd/instance_console.go
+++ b/cmd/incusd/instance_console.go
@@ -186,6 +186,7 @@ func (s *consoleWs) connectVGA(r *http.Request, w http.ResponseWriter) error {
 
 			<-readDone
 			l.Debug("Finished mirroring console to websocket")
+			_ = conn.Close()
 			<-writeDone
 		}()
 
@@ -309,6 +310,7 @@ func (s *consoleWs) doConsole() error {
 
 		<-readDone
 		l.Debug("Finished mirroring console to websocket")
+		_ = conn.Close()
 		<-writeDone
 		close(mirrorDoneCh)
 	}()


### PR DESCRIPTION
This will cause the remote client to get disconnected immediately rather than on the next websocket message exchange.


Sponsored-by: https://webdock.io