### PR TITLE
Add incus bug command

### DIFF
--- a/.codespell-ignore
+++ b/.codespell-ignore
@@ -4,3 +4,4 @@ ECT
 inport
 renderD
 requestor
+upToDate

--- a/.github/ISSUE_TEMPLATE/bug-reports.yml
+++ b/.github/ISSUE_TEMPLATE/bug-reports.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: File a bug report.
+description: File a bug report. You can also use the command incus bug report.
 type: bug
 body:
 - type: checkboxes
@@ -21,7 +21,7 @@ body:
 - type: textarea
   attributes:
     label: Incus system details
-    description: Output of `incus info`.
+    description: Output of `incus bug info`.
     render: yaml
   validations:
     required: true

--- a/cmd/incus/admin_os.go
+++ b/cmd/incus/admin_os.go
@@ -487,7 +487,7 @@ func (c *cmdAdminOSServiceEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(string(data)))
+	content, err := textEditor("", []byte(string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -510,7 +510,7 @@ func (c *cmdAdminOSServiceEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}
@@ -778,7 +778,7 @@ func (c *cmdAdminOSSystemEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(string(data)))
+	content, err := textEditor("", []byte(string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -801,7 +801,7 @@ func (c *cmdAdminOSSystemEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/bug.go
+++ b/cmd/incus/bug.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	incus "github.com/lxc/incus/v6/client"
+	cli "github.com/lxc/incus/v6/internal/cmd"
+	"github.com/lxc/incus/v6/internal/i18n"
+)
+
+type cmdBug struct {
+	global *cmdGlobal
+}
+
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
+func (c *cmdBug) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("bug")
+	cmd.Short = i18n.G("Prepare bug reports")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Prepare bug reports`))
+
+	// Info
+	bugInfoCmd := cmdBugInfo{global: c.global}
+	cmd.AddCommand(bugInfoCmd.Command())
+
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
+	return cmd
+}
+
+// Info.
+type cmdBugInfo struct {
+	global *cmdGlobal
+
+	flagTarget string
+}
+
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
+func (c *cmdBugInfo) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("info", i18n.G("[<remote>:]"))
+	cmd.Short = i18n.G("Show system details to include in bug reports")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Show system details to include in bug reports`))
+
+	cmd.RunE = c.Run
+	cmd.Flags().StringVar(&c.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpRemotes(toComplete, false)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return cmd
+}
+
+// Run runs the actual command logic.
+func (c *cmdBugInfo) Run(cmd *cobra.Command, args []string) error {
+	conf := c.global.conf
+
+	// Quick checks.
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
+	if exit {
+		return err
+	}
+
+	var remote string
+	if len(args) == 1 {
+		remote, _, err = conf.ParseRemote(args[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		remote, _, err = conf.ParseRemote("")
+		if err != nil {
+			return err
+		}
+	}
+
+	d, err := conf.GetInstanceServer(remote)
+	if err != nil {
+		return err
+	}
+
+	return c.remoteInfo(d)
+}
+
+func (c *cmdBugInfo) remoteInfo(d incus.InstanceServer) error {
+	// Targeting
+	if c.flagTarget != "" {
+		if !d.IsClustered() {
+			return errors.New(i18n.G("To use --target, the destination remote must be a cluster"))
+		}
+
+		d = d.UseTarget(c.flagTarget)
+	}
+
+	serverStatus, _, err := d.GetServer()
+	if err != nil {
+		return err
+	}
+
+	unfiltered, err := yaml.Marshal(&serverStatus)
+	if err != nil {
+		return err
+	}
+
+	var data map[string]any
+	err = yaml.Unmarshal(unfiltered, &data)
+	if err != nil {
+		return err
+	}
+
+	filteredFields := map[string][]string{
+		"api_extensions": nil,
+		"environment":    {"addresses", "certificate", "certificate_fingerprint", "server_name", "server_pid"},
+	}
+
+	for field, subfields := range filteredFields {
+		if len(subfields) == 0 {
+			delete(data, field)
+		} else {
+			subdata, ok := data[field].(map[any]any)
+			if ok {
+				for _, subfield := range subfields {
+					delete(subdata, subfield)
+				}
+			}
+		}
+	}
+
+	filtered, err := yaml.Marshal(&data)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s", filtered)
+	return nil
+}

--- a/cmd/incus/bug.go
+++ b/cmd/incus/bug.go
@@ -1,15 +1,21 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/cli/oauth"
+	"github.com/google/go-github/v75/github"
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 type cmdBug struct {
@@ -27,6 +33,10 @@ func (c *cmdBug) Command() *cobra.Command {
 	// Info
 	bugInfoCmd := cmdBugInfo{global: c.global}
 	cmd.AddCommand(bugInfoCmd.Command())
+
+	// Report
+	bugReportCmd := cmdBugReport{global: c.global}
+	cmd.AddCommand(bugReportCmd.Command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -91,33 +101,39 @@ func (c *cmdBugInfo) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return c.remoteInfo(d)
+	serverInfo, err := cmdBugRemoteServerInfo(d, c.flagTarget)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(serverInfo)
+	return nil
 }
 
-func (c *cmdBugInfo) remoteInfo(d incus.InstanceServer) error {
+func cmdBugRemoteServerInfo(d incus.InstanceServer, target string) (string, error) {
 	// Targeting
-	if c.flagTarget != "" {
+	if target != "" {
 		if !d.IsClustered() {
-			return errors.New(i18n.G("To use --target, the destination remote must be a cluster"))
+			return "", errors.New(i18n.G("To use --target, the destination remote must be a cluster"))
 		}
 
-		d = d.UseTarget(c.flagTarget)
+		d = d.UseTarget(target)
 	}
 
 	serverStatus, _, err := d.GetServer()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	unfiltered, err := yaml.Marshal(&serverStatus)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var data map[string]any
 	err = yaml.Unmarshal(unfiltered, &data)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	filteredFields := map[string][]string{
@@ -140,9 +156,250 @@ func (c *cmdBugInfo) remoteInfo(d incus.InstanceServer) error {
 
 	filtered, err := yaml.Marshal(&data)
 	if err != nil {
+		return "", err
+	}
+
+	return string(filtered), nil
+}
+
+// Report.
+type cmdBugReport struct {
+	global *cmdGlobal
+
+	flagTarget string
+}
+
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
+func (c *cmdBugReport) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("report", i18n.G("[<remote>:][<instance>]"))
+	cmd.Short = i18n.G("Report a bug")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Report a bug`))
+	cmd.Example = cli.FormatSection("", i18n.G(
+		`incus bug report [<remote>:]<instance>
+    To report an instance-related bug.
+
+incus bug report [<remote>:]
+    To report a server-related bug.`))
+
+	cmd.RunE = c.Run
+	cmd.Flags().StringVar(&c.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpInstances(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return cmd
+}
+
+// Run runs the actual command logic.
+func (c *cmdBugReport) Run(cmd *cobra.Command, args []string) error {
+	conf := c.global.conf
+
+	// Quick checks.
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
+	if exit {
 		return err
 	}
 
-	fmt.Printf("%s", filtered)
+	var remote string
+	var cName string
+	if len(args) == 1 {
+		remote, cName, err = conf.ParseRemote(args[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		remote, cName, err = conf.ParseRemote("")
+		if err != nil {
+			return err
+		}
+	}
+
+	if cName != "" && c.flagTarget != "" {
+		return errors.New(i18n.G("--target cannot be used with instances"))
+	}
+
+	d, err := conf.GetInstanceServer(remote)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(i18n.G("This command is dedicated to reporting bugs found in Incus. For all support requests and other questions, please ask on our forum, https://discuss.linuxcontainers.org.") + "\n\n")
+
+	issueTitle, err := c.global.asker.AskString(i18n.G("Choose an issue title:")+" ", "", nil)
+	if err != nil {
+		return err
+	}
+
+	existingIssue, err := c.global.asker.AskBool(i18n.G("Is there an existing issue for this?")+" (yes/no) [default=no]: ", "no")
+	if err != nil {
+		return err
+	}
+
+	if existingIssue {
+		fmt.Println("Please only report new bugs.")
+		return nil
+	}
+
+	upToDate, err := c.global.asker.AskBool(i18n.G("Is this happening on an up to date version of Incus?")+" (yes/no) [default=yes]: ", "yes")
+	if err != nil {
+		return err
+	}
+
+	if !upToDate {
+		fmt.Println("Please update your Incus installation to a supported version.")
+		return nil
+	}
+
+	systemDetails, err := cmdBugRemoteServerInfo(d, c.flagTarget)
+	if err != nil {
+		return err
+	}
+
+	instanceDetails := "_No response_"
+	instanceLog := "_No response_"
+	if cName != "" {
+		rawInstanceDetails, err := cmdConfigShowInstance(d, cName, false)
+		if err != nil {
+			return err
+		}
+
+		instanceDetails = "```yaml\n" + rawInstanceDetails + "```"
+
+		rawInstanceLog, err := cmdInfoInstance(d, cName, true)
+		if err != nil {
+			return err
+		}
+
+		instanceLog = "```\n" + rawInstanceLog + "```"
+	}
+
+	currentBehavior, err := c.markdownEditor(i18n.G("What is the current behavior?"), i18n.G("a concise description of what you're experiencing"))
+	if err != nil {
+		return err
+	}
+
+	expectedBehavior, err := c.markdownEditor(i18n.G("What is the expected behavior?"), i18n.G("a concise description of what you expected to happen"))
+	if err != nil {
+		return err
+	}
+
+	reproducer, err := c.markdownEditor(i18n.G("How to reproduce this bug?"), i18n.G("step by step instructions to reproduce the behavior"))
+	if err != nil {
+		return err
+	}
+
+	review, err := c.global.asker.AskBool(i18n.G("We will now submit your issue on GitHub. This is your last chance to review it (wording, secret leakage...) before it is published online. Do you want to review it?")+" (yes/no) [default=yes]: ", "yes")
+	if err != nil {
+		return err
+	}
+
+	issueBody := c.formatIssue(systemDetails, instanceDetails, instanceLog, currentBehavior, expectedBehavior, reproducer)
+	if review {
+		issueBytes, err := textEditor("", []byte(issueBody), "md")
+		if err != nil {
+			return err
+		}
+
+		issueBody = string(issueBytes)
+	}
+
+	host, err := oauth.NewGitHubHost("https://github.com")
+	if err != nil {
+		return err
+	}
+
+	flow := &oauth.Flow{
+		Host:     host,
+		ClientID: "Ov23liSZjBXJ5xjoFjW6",
+		Scopes:   []string{"public_repo"},
+		DisplayCode: func(code string, url string) error {
+			fmt.Printf("Use the following code at %s: %s\n", url, code)
+			return nil
+		},
+		BrowseURL: func(url string) error {
+			_ = util.OpenBrowser(url)
+			return nil
+		},
+	}
+
+	token, err := flow.DeviceFlow()
+	if err != nil {
+		return err
+	}
+
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token.Token})
+	client := oauth2.NewClient(context.Background(), tokenSource)
+	gh := github.NewClient(client)
+
+	issue, _, _ := gh.Issues.Create(context.Background(), "bensmrs", "testrepo", &github.IssueRequest{Title: &issueTitle, Body: &issueBody})
+	url := issue.GetHTMLURL()
+	fmt.Println("Your issue has been created at " + url)
+	_ = util.OpenBrowser(url)
+
 	return nil
+}
+
+// markdownEditor opens a text editor to input Markdown text.
+func (c *cmdBugReport) markdownEditor(question string, description string) (string, error) {
+	data, err := textEditor("", []byte(fmt.Sprintf(i18n.G("### %s\n*Pleuse write %s below the following dashes. You can use Markdown formatting.*")+"\n\n---\n\n\n", question, description)), "md")
+	if err != nil {
+		return "_No response_", err
+	}
+
+	parts := strings.SplitN(string(data), "---", 2)
+	if len(parts) < 2 {
+		return "_No response_", nil
+	}
+
+	answer := strings.TrimSpace(parts[1])
+	if answer == "" {
+		return "_No response_", nil
+	}
+
+	return answer, nil
+}
+
+// formatIssue formats the GitHub issue.
+func (c *cmdBugReport) formatIssue(systemDetails string, instanceDetails string, instanceLog string, currentBehavior string, expectedBehavior string, reproducer string) string {
+	return fmt.Sprintf("*This issue was generated with `incus bug report`.*"+`
+
+### Is there an existing issue for this?
+
+- [x] There is no existing issue for this bug
+
+### Is this happening on an up to date version of Incus?
+
+- [x] This is happening on a supported version of Incus
+
+### Incus system details
+
+`+"```"+`yaml
+%s`+"```"+`
+
+### Instance details
+
+%s
+
+### Instance log
+
+%s
+
+### Current behavior
+
+%s
+
+### Expected behavior
+
+%s
+
+### Steps to reproduce
+
+%s`, systemDetails, instanceDetails, instanceLog, currentBehavior, expectedBehavior, reproducer)
 }

--- a/cmd/incus/cluster.go
+++ b/cmd/incus/cluster.go
@@ -982,7 +982,7 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -1005,7 +1005,7 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/cluster_group.go
+++ b/cmd/incus/cluster_group.go
@@ -404,7 +404,7 @@ func (c *cmdClusterGroupEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -428,7 +428,7 @@ func (c *cmdClusterGroupEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/config.go
+++ b/cmd/incus/config.go
@@ -791,7 +791,7 @@ func (c *cmdConfigShow) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	// Show configuration
-	var data []byte
+	var data string
 
 	if resource.name == "" {
 		// Quick check.
@@ -815,58 +815,69 @@ func (c *cmdConfigShow) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		brief := server.Writable()
-		data, err = yaml.Marshal(&brief)
+		dataBytes, err := yaml.Marshal(&brief)
 		if err != nil {
 			return err
 		}
+
+		data = string(dataBytes)
 	} else {
 		// Quick checks.
 		if c.config.flagTarget != "" {
 			return errors.New(i18n.G("--target cannot be used with instances"))
 		}
 
-		// Instance or snapshot config
-		var brief any
-
-		if instance.IsSnapshot(resource.name) {
-			// Snapshot
-			fields := strings.Split(resource.name, instance.SnapshotDelimiter)
-
-			snap, _, err := resource.server.GetInstanceSnapshot(fields[0], fields[1])
-			if err != nil {
-				return err
-			}
-
-			brief = snap
-			if c.flagExpanded {
-				brief.(*api.InstanceSnapshot).Config = snap.ExpandedConfig
-				brief.(*api.InstanceSnapshot).Devices = snap.ExpandedDevices
-			}
-		} else {
-			// Instance
-			inst, _, err := resource.server.GetInstance(resource.name)
-			if err != nil {
-				return err
-			}
-
-			writable := inst.Writable()
-			brief = &writable
-
-			if c.flagExpanded {
-				brief.(*api.InstancePut).Config = inst.ExpandedConfig
-				brief.(*api.InstancePut).Devices = inst.ExpandedDevices
-			}
-		}
-
-		data, err = yaml.Marshal(&brief)
+		data, err = cmdConfigShowInstance(resource.server, resource.name, c.flagExpanded)
 		if err != nil {
 			return err
 		}
 	}
 
-	fmt.Printf("%s", data)
+	fmt.Print(data)
 
 	return nil
+}
+
+// cmdConfigShowInstance returns the given instance or snapshot configuration.
+func cmdConfigShowInstance(d incus.InstanceServer, name string, expanded bool) (string, error) {
+	var brief any
+
+	if instance.IsSnapshot(name) {
+		// Snapshot
+		fields := strings.Split(name, instance.SnapshotDelimiter)
+
+		snap, _, err := d.GetInstanceSnapshot(fields[0], fields[1])
+		if err != nil {
+			return "", err
+		}
+
+		brief = snap
+		if expanded {
+			brief.(*api.InstanceSnapshot).Config = snap.ExpandedConfig
+			brief.(*api.InstanceSnapshot).Devices = snap.ExpandedDevices
+		}
+	} else {
+		// Instance
+		inst, _, err := d.GetInstance(name)
+		if err != nil {
+			return "", err
+		}
+
+		writable := inst.Writable()
+		brief = &writable
+
+		if expanded {
+			brief.(*api.InstancePut).Config = inst.ExpandedConfig
+			brief.(*api.InstancePut).Devices = inst.ExpandedDevices
+		}
+	}
+
+	data, err := yaml.Marshal(&brief)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
 }
 
 // Unset.

--- a/cmd/incus/config.go
+++ b/cmd/incus/config.go
@@ -243,7 +243,7 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Spawn the editor
-		content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+		content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 		if err != nil {
 			return err
 		}
@@ -283,7 +283,7 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 					return err
 				}
 
-				content, err = textEditor("", content)
+				content, err = textEditor("", content, "yaml")
 				if err != nil {
 					return err
 				}
@@ -335,7 +335,7 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", data)
+	content, err := textEditor("", data, "yaml")
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/config_metadata.go
+++ b/cmd/incus/config_metadata.go
@@ -141,7 +141,7 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(origContent)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(origContent)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/config_template.go
+++ b/cmd/incus/config_template.go
@@ -249,7 +249,7 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err = textEditor("", content)
+	content, err = textEditor("", content, "yaml")
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -346,7 +346,7 @@ func (c *cmdConfigTrustEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -369,7 +369,7 @@ func (c *cmdConfigTrustEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -429,7 +429,7 @@ func (c *cmdFileEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	_, err = textEditor(fname, []byte{})
+	_, err = textEditor(fname, []byte{}, "yaml")
 	if err != nil {
 		return err
 	}

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -456,7 +456,7 @@ func (c *cmdImageEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -479,7 +479,7 @@ func (c *cmdImageEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/main.go
+++ b/cmd/incus/main.go
@@ -147,6 +147,10 @@ Custom commands can be defined through aliases, use "incus alias" to control tho
 	adminCmd := cmdAdmin{global: &globalCmd}
 	app.AddCommand(adminCmd.Command())
 
+	// bug sub-command
+	bugCmd := cmdBug{global: &globalCmd}
+	app.AddCommand(bugCmd.Command())
+
 	// cluster sub-command
 	clusterCmd := cmdCluster{global: &globalCmd}
 	app.AddCommand(clusterCmd.Command())

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -815,7 +815,7 @@ func (c *cmdNetworkEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -838,7 +838,7 @@ func (c *cmdNetworkEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -726,7 +726,7 @@ func (c *cmdNetworkACLEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor.
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -749,7 +749,7 @@ func (c *cmdNetworkACLEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/network_address_set.go
+++ b/cmd/incus/network_address_set.go
@@ -544,7 +544,7 @@ func (c *cmdNetworkAddressSetEdit) Run(cmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -565,7 +565,7 @@ func (c *cmdNetworkAddressSetEdit) Run(cmd *cobra.Command, args []string) error 
 				return err2
 			}
 
-			content, err2 = textEditor("", content)
+			content, err2 = textEditor("", content, "yaml")
 			if err2 != nil {
 				return err2
 			}

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -798,7 +798,7 @@ func (c *cmdNetworkForwardEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor.
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -822,7 +822,7 @@ func (c *cmdNetworkForwardEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/network_integration.go
+++ b/cmd/incus/network_integration.go
@@ -297,7 +297,7 @@ func (c *cmdNetworkIntegrationEdit) Run(cmd *cobra.Command, args []string) error
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (c *cmdNetworkIntegrationEdit) Run(cmd *cobra.Command, args []string) error
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -778,7 +778,7 @@ func (c *cmdNetworkLoadBalancerEdit) Run(cmd *cobra.Command, args []string) erro
 	}
 
 	// Spawn the editor.
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -802,7 +802,7 @@ func (c *cmdNetworkLoadBalancerEdit) Run(cmd *cobra.Command, args []string) erro
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/network_peer.go
+++ b/cmd/incus/network_peer.go
@@ -814,7 +814,7 @@ func (c *cmdNetworkPeerEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor.
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -837,7 +837,7 @@ func (c *cmdNetworkPeerEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -720,7 +720,7 @@ func (c *cmdNetworkZoneEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor.
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -743,7 +743,7 @@ func (c *cmdNetworkZoneEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}
@@ -1443,7 +1443,7 @@ func (c *cmdNetworkZoneRecordEdit) Run(cmd *cobra.Command, args []string) error 
 	}
 
 	// Spawn the editor.
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -1466,7 +1466,7 @@ func (c *cmdNetworkZoneRecordEdit) Run(cmd *cobra.Command, args []string) error 
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/profile.go
+++ b/cmd/incus/profile.go
@@ -606,7 +606,7 @@ func (c *cmdProfileEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -629,7 +629,7 @@ func (c *cmdProfileEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/project.go
+++ b/cmd/incus/project.go
@@ -402,7 +402,7 @@ func (c *cmdProjectEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -425,7 +425,7 @@ func (c *cmdProjectEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/storage.go
+++ b/cmd/incus/storage.go
@@ -368,7 +368,7 @@ func (c *cmdStorageEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func (c *cmdStorageEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -361,7 +361,7 @@ func (c *cmdStorageBucketEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor.
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (c *cmdStorageBucketEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}
@@ -1365,7 +1365,7 @@ func (c *cmdStorageBucketKeyEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor.
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -1388,7 +1388,7 @@ func (c *cmdStorageBucketKeyEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -1128,7 +1128,7 @@ func (c *cmdStorageVolumeEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)))
+	content, err := textEditor("", []byte(c.helpTemplate()+"\n\n"+string(data)), "yaml")
 	if err != nil {
 		return err
 	}
@@ -1152,7 +1152,7 @@ func (c *cmdStorageVolumeEdit) Run(cmd *cobra.Command, args []string) error {
 					return err
 				}
 
-				content, err = textEditor("", content)
+				content, err = textEditor("", content, "yaml")
 				if err != nil {
 					return err
 				}
@@ -1184,7 +1184,7 @@ func (c *cmdStorageVolumeEdit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			content, err = textEditor("", content)
+			content, err = textEditor("", content, "yaml")
 			if err != nil {
 				return err
 			}

--- a/cmd/incus/utils.go
+++ b/cmd/incus/utils.go
@@ -500,8 +500,8 @@ func getImgInfo(d incus.InstanceServer, conf *config.Config, imgRemote string, i
 	return imgRemoteServer, imgInfo, nil
 }
 
-// Spawn the editor with a temporary YAML file for editing configs.
-func textEditor(inPath string, inContent []byte) ([]byte, error) {
+// Spawn the editor with a temporary file for editing configs.
+func textEditor(inPath string, inContent []byte, format string) ([]byte, error) {
 	var f *os.File
 	var err error
 	var path string
@@ -554,7 +554,7 @@ func textEditor(inPath string, inContent []byte) ([]byte, error) {
 			return []byte{}, err
 		}
 
-		path = fmt.Sprintf("%s.yaml", f.Name())
+		path = fmt.Sprintf("%s.%s", f.Name(), format)
 		err = os.Rename(f.Name(), path)
 		if err != nil {
 			return []byte{}, err

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,9 @@ require (
 	github.com/cenkalti/hub v1.0.2 // indirect
 	github.com/cenkalti/rpc2 v1.0.4 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cli/browser v1.0.0 // indirect
+	github.com/cli/oauth v1.2.0 // indirect
+	github.com/cli/safeexec v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -91,6 +94,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/google/go-github/v75 v75.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/renameio v1.0.1 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,12 @@ github.com/checkpoint-restore/go-criu/v6 v6.3.0/go.mod h1:rrRTN/uSwY2X+BPRl/gkul
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cli/browser v1.0.0 h1:RIleZgXrhdiCVgFBSjtWwkLPUCWyhhhN5k5HGSBt1js=
+github.com/cli/browser v1.0.0/go.mod h1:IEWkHYbLjkhtjwwWlwTHW2lGxeS5gezEQBMLTwDHf5Q=
+github.com/cli/oauth v1.2.0 h1:9Bb7nWsgi92Xy5Ifa0oKfW6D1+hNAsO6OWSCx7FJdKA=
+github.com/cli/oauth v1.2.0/go.mod h1:qd/FX8ZBD6n1sVNQO3aIdRxeu5LGw9WhKnYhIIoC2A4=
+github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
+github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -216,6 +222,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v75 v75.0.0 h1:k7q8Bvg+W5KxRl9Tjq16a9XEgVY1pwuiG5sIL7435Ic=
+github.com/google/go-github/v75 v75.0.0/go.mod h1:H3LUJEA1TCrzuUqtdAQniBNwuKiQIqdGKgBo1/M/uqI=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2025-08-02 15:02+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -18,17 +18,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.13-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  Gehäuse:"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  Firmware:"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  Mainboard:"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 #, fuzzy
@@ -619,7 +627,7 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
@@ -644,7 +652,7 @@ msgstr "%s %q im Pool %q im Projekt %q (beinhaltet %d Snapshots)"
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
@@ -668,17 +676,17 @@ msgstr "'%s' ist kein unterstützter Dateityp"
 msgid "(none)"
 msgstr "(kein Wert)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Level %d (Typ: %s): %s"
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
@@ -735,8 +743,8 @@ msgstr "--refresh kann nur mit Instanzen verwendet werden"
 msgid "--target can only be used with clusters"
 msgstr "--target kann nur mit Clustern verwendet werden"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr "--target kann nicht mit Instanzen verwendet werden"
 
@@ -1011,12 +1019,12 @@ msgstr "IP-Adresse unter der der Server erreichbar sein soll (Standard: keine)"
 msgid "Address to bind to (not including port)"
 msgstr "IP-Adresse unter der der Server erreichbar sein soll (ohne Port)"
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Adresse: %s"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr "Adresse: %v"
@@ -1079,13 +1087,13 @@ msgstr "Alle Server Adressen sind nicht erreichbar"
 msgid "Alternative certificate name"
 msgstr "Alternativer Zertifikatsbezeichnung"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "Architektur: %v"
@@ -1169,7 +1177,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr "Authentifizierungstyp '%s' wird nicht vom Server unterstützt"
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "Automatische Aushandlung: %v"
@@ -1192,7 +1200,7 @@ msgstr "Automatischer Modus (nicht-interaktiv)"
 msgid "Available projects:"
 msgstr "Verfügbare Projekte:"
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "Durchschnitt: %.2f %.2f %.2f"
@@ -1229,7 +1237,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Backup erfolgreich exportiert!"
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr "Sicherungen:"
 
@@ -1282,7 +1290,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr "Sowohl --all als auch ein Instanzname angegeben"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
@@ -1296,16 +1304,16 @@ msgstr "Netzwerk-Brücke:"
 msgid "Bucket description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Bus Adresse: %v"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1334,19 +1342,19 @@ msgstr "Prozessorauslastung (%s):"
 msgid "CPU USAGE"
 msgstr "CPU NUTZUNG"
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "CPU Nutzung (in Sekunden)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "Prozessorauslastung:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr "CPUs:"
 
@@ -1359,7 +1367,7 @@ msgstr "ERSTELLT AM"
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA Version: %v"
@@ -1369,7 +1377,7 @@ msgstr "CUDA Version: %v"
 msgid "Cached: %s"
 msgstr "Zwischengespeichert: %s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr "Zwischenspeicher:"
 
@@ -1489,12 +1497,12 @@ msgstr "Kann --volume-only nicht setzen, wenn ein Snapshot kopiert wird"
 msgid "Cannot set key: %s"
 msgstr "Kann Schlüssel nicht setzen: %s"
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr "Karte: %d:"
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1542,6 +1550,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1610,16 +1622,17 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1773,7 +1786,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1861,12 +1874,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 #, fuzzy
 msgid "Cores:"
 msgstr "Fehler: %v\n"
@@ -2063,7 +2076,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -2084,7 +2097,7 @@ msgstr "Erstelle %s"
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -2118,7 +2131,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -2132,7 +2145,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Erstellt: %s"
@@ -2295,6 +2308,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2311,7 +2325,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2337,7 +2351,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2451,7 +2465,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -2480,7 +2494,7 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2504,7 +2518,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Profil %s erstellt\n"
@@ -2537,7 +2551,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2572,20 +2586,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr "Festplatte %d:"
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "Festplattennutzung:"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr "Festplatte:"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr "Festplatten:"
 
@@ -2673,7 +2687,7 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr ""
@@ -2682,7 +2696,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2975,12 +2989,12 @@ msgstr "Fehler beim Löschen des Parameters: %v"
 msgid "Error updating template file: %s"
 msgstr "Fehler beim Aktualisieren der Template Datei: %s"
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, fuzzy, c-format
 msgid "Error: %v\n"
 msgstr "Fehler: %v\n"
@@ -3109,7 +3123,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 #, fuzzy
 msgid "Expires at"
@@ -3225,7 +3239,7 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr "ZUERST BEOBACHTET"
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3576,7 +3590,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed validation request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3730,18 +3744,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3750,11 +3764,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3996,17 +4010,21 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 #, fuzzy
 msgid "Hostname"
 msgstr "Name"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -4034,12 +4052,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -4052,7 +4070,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -4061,7 +4079,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -4105,7 +4123,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4255,7 +4273,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -4263,7 +4281,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr ""
 
@@ -4426,7 +4444,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -4478,7 +4496,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid type %q"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -4495,7 +4521,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -4527,7 +4553,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
@@ -4551,12 +4577,12 @@ msgstr "Erstelle %s"
 msgid "Launching the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architektur: %s\n"
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -5463,11 +5489,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5476,7 +5502,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -5519,7 +5545,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -5529,7 +5555,7 @@ msgstr "Profil %s erstellt\n"
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -5571,7 +5597,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5843,12 +5869,12 @@ msgstr "Veröffentliche Abbild"
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5878,19 +5904,19 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -6150,12 +6176,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -6280,11 +6306,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -6295,26 +6321,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -6379,13 +6405,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -6535,7 +6561,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -6630,7 +6656,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6649,11 +6675,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 #, fuzzy
 msgid "OS Version"
 msgstr "Fingerabdruck: %s\n"
@@ -6704,7 +6730,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Operating System:"
 msgstr "Profil %s gelöscht\n"
@@ -6714,7 +6740,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6726,17 +6752,17 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 #, fuzzy
 msgid "PCI device:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 #, fuzzy
 msgid "PCI devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6749,7 +6775,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6786,19 +6812,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -6867,17 +6893,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6933,7 +6963,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -6943,22 +6973,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -7138,7 +7168,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -7233,7 +7263,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -7420,9 +7450,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -7433,7 +7467,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -7541,7 +7575,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -7554,7 +7588,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -7629,12 +7663,12 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr ""
@@ -7643,7 +7677,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Erstellt: %s"
@@ -8109,7 +8143,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
@@ -8119,7 +8153,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance snapshot configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -8247,6 +8281,10 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -8259,17 +8297,17 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -8312,7 +8350,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Erstellt: %s"
@@ -8330,11 +8368,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -8363,7 +8401,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Erstellt: %s"
@@ -8377,7 +8415,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -8387,11 +8425,11 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -8519,21 +8557,21 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Successfully updated cluster certificates"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -8549,7 +8587,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -8574,7 +8612,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8845,7 +8883,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8868,7 +8906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8876,6 +8914,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8895,7 +8940,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8921,16 +8966,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8939,13 +8984,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, fuzzy, c-format
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
@@ -8994,7 +9039,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -9013,8 +9058,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -9036,12 +9081,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 #, fuzzy
 msgid "USB device:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "USB devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -9058,7 +9103,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -9154,7 +9199,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -9327,11 +9372,11 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -9390,8 +9435,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9410,7 +9455,7 @@ msgstr "Profil %s erstellt\n"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -9427,28 +9472,28 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -9457,12 +9502,12 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Fehler: %v\n"
@@ -9480,7 +9525,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -9515,6 +9560,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -9530,6 +9582,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -9690,7 +9750,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -11015,7 +11075,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -11024,7 +11084,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -11056,6 +11116,14 @@ msgstr ""
 "\n"
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
+msgstr ""
 
 #: cmd/incus/info.go:646
 #, fuzzy
@@ -11129,6 +11197,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -11287,7 +11364,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -11868,6 +11945,10 @@ msgstr "sshfs wurde gestoppt"
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs mounted %q auf %q"
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
+msgstr ""
 
 #: cmd/incus/storage.go:573
 msgid "total space"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2025-05-18 17:02+0000\n"
 "Last-Translator: Jorge Teixeira <hey@teixe.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/incus/cli/es/>\n"
@@ -18,17 +18,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  Chasis:"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  Firmware:"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  Placa base:"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 #, fuzzy
@@ -617,7 +625,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -642,7 +650,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
@@ -666,17 +674,17 @@ msgstr "%s no es un tipo de archivo soportado."
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partición %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Puerto %d (%s)"
@@ -731,8 +739,8 @@ msgstr ""
 msgid "--target can only be used with clusters"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -977,12 +985,12 @@ msgstr ""
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Address: %v"
 msgstr "Expira: %s"
@@ -1043,13 +1051,13 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
@@ -1119,7 +1127,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1141,7 +1149,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1179,7 +1187,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr ""
 
@@ -1231,7 +1239,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Creado: %s"
@@ -1245,16 +1253,16 @@ msgstr ""
 msgid "Bucket description"
 msgstr "Descripción"
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1283,19 +1291,19 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr ""
 
@@ -1307,7 +1315,7 @@ msgstr "CREADO"
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versión de CUDA: %v"
@@ -1317,7 +1325,7 @@ msgstr "Versión de CUDA: %v"
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 #, fuzzy
 msgid "Caches:"
 msgstr "Cacheado: %s"
@@ -1431,12 +1439,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Cacheado: %s"
@@ -1480,6 +1488,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1549,16 +1561,17 @@ msgstr "Perfil %s eliminado de %s"
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1703,7 +1716,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1789,12 +1802,12 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 #, fuzzy
 msgid "Cores:"
 msgstr "Expira: %s"
@@ -1979,7 +1992,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -2000,7 +2013,7 @@ msgstr "Creando %s"
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -2034,7 +2047,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -2048,7 +2061,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Auto actualización: %s"
@@ -2208,6 +2221,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2224,7 +2238,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2250,7 +2264,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2364,7 +2378,7 @@ msgstr ""
 msgid "Description"
 msgstr "Descripción"
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
@@ -2392,7 +2406,7 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Dispositivo: %s"
@@ -2412,7 +2426,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Expira: %s"
@@ -2445,7 +2459,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
@@ -2475,20 +2489,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr "Disco:"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr "Discos:"
 
@@ -2576,12 +2590,12 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2859,12 +2873,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, fuzzy, c-format
 msgid "Error: %v\n"
 msgstr "Error: %v\n"
@@ -2943,7 +2957,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 #, fuzzy
 msgid "Expires at"
@@ -3052,7 +3066,7 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3403,7 +3417,7 @@ msgstr "Acepta certificado"
 msgid "Failed validation request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3554,18 +3568,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3574,11 +3588,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3811,17 +3825,21 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 #, fuzzy
 msgid "Hostname"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3849,12 +3867,12 @@ msgstr "Copiando la imagen: %s"
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3867,7 +3885,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3876,7 +3894,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3920,7 +3938,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4068,7 +4086,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -4076,7 +4094,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
@@ -4238,7 +4256,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4289,7 +4307,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Cacheado: %s"
@@ -4302,7 +4328,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -4334,7 +4360,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
@@ -4358,12 +4384,12 @@ msgstr "Creando %s"
 msgid "Launching the instance"
 msgstr "Creando el contenedor"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Arquitectura: %s"
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -5266,11 +5292,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5279,7 +5305,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr "Registro:"
 
@@ -5320,7 +5346,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -5330,7 +5356,7 @@ msgstr "Expira: %s"
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
@@ -5368,7 +5394,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5620,12 +5646,12 @@ msgstr ""
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
@@ -5655,19 +5681,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5925,12 +5951,12 @@ msgstr "%s no es un directorio"
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -6050,11 +6076,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -6065,26 +6091,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -6145,13 +6171,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -6300,7 +6326,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -6391,7 +6417,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6410,11 +6436,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 #, fuzzy
 msgid "OS Version"
 msgstr "Versión de CUDA: %v"
@@ -6465,7 +6491,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6474,7 +6500,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6486,16 +6512,16 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid "PCI devices:"
 msgstr ""
 
@@ -6507,7 +6533,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6544,19 +6570,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -6623,17 +6649,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6689,7 +6719,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -6699,22 +6729,22 @@ msgstr "Procesos: %d"
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6889,7 +6919,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -6983,7 +7013,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -7161,9 +7191,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -7174,7 +7208,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -7280,7 +7314,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -7293,7 +7327,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -7368,17 +7402,17 @@ msgstr "Creado: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Creado: %s"
@@ -7822,7 +7856,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7831,7 +7865,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -7953,6 +7987,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -7965,16 +8003,16 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -8016,7 +8054,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
@@ -8034,11 +8072,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -8066,7 +8104,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Auto actualización: %s"
@@ -8080,7 +8118,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -8090,11 +8128,11 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -8216,21 +8254,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates"
 msgstr "Acepta certificado"
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -8246,7 +8284,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -8271,7 +8309,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8539,7 +8577,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8560,7 +8598,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8568,6 +8606,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8587,7 +8632,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8611,16 +8656,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8629,13 +8674,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8684,7 +8729,7 @@ msgstr "Contraseña admin para %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -8704,8 +8749,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -8727,11 +8772,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid "USB devices:"
 msgstr ""
 
@@ -8747,7 +8792,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8839,7 +8884,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -9005,11 +9050,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -9067,8 +9112,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9087,7 +9132,7 @@ msgstr "Perfil %s creado"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -9104,38 +9149,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"
@@ -9153,7 +9198,7 @@ msgstr "Descripción"
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -9188,6 +9233,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -9203,6 +9255,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -9347,7 +9407,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -10168,12 +10228,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -10192,6 +10252,14 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
+msgstr ""
 
 #: cmd/incus/info.go:646
 msgid "application"
@@ -10256,6 +10324,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -10403,7 +10480,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10849,6 +10926,10 @@ msgstr ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -18,17 +18,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  Châssis :"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  Firmware :"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  Carte mère :"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 msgid ""
@@ -625,7 +633,7 @@ msgstr ""
 "### Ceci est une représentation yaml d'un membre du cluster.\n"
 "### Toute ligne commençant par un '#' sera ignorée."
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, en ligne: %v, nœud NUMA : %v)"
@@ -650,7 +658,7 @@ msgstr "%s %q pool %q du projet %q (incluant %d copie instantanée)"
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d disponible)"
@@ -674,17 +682,17 @@ msgstr "'%s' n'est pas un format de fichier pris en charge"
 msgid "(none)"
 msgstr "(aucun)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Niveau %d (type: %s): %s"
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
@@ -736,8 +744,8 @@ msgstr "--refresh ne peut être utilisé qu'avec des instances"
 msgid "--target can only be used with clusters"
 msgstr "--target ne peut pas être utilisé qu'avec des clusters"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
@@ -997,12 +1005,12 @@ msgstr "Adresses à associé à (défaut: aucun)"
 msgid "Address to bind to (not including port)"
 msgstr "Adresses à associé à (sans inclure les ports)"
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr "Addresse : %s"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr "Addresse : %v"
@@ -1064,13 +1072,13 @@ msgstr "Toutes les adresses serveurs sont indisponibles"
 msgid "Alternative certificate name"
 msgstr "Nom alternatif du certificat"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "Architecture : %v"
@@ -1143,7 +1151,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "Auto-négociation: %v"
@@ -1166,7 +1174,7 @@ msgstr "Mode automatique (non-interactif)"
 msgid "Available projects:"
 msgstr "Projets disponibles :"
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "Moyenne : %.2f %.2f %.2f"
@@ -1205,7 +1213,7 @@ msgstr "Sauvegarder le volume de stockage : %s"
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1258,7 +1266,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr "À la fois--all et le nom d'instance on été donné"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr "Marque : %v"
@@ -1272,16 +1280,16 @@ msgstr "Pont:"
 msgid "Bucket description"
 msgstr "Description"
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Adresse du bus : %v"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1310,19 +1318,19 @@ msgstr "TEMPS CPU(s)"
 msgid "CPU USAGE"
 msgstr "UTILISATION CPU"
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr "CPU :"
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr "CPUs :"
 
@@ -1334,7 +1342,7 @@ msgstr "CRÉÉ"
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Version CUDA : %v"
@@ -1344,7 +1352,7 @@ msgstr "Version CUDA : %v"
 msgid "Cached: %s"
 msgstr "En cache : %s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr "Caches mémoire :"
 
@@ -1465,12 +1473,12 @@ msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 msgid "Cannot set key: %s"
 msgstr "Impossible d'assigner les clés: %s"
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr "Cartes %d:"
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "Cartes : %s (%s)"
@@ -1518,6 +1526,10 @@ msgstr "Test si le démon est prêt (tentative %d)"
 #, c-format
 msgid "Choose %s:"
 msgstr "Choisir %s:"
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
+msgstr ""
 
 #: cmd/incus/config_trust.go:150
 #, c-format
@@ -1585,16 +1597,17 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1747,7 +1760,7 @@ msgstr "Type de contenu, bloc ou système de fichier"
 msgid "Content type: %s"
 msgstr "Type de contenu : %s"
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "Contrôle: %s (%s)"
@@ -1849,12 +1862,12 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the storage volume: %s"
 msgstr "Copie du volume de stockage : %s"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr "Coeur %d"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr "Cœurs : %v"
 
@@ -2070,7 +2083,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -2091,7 +2104,7 @@ msgstr "Création de %s"
 msgid "Creating the instance"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "Nombre actuel de VFs: %d"
@@ -2125,7 +2138,7 @@ msgstr "UTILISATION DISQUE"
 msgid "DRIVER"
 msgstr "PILOTE"
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr "DRM:"
 
@@ -2139,7 +2152,7 @@ msgstr "Le démon ne fonctionne toujours pas après %ds d'attente (%v)"
 msgid "Daemon still running after %ds timeout"
 msgstr "Le démon continue de fonctionner après %ds d'attente"
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "État : %s"
@@ -2309,6 +2322,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2325,7 +2339,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2351,7 +2365,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2465,7 +2479,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Description"
 msgstr "Description"
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
@@ -2493,7 +2507,7 @@ msgstr "Détacher les interfaces réseaux des instances"
 msgid "Detach network interfaces from profiles"
 msgstr "Détacher les interfaces réseau des profils"
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Serveur distant : %s"
@@ -2513,7 +2527,7 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Addresse : %s"
@@ -2551,7 +2565,7 @@ msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 "Le périphérique du ou des profils ne peut pas être récupérés pour l'instance"
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
@@ -2582,20 +2596,20 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Disque %d:"
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr "Disque utilisé :"
 
@@ -2684,12 +2698,12 @@ msgstr "Ne pas afficher les informations sur l'état d'avancement"
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Pilote: %v (%v)"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "Pilote: %v (%v)"
@@ -2994,12 +3008,12 @@ msgstr "Erreur dans le déparamétrage de la propriété: %v"
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier: %s"
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, fuzzy, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr "Erreur lors de l'exécution de l'expansion de l'alias : %s\n"
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, fuzzy, c-format
 msgid "Error: %v\n"
 msgstr "Erreur : %v\n"
@@ -3133,7 +3147,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 #, fuzzy
 msgid "Expires at"
@@ -3250,7 +3264,7 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr "PREMIÈRE VUE"
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 #, fuzzy
 msgid "FQDN"
 msgstr "FQDN (nom de domaine pleinement qualifié)"
@@ -3614,7 +3628,7 @@ msgstr "Échec de l'écriture du fichier de certificat serveur %q : %w"
 msgid "Failed validation request: %w"
 msgstr "Échec de la demande de validation : %w"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "Nom : %s"
@@ -3796,18 +3810,18 @@ msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 "L'alias trouvé %q fait référence à un argument en dehors du nombre donné"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, fuzzy, c-format
 msgid "Free: %v"
 msgstr "Libre : %v"
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "Fréquence : %vMhz"
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "Fréquence : %vMhz (min : %vMhz, max : %vMhz)"
@@ -3816,11 +3830,11 @@ msgstr "Fréquence : %vMhz (min : %vMhz, max : %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr "GPU :"
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr "GPUs :"
 
@@ -4067,17 +4081,21 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 #, fuzzy
 msgid "Hostname"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -4106,12 +4124,12 @@ msgstr "La copie d'E/S de sshfs vers l'instance a échoué : %v"
 msgid "ID"
 msgstr "PID"
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, fuzzy, c-format
 msgid "ID: %d"
 msgstr "Pid : %d"
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr "ID : %s"
@@ -4124,7 +4142,7 @@ msgstr "IMAGES"
 msgid "INSTANCE NAME"
 msgstr "NOM DE L'INSTANCE"
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -4133,7 +4151,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -4181,7 +4199,7 @@ msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "Si l'instantané de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 #, fuzzy
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
@@ -4345,7 +4363,7 @@ msgstr "Afficher les commandes moins communes"
 msgid "Incus - Command line client"
 msgstr "Incus - Client en ligne de commande"
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr "Infiniband :"
 
@@ -4353,7 +4371,7 @@ msgstr "Infiniband :"
 msgid "Input data"
 msgstr "Données d'entrée"
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
@@ -4526,7 +4544,7 @@ msgstr ""
 "Nom invalide dans \"%s\", la chaîne vide n'est autorisée que lorsque "
 "maxWidth est défini."
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -4578,7 +4596,15 @@ msgstr "Cible invalide %s"
 msgid "Invalid type %q"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Créé : %s"
@@ -4591,7 +4617,7 @@ msgstr "Rejoindre un cluster existant nécessite d'être root"
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr "Version du noyau"
 
@@ -4624,7 +4650,7 @@ msgstr "ADRESSE D’ÉCOUTE"
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
@@ -4648,12 +4674,12 @@ msgstr "Création de %s"
 msgid "Launching the instance"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architecture : %s"
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, fuzzy, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "Vitesse de la liaison : %dMbit/s (%s duplex)"
@@ -5620,11 +5646,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5633,7 +5659,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr "Journal :"
 
@@ -5676,7 +5702,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -5686,7 +5712,7 @@ msgstr "Expire : %s"
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
@@ -5724,7 +5750,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5994,12 +6020,12 @@ msgstr "Rendre l'image publique"
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
@@ -6029,19 +6055,19 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr "Mémoire utilisée :"
 
@@ -6304,12 +6330,12 @@ msgstr "%s n'est pas un répertoire"
 msgid "Mode"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, fuzzy, c-format
 msgid "Model: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -6435,11 +6461,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -6450,26 +6476,26 @@ msgstr ""
 msgid "NO"
 msgstr "NON"
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 #, fuzzy
 msgid "Name"
@@ -6535,13 +6561,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Name: %v"
 msgstr "Nom : %s"
@@ -6691,7 +6717,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
@@ -6785,7 +6811,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6804,11 +6830,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 #, fuzzy
 msgid "OS Version"
 msgstr "Version CUDA : %v"
@@ -6870,7 +6896,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Operating System:"
 msgstr "Le réseau %s a été supprimé"
@@ -6880,7 +6906,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6893,17 +6919,17 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 #, fuzzy
 msgid "PCI device:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 #, fuzzy
 msgid "PCI devices:"
 msgstr "Création du conteneur"
@@ -6916,7 +6942,7 @@ msgstr ""
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
@@ -6953,20 +6979,20 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr "Paquets émis"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 #, fuzzy
 msgid "Partitions:"
 msgstr "Options :"
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -7034,17 +7060,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -7101,7 +7131,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -7111,22 +7141,22 @@ msgstr "Processus : %d"
 msgid "Processing aliases failed: %s"
 msgstr "Le traitement des alias a échoué : %s"
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -7306,7 +7336,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -7404,7 +7434,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, fuzzy, c-format
 msgid "Removable: %v"
 msgstr "Serveur distant : %s"
@@ -7591,9 +7621,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -7604,7 +7638,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -7728,7 +7762,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "Publié : %s"
@@ -7741,7 +7775,7 @@ msgstr "INSTANTANÉS"
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -7820,17 +7854,17 @@ msgstr "Créé : %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marque : %v"
@@ -8294,7 +8328,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
@@ -8304,7 +8338,7 @@ msgstr "Afficher des informations supplémentaires"
 msgid "Show instance snapshot configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -8435,6 +8469,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 #, fuzzy
 msgid "Show the current project"
@@ -8449,17 +8487,17 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -8502,7 +8540,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "État : %s"
@@ -8521,11 +8559,11 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -8554,7 +8592,7 @@ msgstr "Source :"
 msgid "Start instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "État : %s"
@@ -8568,7 +8606,7 @@ msgstr "Démarrage de %s"
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -8578,12 +8616,12 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -8710,21 +8748,21 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Successfully updated cluster certificates"
 msgstr "Accepter le certificat"
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -8742,7 +8780,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -8767,7 +8805,7 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -9048,7 +9086,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -9069,7 +9107,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\". Vouliez-vous un alias ?"
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -9077,6 +9115,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -9096,7 +9141,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -9123,7 +9168,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, fuzzy, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
@@ -9131,9 +9176,9 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -9142,13 +9187,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, fuzzy, c-format
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
@@ -9197,7 +9242,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -9217,8 +9262,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -9240,12 +9285,12 @@ msgstr "URL"
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 #, fuzzy
 msgid "USB device:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "USB devices:"
 msgstr "Création du conteneur"
@@ -9262,7 +9307,7 @@ msgstr "UTILISÉ PAR"
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -9357,7 +9402,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -9532,11 +9577,11 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -9595,8 +9640,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
@@ -9616,7 +9661,7 @@ msgstr "L'utilisateur a annulé l'opération de suppression."
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -9633,38 +9678,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Version CUDA : %v"
@@ -9682,7 +9727,7 @@ msgstr "Description"
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, fuzzy, c-format
 msgid "WWN: %s"
 msgstr "Nom : %s"
@@ -9717,6 +9762,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -9732,6 +9784,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -9891,7 +9951,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -11288,7 +11348,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -11300,7 +11360,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -11335,6 +11395,14 @@ msgstr ""
 "\n"
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
+msgstr ""
 
 #: cmd/incus/info.go:646
 #, fuzzy
@@ -11403,6 +11471,25 @@ msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
+
+#: cmd/incus/bug.go:179
+#, fuzzy
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
+msgstr ""
+"Utilisation: lxc info [<serveur distant>:][<conteneur>] [--show-log]\n"
+"\n"
+"Afficher l'information du conteneur ou du serveur.\n"
+"\n"
+"lxc info [<serveur distant>:]<conteneur> [--show-log]\n"
+"    Pour l'information du conteneur.\n"
+"\n"
+"lxc info [<serveur distant>:]\n"
+"    Pour l'information du serveur LXD."
 
 #: cmd/incus/cluster.go:912
 msgid ""
@@ -11549,7 +11636,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 #, fuzzy
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
@@ -12019,6 +12106,10 @@ msgstr "sshfs s'est arrêté"
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs monté %q sur %q"
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
+msgstr ""
 
 #: cmd/incus/storage.go:573
 msgid "total space"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -19,17 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  Chassis:"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  Firmware:"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  Motherboard:"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 msgid ""
@@ -366,7 +374,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, node NUMA: %v)"
@@ -391,7 +399,7 @@ msgstr "%s %q pada pool %q dalam proyek %q (termasuk %d snapshot)"
 msgid "%s (%d more)"
 msgstr "%s (%d lagi)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d tersedia)"
@@ -415,17 +423,17 @@ msgstr "'%s' bukan tipe berkas yang didukung"
 msgid "(none)"
 msgstr "(nihil)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partisi %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
@@ -474,8 +482,8 @@ msgstr ""
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -712,12 +720,12 @@ msgstr ""
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr ""
@@ -777,13 +785,13 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arsitektur: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "Arsitektur: %v"
@@ -850,7 +858,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -872,7 +880,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -910,7 +918,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr "Cadangan:"
 
@@ -961,7 +969,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr "Merek: %v"
@@ -975,16 +983,16 @@ msgstr "Bridge:"
 msgid "Bucket description"
 msgstr "deskripsi"
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Alamat Bus: %v"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Byte diterima"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Byte dikirim"
 
@@ -1012,19 +1020,19 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr "PENGGUNAAN CPU"
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "Penggunaan CPU (dalam detik)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "Penggunaan CPU:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr "CPU:"
 
@@ -1036,7 +1044,7 @@ msgstr "DIBUAT"
 msgid "CREATED AT"
 msgstr "DIBUAT PADA"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versi CUDA: %v"
@@ -1046,7 +1054,7 @@ msgstr "Versi CUDA: %v"
 msgid "Cached: %s"
 msgstr "Disinggahkan: %s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr "Singgahan:"
 
@@ -1156,12 +1164,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr "Kartu %d:"
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "Kartu: %s (%s)"
@@ -1205,6 +1213,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1273,16 +1285,17 @@ msgstr ""
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1423,7 +1436,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1507,12 +1520,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr "Core %d"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr "Core:"
 
@@ -1687,7 +1700,7 @@ msgstr "Buat pool penyimpanan"
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -1707,7 +1720,7 @@ msgstr "Membuat %s: %%s"
 msgid "Creating the instance"
 msgstr "Membuat instansi"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -1741,7 +1754,7 @@ msgstr "PENGGUNAAN DISK"
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr "DRM:"
 
@@ -1755,7 +1768,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, c-format
 msgid "Date: %s"
 msgstr "Tanggal: %s"
@@ -1903,6 +1916,7 @@ msgstr "Hapus peringatan"
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -1919,7 +1933,7 @@ msgstr "Hapus peringatan"
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -1945,7 +1959,7 @@ msgstr "Hapus peringatan"
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2059,7 +2073,7 @@ msgstr "Hapus peringatan"
 msgid "Description"
 msgstr "Deskripsi"
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr "Deskripsi: %s"
@@ -2084,7 +2098,7 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, c-format
 msgid "Device %d:"
 msgstr "Perangkat %d:"
@@ -2104,7 +2118,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
@@ -2136,7 +2150,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr "Perangkat: %s"
@@ -2165,20 +2179,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "Penggunaan disk:"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr "Disk:"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr "Disk:"
 
@@ -2260,12 +2274,12 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Driver: %v"
 msgstr "Driver: %v"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "Driver: %v (%v)"
@@ -2535,12 +2549,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
@@ -2618,7 +2632,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr "Kedaluwarsa pada"
@@ -2721,7 +2735,7 @@ msgstr "SIDIKJARI"
 msgid "FIRST SEEN"
 msgstr "PERTAMA TERLIHAT"
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr "FQDN"
 
@@ -3072,7 +3086,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3222,18 +3236,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3242,11 +3256,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3458,15 +3472,19 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3494,12 +3512,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3512,7 +3530,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3521,7 +3539,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3561,7 +3579,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3704,7 +3722,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -3712,7 +3730,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr ""
 
@@ -3870,7 +3888,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3917,7 +3935,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3930,7 +3956,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -3962,7 +3988,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3985,12 +4011,12 @@ msgstr ""
 msgid "Launching the instance"
 msgstr ""
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -4875,11 +4901,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr "deskripsi"
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4888,7 +4914,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -4929,7 +4955,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -4938,7 +4964,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -4976,7 +5002,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5208,12 +5234,12 @@ msgstr ""
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -5242,19 +5268,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5491,12 +5517,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -5614,11 +5640,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -5629,26 +5655,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -5709,13 +5735,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -5864,7 +5890,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -5955,7 +5981,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5974,11 +6000,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr ""
 
@@ -6027,7 +6053,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6036,7 +6062,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6048,16 +6074,16 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid "PCI devices:"
 msgstr ""
 
@@ -6069,7 +6095,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6106,19 +6132,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6184,17 +6210,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6249,7 +6279,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6259,22 +6289,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, c-format
 msgid "Product ID: %v"
 msgstr "ID Produk: %v"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid "Product: %s"
 msgstr "Produk: %s"
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr "Produk: %v"
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr "Produk: %v (%v)"
@@ -6445,7 +6475,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -6537,7 +6567,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -6703,9 +6733,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -6716,7 +6750,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -6815,7 +6849,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6828,7 +6862,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -6902,17 +6936,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -7337,7 +7371,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7345,7 +7379,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -7456,6 +7490,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr "Tampilkan proyek saat ini"
@@ -7468,15 +7506,15 @@ msgstr "Tampilkan remote baku"
 msgid "Show the expanded configuration"
 msgstr "Tampilkan konfigurasi yang diperluas"
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 msgid "Show the instance's access list"
 msgstr "Tampilkan daftar akses instansi"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid "Show the instance's recent log entries"
 msgstr "Tampilkan entri log terkini instansi"
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr "Tampilkan sumber daya yang tersedia ke server"
 
@@ -7517,7 +7555,7 @@ msgstr "Ukuran dalam GiB dari perangkat loop baru"
 msgid "Size: %.2fMiB"
 msgstr "Ukuran: %.2fMiB"
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr "Ukuran: %s"
@@ -7535,11 +7573,11 @@ msgstr "Volume penyimpanan snapshot"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "Snapshot itu hanya-baca dan tidak bisa diubah konfigurasinya"
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr "Snapshot:"
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr "Soket %d:"
@@ -7567,7 +7605,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, c-format
 msgid "Started: %s"
 msgstr ""
@@ -7581,7 +7619,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr ""
 
@@ -7590,11 +7628,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7714,21 +7752,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7744,7 +7782,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -7769,7 +7807,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8037,7 +8075,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8058,7 +8096,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8066,6 +8104,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8084,7 +8129,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8108,16 +8153,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8126,13 +8171,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8181,7 +8226,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8199,8 +8244,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8222,11 +8267,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid "USB devices:"
 msgstr ""
 
@@ -8242,7 +8287,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8331,7 +8376,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -8476,11 +8521,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8537,8 +8582,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8556,7 +8601,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr "VF: %d"
@@ -8573,38 +8618,38 @@ msgstr "Pemfilteran VLAN"
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, c-format
 msgid "Vendor ID: %v"
 msgstr "ID Vendor: %v"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, c-format
 msgid "Vendor: %s"
 msgstr "Vendor: %s"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr "Vendor: %v"
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr "Vendor: %v (%v)"
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr "Versi: %s"
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr "Versi: %v"
@@ -8622,7 +8667,7 @@ msgstr "deskripsi"
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr "WWN: %s"
@@ -8657,6 +8702,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -8672,6 +8724,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -8813,7 +8873,7 @@ msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>] [<path>]"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -9492,11 +9552,11 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -9510,6 +9570,14 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1031
 msgid "[[<remote>:]<member>]"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
 msgstr ""
 
 #: cmd/incus/info.go:646
@@ -9575,6 +9643,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -9722,7 +9799,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10168,6 +10245,10 @@ msgstr ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2025-10-06 17:21-0400\n"
+        "POT-Creation-Date: 2025-10-08 23:58+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,16 +16,22 @@ msgstr  "Project-Id-Version: incus\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid   "  Chassis:"
 msgstr  ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid   "  Firmware:"
 msgstr  ""
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid   "  Motherboard:"
+msgstr  ""
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid   "### %s\n"
+        "*Pleuse write %s below the following dashes. You can use Markdown formatting.*"
 msgstr  ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
@@ -339,7 +345,7 @@ msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
@@ -364,7 +370,7 @@ msgstr  ""
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid   "%s (%s) (%d available)"
 msgstr  ""
@@ -388,17 +394,17 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid   "- Level %d (type: %s): %s"
 msgstr  ""
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid   "- Partition %d"
 msgstr  ""
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid   "- Port %d (%s)"
 msgstr  ""
@@ -447,7 +453,7 @@ msgstr  ""
 msgid   "--target can only be used with clusters"
 msgstr  ""
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620 cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -673,12 +679,12 @@ msgstr  ""
 msgid   "Address to bind to (not including port)"
 msgstr  ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid   "Address: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid   "Address: %v"
 msgstr  ""
@@ -737,12 +743,12 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509 cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518 cmd/incus/info.go:659
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid   "Architecture: %v"
 msgstr  ""
@@ -808,7 +814,7 @@ msgstr  ""
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid   "Auto negotiation: %v"
 msgstr  ""
@@ -830,7 +836,7 @@ msgstr  ""
 msgid   "Available projects:"
 msgstr  ""
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid   "Average: %.2f %.2f %.2f"
 msgstr  ""
@@ -866,7 +872,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid   "Backups:"
 msgstr  ""
 
@@ -911,7 +917,7 @@ msgstr  ""
 msgid   "Both --all and instance name given"
 msgstr  ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid   "Brand: %v"
 msgstr  ""
@@ -924,16 +930,16 @@ msgstr  ""
 msgid   "Bucket description"
 msgstr  ""
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid   "Bus Address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -961,19 +967,19 @@ msgstr  ""
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid   "CPU usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid   "CPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid   "CPUs:"
 msgstr  ""
 
@@ -985,7 +991,7 @@ msgstr  ""
 msgid   "CREATED AT"
 msgstr  ""
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid   "CUDA Version: %v"
 msgstr  ""
@@ -995,7 +1001,7 @@ msgstr  ""
 msgid   "Cached: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid   "Caches:"
 msgstr  ""
 
@@ -1101,12 +1107,12 @@ msgstr  ""
 msgid   "Cannot set key: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid   "Card: %s (%s)"
 msgstr  ""
@@ -1147,6 +1153,10 @@ msgstr  ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid   "Choose %s:"
+msgstr  ""
+
+#: cmd/incus/bug.go:235
+msgid   "Choose an issue title:"
 msgstr  ""
 
 #: cmd/incus/config_trust.go:150
@@ -1212,7 +1222,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285 cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622 cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103 cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652 cmd/incus/network.go:1726 cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265 cmd/incus/network_load_balancer.go:350 cmd/incus/network_load_balancer.go:530 cmd/incus/network_load_balancer.go:667 cmd/incus/network_load_balancer.go:834 cmd/incus/network_load_balancer.go:927 cmd/incus/network_load_balancer.go:1008 cmd/incus/network_load_balancer.go:1126 cmd/incus/network_load_balancer.go:1205 cmd/incus/storage.go:116 cmd/incus/storage.go:424 cmd/incus/storage.go:509 cmd/incus/storage.go:873 cmd/incus/storage.go:975 cmd/incus/storage.go:1070 cmd/incus/storage_bucket.go:110 cmd/incus/storage_bucket.go:218 cmd/incus/storage_bucket.go:283 cmd/incus/storage_bucket.go:416 cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:797 cmd/incus/storage_bucket.go:865 cmd/incus/storage_bucket.go:967 cmd/incus/storage_bucket.go:1108 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1283 cmd/incus/storage_bucket.go:1421 cmd/incus/storage_bucket.go:1496 cmd/incus/storage_bucket.go:1645 cmd/incus/storage_volume.go:380 cmd/incus/storage_volume.go:605 cmd/incus/storage_volume.go:718 cmd/incus/storage_volume.go:1001 cmd/incus/storage_volume.go:1229 cmd/incus/storage_volume.go:1364 cmd/incus/storage_volume.go:1860 cmd/incus/storage_volume.go:1954 cmd/incus/storage_volume.go:2048 cmd/incus/storage_volume.go:2212 cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3056 cmd/incus/storage_volume.go:3138 cmd/incus/storage_volume.go:3232 cmd/incus/storage_volume.go:3408
+#: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285 cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622 cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63 cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900 cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49 cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652 cmd/incus/network.go:1726 cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265 cmd/incus/network_load_balancer.go:350 cmd/incus/network_load_balancer.go:530 cmd/incus/network_load_balancer.go:667 cmd/incus/network_load_balancer.go:834 cmd/incus/network_load_balancer.go:927 cmd/incus/network_load_balancer.go:1008 cmd/incus/network_load_balancer.go:1126 cmd/incus/network_load_balancer.go:1205 cmd/incus/storage.go:116 cmd/incus/storage.go:424 cmd/incus/storage.go:509 cmd/incus/storage.go:873 cmd/incus/storage.go:975 cmd/incus/storage.go:1070 cmd/incus/storage_bucket.go:110 cmd/incus/storage_bucket.go:218 cmd/incus/storage_bucket.go:283 cmd/incus/storage_bucket.go:416 cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:797 cmd/incus/storage_bucket.go:865 cmd/incus/storage_bucket.go:967 cmd/incus/storage_bucket.go:1108 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1283 cmd/incus/storage_bucket.go:1421 cmd/incus/storage_bucket.go:1496 cmd/incus/storage_bucket.go:1645 cmd/incus/storage_volume.go:380 cmd/incus/storage_volume.go:605 cmd/incus/storage_volume.go:718 cmd/incus/storage_volume.go:1001 cmd/incus/storage_volume.go:1229 cmd/incus/storage_volume.go:1364 cmd/incus/storage_volume.go:1860 cmd/incus/storage_volume.go:1954 cmd/incus/storage_volume.go:2048 cmd/incus/storage_volume.go:2212 cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3056 cmd/incus/storage_volume.go:3138 cmd/incus/storage_volume.go:3232 cmd/incus/storage_volume.go:3408
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1300,7 +1310,7 @@ msgstr  ""
 msgid   "Content type: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid   "Control: %s (%s)"
 msgstr  ""
@@ -1377,12 +1387,12 @@ msgstr  ""
 msgid   "Copying the storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid   "Core %d"
 msgstr  ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid   "Cores:"
 msgstr  ""
 
@@ -1555,7 +1565,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666 cmd/incus/storage_volume.go:1483
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670 cmd/incus/storage_volume.go:1483
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1574,7 +1584,7 @@ msgstr  ""
 msgid   "Creating the instance"
 msgstr  ""
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid   "Current number of VFs: %d"
 msgstr  ""
@@ -1599,7 +1609,7 @@ msgstr  ""
 msgid   "DRIVER"
 msgstr  ""
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid   "DRM:"
 msgstr  ""
 
@@ -1613,7 +1623,7 @@ msgstr  ""
 msgid   "Daemon still running after %ds timeout"
 msgstr  ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, c-format
 msgid   "Date: %s"
 msgstr  ""
@@ -1746,11 +1756,11 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81 cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21 cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47 cmd/incus/admin_os.go:33 cmd/incus/admin_os.go:74 cmd/incus/admin_os.go:105 cmd/incus/admin_os.go:183 cmd/incus/admin_os.go:255 cmd/incus/admin_os.go:283 cmd/incus/admin_os.go:396 cmd/incus/admin_os.go:428 cmd/incus/admin_os.go:541 cmd/incus/admin_os.go:619 cmd/incus/admin_os.go:691 cmd/incus/admin_os.go:719 cmd/incus/admin_os.go:829 cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31 cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32 cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63 cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229 cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341 cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536 cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722 cmd/incus/cluster.go:815 cmd/incus/cluster.go:910 cmd/incus/cluster.go:1033 cmd/incus/cluster.go:1113 cmd/incus/cluster.go:1280 cmd/incus/cluster.go:1370 cmd/incus/cluster.go:1496 cmd/incus/cluster.go:1526 cmd/incus/cluster_group.go:37 cmd/incus/cluster_group.go:103 cmd/incus/cluster_group.go:190 cmd/incus/cluster_group.go:282 cmd/incus/cluster_group.go:342 cmd/incus/cluster_group.go:467 cmd/incus/cluster_group.go:623 cmd/incus/cluster_group.go:708 cmd/incus/cluster_group.go:764 cmd/incus/cluster_group.go:827 cmd/incus/cluster_group.go:904 cmd/incus/cluster_group.go:979 cmd/incus/cluster_group.go:1059 cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53 cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97 cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754 cmd/incus/config.go:886 cmd/incus/config_device.go:27 cmd/incus/config_device.go:83 cmd/incus/config_device.go:227 cmd/incus/config_device.go:326 cmd/incus/config_device.go:411 cmd/incus/config_device.go:515 cmd/incus/config_device.go:633 cmd/incus/config_device.go:640 cmd/incus/config_device.go:771 cmd/incus/config_device.go:858 cmd/incus/config_metadata.go:28 cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192 cmd/incus/config_template.go:28 cmd/incus/config_template.go:70 cmd/incus/config_template.go:140 cmd/incus/config_template.go:196 cmd/incus/config_template.go:299 cmd/incus/config_template.go:373 cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93 cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285 cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:616 cmd/incus/config_trust.go:775 cmd/incus/config_trust.go:823 cmd/incus/config_trust.go:896 cmd/incus/console.go:42 cmd/incus/copy.go:44 cmd/incus/create.go:47 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:34 cmd/incus/file.go:53 cmd/incus/file.go:100 cmd/incus/file.go:295 cmd/incus/file.go:379 cmd/incus/file.go:459 cmd/incus/file.go:696 cmd/incus/file.go:1365 cmd/incus/image.go:44 cmd/incus/image.go:153 cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509 cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088 cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599 cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32 cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141 cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387 cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25 cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25 cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41 cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354 cmd/incus/network.go:472 cmd/incus/network.go:532 cmd/incus/network.go:631 cmd/incus/network.go:730 cmd/incus/network.go:868 cmd/incus/network.go:951 cmd/incus/network.go:1111 cmd/incus/network.go:1331 cmd/incus/network.go:1491 cmd/incus/network.go:1553 cmd/incus/network.go:1649 cmd/incus/network.go:1723 cmd/incus/network_acl.go:31 cmd/incus/network_acl.go:98 cmd/incus/network_acl.go:200 cmd/incus/network_acl.go:263 cmd/incus/network_acl.go:321 cmd/incus/network_acl.go:399 cmd/incus/network_acl.go:504 cmd/incus/network_acl.go:592 cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778 cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897 cmd/incus/network_acl.go:914 cmd/incus/network_acl.go:1062 cmd/incus/network_address_set.go:32 cmd/incus/network_address_set.go:95 cmd/incus/network_address_set.go:189 cmd/incus/network_address_set.go:249 cmd/incus/network_address_set.go:353 cmd/incus/network_address_set.go:429 cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594 cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703 cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36 cmd/incus/network_forward.go:31 cmd/incus/network_forward.go:95 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:339 cmd/incus/network_forward.go:449 cmd/incus/network_forward.go:536 cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695 cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928 cmd/incus/network_forward.go:945 cmd/incus/network_forward.go:1031 cmd/incus/network_integration.go:30 cmd/incus/network_integration.go:88 cmd/incus/network_integration.go:181 cmd/incus/network_integration.go:233 cmd/incus/network_integration.go:355 cmd/incus/network_integration.go:419 cmd/incus/network_integration.go:566 cmd/incus/network_integration.go:620 cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732 cmd/incus/network_load_balancer.go:32 cmd/incus/network_load_balancer.go:104 cmd/incus/network_load_balancer.go:262 cmd/incus/network_load_balancer.go:342 cmd/incus/network_load_balancer.go:452 cmd/incus/network_load_balancer.go:522 cmd/incus/network_load_balancer.go:632 cmd/incus/network_load_balancer.go:664 cmd/incus/network_load_balancer.go:831 cmd/incus/network_load_balancer.go:907 cmd/incus/network_load_balancer.go:924 cmd/incus/network_load_balancer.go:1005 cmd/incus/network_load_balancer.go:1106 cmd/incus/network_load_balancer.go:1123 cmd/incus/network_load_balancer.go:1201 cmd/incus/network_load_balancer.go:1325 cmd/incus/network_peer.go:31 cmd/incus/network_peer.go:91 cmd/incus/network_peer.go:259 cmd/incus/network_peer.go:334 cmd/incus/network_peer.go:489 cmd/incus/network_peer.go:576 cmd/incus/network_peer.go:678 cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866 cmd/incus/network_zone.go:36 cmd/incus/network_zone.go:96 cmd/incus/network_zone.go:264 cmd/incus/network_zone.go:329 cmd/incus/network_zone.go:407 cmd/incus/network_zone.go:510 cmd/incus/network_zone.go:598 cmd/incus/network_zone.go:643 cmd/incus/network_zone.go:772 cmd/incus/network_zone.go:830 cmd/incus/network_zone.go:888 cmd/incus/network_zone.go:972 cmd/incus/network_zone.go:1038 cmd/incus/network_zone.go:1119 cmd/incus/network_zone.go:1225 cmd/incus/network_zone.go:1314 cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1575 cmd/incus/network_zone.go:1636 cmd/incus/operation.go:32 cmd/incus/operation.go:66 cmd/incus/operation.go:119 cmd/incus/operation.go:300 cmd/incus/profile.go:38 cmd/incus/profile.go:114 cmd/incus/profile.go:191 cmd/incus/profile.go:284 cmd/incus/profile.go:370 cmd/incus/profile.go:461 cmd/incus/profile.go:521 cmd/incus/profile.go:659 cmd/incus/profile.go:737 cmd/incus/profile.go:928 cmd/incus/profile.go:1018 cmd/incus/profile.go:1080 cmd/incus/profile.go:1169 cmd/incus/profile.go:1235 cmd/incus/project.go:40 cmd/incus/project.go:111 cmd/incus/project.go:217 cmd/incus/project.go:317 cmd/incus/project.go:455 cmd/incus/project.go:532 cmd/incus/project.go:761 cmd/incus/project.go:828 cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025 cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35 cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49 cmd/incus/remote.go:124 cmd/incus/remote.go:677 cmd/incus/remote.go:724 cmd/incus/remote.go:789 cmd/incus/remote.go:893 cmd/incus/remote.go:1070 cmd/incus/remote.go:1151 cmd/incus/remote.go:1216 cmd/incus/remote.go:1264 cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33 cmd/incus/snapshot.go:83 cmd/incus/snapshot.go:231 cmd/incus/snapshot.go:325 cmd/incus/snapshot.go:486 cmd/incus/snapshot.go:549 cmd/incus/snapshot.go:628 cmd/incus/storage.go:41 cmd/incus/storage.go:108 cmd/incus/storage.go:227 cmd/incus/storage.go:287 cmd/incus/storage.go:421 cmd/incus/storage.go:505 cmd/incus/storage.go:688 cmd/incus/storage.go:867 cmd/incus/storage.go:971 cmd/incus/storage.go:1067 cmd/incus/storage_bucket.go:37 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:216 cmd/incus/storage_bucket.go:279 cmd/incus/storage_bucket.go:414 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:674 cmd/incus/storage_bucket.go:792 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:899 cmd/incus/storage_bucket.go:947 cmd/incus/storage_bucket.go:1099 cmd/incus/storage_bucket.go:1213 cmd/incus/storage_bucket.go:1279 cmd/incus/storage_bucket.go:1416 cmd/incus/storage_bucket.go:1489 cmd/incus/storage_bucket.go:1640 cmd/incus/storage_volume.go:61 cmd/incus/storage_volume.go:173 cmd/incus/storage_volume.go:266 cmd/incus/storage_volume.go:376 cmd/incus/storage_volume.go:597 cmd/incus/storage_volume.go:715 cmd/incus/storage_volume.go:790 cmd/incus/storage_volume.go:890 cmd/incus/storage_volume.go:989 cmd/incus/storage_volume.go:1215 cmd/incus/storage_volume.go:1353 cmd/incus/storage_volume.go:1515 cmd/incus/storage_volume.go:1600 cmd/incus/storage_volume.go:1856 cmd/incus/storage_volume.go:1951 cmd/incus/storage_volume.go:2033 cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2303 cmd/incus/storage_volume.go:2363 cmd/incus/storage_volume.go:2393 cmd/incus/storage_volume.go:2493 cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2704 cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2802 cmd/incus/storage_volume.go:2965 cmd/incus/storage_volume.go:3054 cmd/incus/storage_volume.go:3136 cmd/incus/storage_volume.go:3225 cmd/incus/storage_volume.go:3401 cmd/incus/top.go:43 cmd/incus/version.go:23 cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273 cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81 cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21 cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47 cmd/incus/admin_os.go:33 cmd/incus/admin_os.go:74 cmd/incus/admin_os.go:105 cmd/incus/admin_os.go:183 cmd/incus/admin_os.go:255 cmd/incus/admin_os.go:283 cmd/incus/admin_os.go:396 cmd/incus/admin_os.go:428 cmd/incus/admin_os.go:541 cmd/incus/admin_os.go:619 cmd/incus/admin_os.go:691 cmd/incus/admin_os.go:719 cmd/incus/admin_os.go:829 cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31 cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32 cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63 cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229 cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177 cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341 cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536 cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722 cmd/incus/cluster.go:815 cmd/incus/cluster.go:910 cmd/incus/cluster.go:1033 cmd/incus/cluster.go:1113 cmd/incus/cluster.go:1280 cmd/incus/cluster.go:1370 cmd/incus/cluster.go:1496 cmd/incus/cluster.go:1526 cmd/incus/cluster_group.go:37 cmd/incus/cluster_group.go:103 cmd/incus/cluster_group.go:190 cmd/incus/cluster_group.go:282 cmd/incus/cluster_group.go:342 cmd/incus/cluster_group.go:467 cmd/incus/cluster_group.go:623 cmd/incus/cluster_group.go:708 cmd/incus/cluster_group.go:764 cmd/incus/cluster_group.go:827 cmd/incus/cluster_group.go:904 cmd/incus/cluster_group.go:979 cmd/incus/cluster_group.go:1059 cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53 cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97 cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754 cmd/incus/config.go:897 cmd/incus/config_device.go:27 cmd/incus/config_device.go:83 cmd/incus/config_device.go:227 cmd/incus/config_device.go:326 cmd/incus/config_device.go:411 cmd/incus/config_device.go:515 cmd/incus/config_device.go:633 cmd/incus/config_device.go:640 cmd/incus/config_device.go:771 cmd/incus/config_device.go:858 cmd/incus/config_metadata.go:28 cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192 cmd/incus/config_template.go:28 cmd/incus/config_template.go:70 cmd/incus/config_template.go:140 cmd/incus/config_template.go:196 cmd/incus/config_template.go:299 cmd/incus/config_template.go:373 cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93 cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285 cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:616 cmd/incus/config_trust.go:775 cmd/incus/config_trust.go:823 cmd/incus/config_trust.go:896 cmd/incus/console.go:42 cmd/incus/copy.go:44 cmd/incus/create.go:47 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:34 cmd/incus/file.go:53 cmd/incus/file.go:100 cmd/incus/file.go:295 cmd/incus/file.go:379 cmd/incus/file.go:459 cmd/incus/file.go:696 cmd/incus/file.go:1365 cmd/incus/image.go:44 cmd/incus/image.go:153 cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509 cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088 cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599 cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32 cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141 cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387 cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25 cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25 cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41 cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354 cmd/incus/network.go:472 cmd/incus/network.go:532 cmd/incus/network.go:631 cmd/incus/network.go:730 cmd/incus/network.go:868 cmd/incus/network.go:951 cmd/incus/network.go:1111 cmd/incus/network.go:1331 cmd/incus/network.go:1491 cmd/incus/network.go:1553 cmd/incus/network.go:1649 cmd/incus/network.go:1723 cmd/incus/network_acl.go:31 cmd/incus/network_acl.go:98 cmd/incus/network_acl.go:200 cmd/incus/network_acl.go:263 cmd/incus/network_acl.go:321 cmd/incus/network_acl.go:399 cmd/incus/network_acl.go:504 cmd/incus/network_acl.go:592 cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778 cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897 cmd/incus/network_acl.go:914 cmd/incus/network_acl.go:1062 cmd/incus/network_address_set.go:32 cmd/incus/network_address_set.go:95 cmd/incus/network_address_set.go:189 cmd/incus/network_address_set.go:249 cmd/incus/network_address_set.go:353 cmd/incus/network_address_set.go:429 cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594 cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703 cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36 cmd/incus/network_forward.go:31 cmd/incus/network_forward.go:95 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:339 cmd/incus/network_forward.go:449 cmd/incus/network_forward.go:536 cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695 cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928 cmd/incus/network_forward.go:945 cmd/incus/network_forward.go:1031 cmd/incus/network_integration.go:30 cmd/incus/network_integration.go:88 cmd/incus/network_integration.go:181 cmd/incus/network_integration.go:233 cmd/incus/network_integration.go:355 cmd/incus/network_integration.go:419 cmd/incus/network_integration.go:566 cmd/incus/network_integration.go:620 cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732 cmd/incus/network_load_balancer.go:32 cmd/incus/network_load_balancer.go:104 cmd/incus/network_load_balancer.go:262 cmd/incus/network_load_balancer.go:342 cmd/incus/network_load_balancer.go:452 cmd/incus/network_load_balancer.go:522 cmd/incus/network_load_balancer.go:632 cmd/incus/network_load_balancer.go:664 cmd/incus/network_load_balancer.go:831 cmd/incus/network_load_balancer.go:907 cmd/incus/network_load_balancer.go:924 cmd/incus/network_load_balancer.go:1005 cmd/incus/network_load_balancer.go:1106 cmd/incus/network_load_balancer.go:1123 cmd/incus/network_load_balancer.go:1201 cmd/incus/network_load_balancer.go:1325 cmd/incus/network_peer.go:31 cmd/incus/network_peer.go:91 cmd/incus/network_peer.go:259 cmd/incus/network_peer.go:334 cmd/incus/network_peer.go:489 cmd/incus/network_peer.go:576 cmd/incus/network_peer.go:678 cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866 cmd/incus/network_zone.go:36 cmd/incus/network_zone.go:96 cmd/incus/network_zone.go:264 cmd/incus/network_zone.go:329 cmd/incus/network_zone.go:407 cmd/incus/network_zone.go:510 cmd/incus/network_zone.go:598 cmd/incus/network_zone.go:643 cmd/incus/network_zone.go:772 cmd/incus/network_zone.go:830 cmd/incus/network_zone.go:888 cmd/incus/network_zone.go:972 cmd/incus/network_zone.go:1038 cmd/incus/network_zone.go:1119 cmd/incus/network_zone.go:1225 cmd/incus/network_zone.go:1314 cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1575 cmd/incus/network_zone.go:1636 cmd/incus/operation.go:32 cmd/incus/operation.go:66 cmd/incus/operation.go:119 cmd/incus/operation.go:300 cmd/incus/profile.go:38 cmd/incus/profile.go:114 cmd/incus/profile.go:191 cmd/incus/profile.go:284 cmd/incus/profile.go:370 cmd/incus/profile.go:461 cmd/incus/profile.go:521 cmd/incus/profile.go:659 cmd/incus/profile.go:737 cmd/incus/profile.go:928 cmd/incus/profile.go:1018 cmd/incus/profile.go:1080 cmd/incus/profile.go:1169 cmd/incus/profile.go:1235 cmd/incus/project.go:40 cmd/incus/project.go:111 cmd/incus/project.go:217 cmd/incus/project.go:317 cmd/incus/project.go:455 cmd/incus/project.go:532 cmd/incus/project.go:761 cmd/incus/project.go:828 cmd/incus/project.go:916 cmd/incus/project.go:962 cmd/incus/project.go:1025 cmd/incus/project.go:1095 cmd/incus/project.go:1211 cmd/incus/publish.go:35 cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:49 cmd/incus/remote.go:124 cmd/incus/remote.go:677 cmd/incus/remote.go:724 cmd/incus/remote.go:789 cmd/incus/remote.go:893 cmd/incus/remote.go:1070 cmd/incus/remote.go:1151 cmd/incus/remote.go:1216 cmd/incus/remote.go:1264 cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33 cmd/incus/snapshot.go:83 cmd/incus/snapshot.go:231 cmd/incus/snapshot.go:325 cmd/incus/snapshot.go:486 cmd/incus/snapshot.go:549 cmd/incus/snapshot.go:628 cmd/incus/storage.go:41 cmd/incus/storage.go:108 cmd/incus/storage.go:227 cmd/incus/storage.go:287 cmd/incus/storage.go:421 cmd/incus/storage.go:505 cmd/incus/storage.go:688 cmd/incus/storage.go:867 cmd/incus/storage.go:971 cmd/incus/storage.go:1067 cmd/incus/storage_bucket.go:37 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:216 cmd/incus/storage_bucket.go:279 cmd/incus/storage_bucket.go:414 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:674 cmd/incus/storage_bucket.go:792 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:899 cmd/incus/storage_bucket.go:947 cmd/incus/storage_bucket.go:1099 cmd/incus/storage_bucket.go:1213 cmd/incus/storage_bucket.go:1279 cmd/incus/storage_bucket.go:1416 cmd/incus/storage_bucket.go:1489 cmd/incus/storage_bucket.go:1640 cmd/incus/storage_volume.go:61 cmd/incus/storage_volume.go:173 cmd/incus/storage_volume.go:266 cmd/incus/storage_volume.go:376 cmd/incus/storage_volume.go:597 cmd/incus/storage_volume.go:715 cmd/incus/storage_volume.go:790 cmd/incus/storage_volume.go:890 cmd/incus/storage_volume.go:989 cmd/incus/storage_volume.go:1215 cmd/incus/storage_volume.go:1353 cmd/incus/storage_volume.go:1515 cmd/incus/storage_volume.go:1600 cmd/incus/storage_volume.go:1856 cmd/incus/storage_volume.go:1951 cmd/incus/storage_volume.go:2033 cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2303 cmd/incus/storage_volume.go:2363 cmd/incus/storage_volume.go:2393 cmd/incus/storage_volume.go:2493 cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2704 cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2802 cmd/incus/storage_volume.go:2965 cmd/incus/storage_volume.go:3054 cmd/incus/storage_volume.go:3136 cmd/incus/storage_volume.go:3225 cmd/incus/storage_volume.go:3401 cmd/incus/top.go:43 cmd/incus/version.go:23 cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273 cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
@@ -1775,7 +1785,7 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, c-format
 msgid   "Device %d:"
 msgstr  ""
@@ -1795,7 +1805,7 @@ msgstr  ""
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid   "Device Address: %v"
 msgstr  ""
@@ -1821,7 +1831,7 @@ msgstr  ""
 msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid   "Device: %s"
 msgstr  ""
@@ -1850,20 +1860,20 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid   "Disk usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid   "Disk:"
 msgstr  ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid   "Disks:"
 msgstr  ""
 
@@ -1944,12 +1954,12 @@ msgstr  ""
 msgid   "Down delay"
 msgstr  ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, c-format
 msgid   "Driver: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid   "Driver: %v (%v)"
 msgstr  ""
@@ -2179,12 +2189,12 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid   "Error while executing alias expansion: %s\n"
 msgstr  ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid   "Error: %v\n"
 msgstr  ""
@@ -2258,7 +2268,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516 cmd/incus/storage_volume.go:1566
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516 cmd/incus/storage_volume.go:1566
 msgid   "Expires at"
 msgstr  ""
 
@@ -2353,7 +2363,7 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid   "FQDN"
 msgstr  ""
 
@@ -2701,7 +2711,7 @@ msgstr  ""
 msgid   "Failed validation request: %w"
 msgstr  ""
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid   "Family: %v"
 msgstr  ""
@@ -2824,17 +2834,17 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536 cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545 cmd/incus/info.go:551
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid   "Frequency: %vMhz"
 msgstr  ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
@@ -2843,11 +2853,11 @@ msgstr  ""
 msgid   "GLOBAL"
 msgstr  ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid   "GPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid   "GPUs:"
 msgstr  ""
 
@@ -3051,15 +3061,19 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid   "Host interface"
 msgstr  ""
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 msgid   "Hostname"
 msgstr  ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid   "How to reproduce this bug?"
+msgstr  ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid   "Hugepages:\n"
 msgstr  ""
 
@@ -3087,12 +3101,12 @@ msgstr  ""
 msgid   "ID"
 msgstr  ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid   "ID: %d"
 msgstr  ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid   "ID: %s"
 msgstr  ""
@@ -3105,7 +3119,7 @@ msgstr  ""
 msgid   "INSTANCE NAME"
 msgstr  ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid   "IOMMU group: %v"
 msgstr  ""
@@ -3114,7 +3128,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid   "IP addresses"
 msgstr  ""
 
@@ -3154,7 +3168,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid   "If this is your first time running Incus on this machine, you should also run: incus admin init"
 msgstr  ""
 
@@ -3293,7 +3307,7 @@ msgstr  ""
 msgid   "Incus - Command line client"
 msgstr  ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid   "Infiniband:"
 msgstr  ""
 
@@ -3301,7 +3315,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid   "Instance Only"
 msgstr  ""
 
@@ -3455,7 +3469,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -3500,7 +3514,15 @@ msgstr  ""
 msgid   "Invalid type %q"
 msgstr  ""
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid   "Is there an existing issue for this?"
+msgstr  ""
+
+#: cmd/incus/bug.go:250
+msgid   "Is this happening on an up to date version of Incus?"
+msgstr  ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid   "IsSM: %s (%s)"
 msgstr  ""
@@ -3513,7 +3535,7 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid   "Kernel Version"
 msgstr  ""
 
@@ -3541,7 +3563,7 @@ msgstr  ""
 msgid   "LOCATION"
 msgstr  ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
@@ -3564,12 +3586,12 @@ msgstr  ""
 msgid   "Launching the instance"
 msgstr  ""
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid   "Link detected: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
@@ -4411,11 +4433,11 @@ msgstr  ""
 msgid   "Load balancer description"
 msgstr  ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid   "Load:"
 msgstr  ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -4424,7 +4446,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid   "Log:"
 msgstr  ""
 
@@ -4465,7 +4487,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid   "MAC address"
 msgstr  ""
 
@@ -4474,7 +4496,7 @@ msgstr  ""
 msgid   "MAC address: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid   "MAD: %s (%s)"
 msgstr  ""
@@ -4512,7 +4534,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid   "MTU"
 msgstr  ""
 
@@ -4737,12 +4759,12 @@ msgstr  ""
 msgid   "Manually trigger the generation of a client certificate"
 msgstr  ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid   "Maximum number of VFs: %d"
 msgstr  ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid   "Mdev profiles:"
 msgstr  ""
 
@@ -4771,19 +4793,19 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid   "Memory (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid   "Memory usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid   "Memory:"
 msgstr  ""
 
@@ -4925,12 +4947,12 @@ msgstr  ""
 msgid   "Mode"
 msgstr  ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid   "Model: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid   "Model: %v"
 msgstr  ""
@@ -5030,11 +5052,11 @@ msgstr  ""
 msgid   "NEW: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid   "NIC:"
 msgstr  ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid   "NICs:"
 msgstr  ""
 
@@ -5042,25 +5064,25 @@ msgstr  ""
 msgid   "NO"
 msgstr  ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293 cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302 cmd/incus/info.go:389
 #, c-format
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid   "NVIDIA information:"
 msgstr  ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514 cmd/incus/storage_volume.go:1564
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514 cmd/incus/storage_volume.go:1564
 msgid   "Name"
 msgstr  ""
 
@@ -5119,12 +5141,12 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004 cmd/incus/storage_volume.go:1454
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004 cmd/incus/storage_volume.go:1454
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid   "Name: %v"
 msgstr  ""
@@ -5268,7 +5290,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid   "Network usage:"
 msgstr  ""
 
@@ -5358,7 +5380,7 @@ msgstr  ""
 msgid   "No value found in %q"
 msgstr  ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
@@ -5375,11 +5397,11 @@ msgstr  ""
 msgid   "Number of placement groups"
 msgstr  ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid   "OS"
 msgstr  ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid   "OS Version"
 msgstr  ""
 
@@ -5427,7 +5449,7 @@ msgstr  ""
 msgid   "Open the web interface"
 msgstr  ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid   "Operating System:"
 msgstr  ""
 
@@ -5436,7 +5458,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -5448,16 +5470,16 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid   "PCI address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid   "PCI device:"
 msgstr  ""
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid   "PCI devices:"
 msgstr  ""
 
@@ -5469,7 +5491,7 @@ msgstr  ""
 msgid   "PID"
 msgstr  ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
@@ -5502,19 +5524,19 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid   "Packets sent"
 msgstr  ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid   "Partitions:"
 msgstr  ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -5578,17 +5600,21 @@ msgstr  ""
 msgid   "Port to bind to (default: %d)"
 msgstr  ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid   "Port type: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid   "Ports:"
 msgstr  ""
 
 #: cmd/incus/admin_init.go:58
 msgid   "Pre-seed mode, expects YAML config from stdin"
+msgstr  ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid   "Prepare bug reports"
 msgstr  ""
 
 #: cmd/incus/top.go:447
@@ -5631,7 +5657,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -5641,22 +5667,22 @@ msgstr  ""
 msgid   "Processing aliases failed: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, c-format
 msgid   "Product ID: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid   "Product: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid   "Product: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid   "Product: %v (%v)"
 msgstr  ""
@@ -5825,7 +5851,7 @@ msgstr  ""
 msgid   "ROLES"
 msgstr  ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid   "Read-Only: %v"
 msgstr  ""
@@ -5909,7 +5935,7 @@ msgstr  ""
 msgid   "Remote trust token"
 msgstr  ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid   "Removable: %v"
 msgstr  ""
@@ -6071,9 +6097,13 @@ msgstr  ""
 msgid   "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr  ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid   "Render: %s (%s)"
+msgstr  ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid   "Report a bug"
 msgstr  ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -6084,7 +6114,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid   "Resources:"
 msgstr  ""
 
@@ -6181,7 +6211,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid   "SKU: %v"
 msgstr  ""
@@ -6194,7 +6224,7 @@ msgstr  ""
 msgid   "SOURCE"
 msgstr  ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid   "SR-IOV information:"
 msgstr  ""
 
@@ -6266,17 +6296,17 @@ msgstr  ""
 msgid   "Send a raw query to the server"
 msgstr  ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, c-format
 msgid   "Serial Number: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, c-format
 msgid   "Serial: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid   "Serial: %v"
 msgstr  ""
@@ -6663,7 +6693,7 @@ msgstr  ""
 msgid   "Show instance or server configurations"
 msgstr  ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid   "Show instance or server information"
 msgstr  ""
 
@@ -6671,7 +6701,7 @@ msgstr  ""
 msgid   "Show instance snapshot configuration"
 msgstr  ""
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -6775,6 +6805,10 @@ msgid   "Show storage volume state information\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid   "Show system details to include in bug reports"
+msgstr  ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid   "Show the current project"
 msgstr  ""
@@ -6787,15 +6821,15 @@ msgstr  ""
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 msgid   "Show the instance's access list"
 msgstr  ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid   "Show the instance's recent log entries"
 msgstr  ""
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid   "Show the resources available to the server"
 msgstr  ""
 
@@ -6836,7 +6870,7 @@ msgstr  ""
 msgid   "Size: %.2fMiB"
 msgstr  ""
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid   "Size: %s"
 msgstr  ""
@@ -6853,11 +6887,11 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid   "Snapshots:"
 msgstr  ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
@@ -6883,7 +6917,7 @@ msgstr  ""
 msgid   "Start instances"
 msgstr  ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, c-format
 msgid   "Started: %s"
 msgstr  ""
@@ -6897,7 +6931,7 @@ msgstr  ""
 msgid   "Starting recovery..."
 msgstr  ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid   "State"
 msgstr  ""
 
@@ -6906,11 +6940,11 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid   "Stateful"
 msgstr  ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -7028,21 +7062,21 @@ msgstr  ""
 msgid   "Successfully updated cluster certificates"
 msgstr  ""
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid   "Supported modes: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid   "Swap (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -7058,7 +7092,7 @@ msgstr  ""
 msgid   "Symlink target path can only be used for type \"symlink\""
 msgstr  ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid   "System:"
 msgstr  ""
 
@@ -7078,7 +7112,7 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid   "Taken at"
 msgstr  ""
 
@@ -7329,7 +7363,7 @@ msgstr  ""
 msgid   "The server doesn't have a web UI installed"
 msgstr  ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
@@ -7349,11 +7383,15 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid   "This client hasn't been configured to use a remote server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote server.\n"
         "\n"
         "If you already added a remote server, make it the default with \"incus remote switch NAME\"."
+msgstr  ""
+
+#: cmd/incus/bug.go:233
+msgid   "This command is dedicated to reporting bugs found in Incus. For all support requests and other questions, please ask on our forum, https://discuss.linuxcontainers.org."
 msgstr  ""
 
 #: cmd/incus/webui_windows.go:15
@@ -7372,7 +7410,7 @@ msgstr  ""
 msgid   "This server is not available on the network"
 msgstr  ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid   "Threads:"
 msgstr  ""
 
@@ -7396,13 +7434,13 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid   "To start your first container, try: incus launch images:%s\n"
         "Or for a virtual machine: incus launch images:%s --vm"
 msgstr  ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389 cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -7411,12 +7449,12 @@ msgstr  ""
 msgid   "Total: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538 cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547 cmd/incus/info.go:553
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid   "Transceiver type: %s"
 msgstr  ""
@@ -7465,7 +7503,7 @@ msgstr  ""
 msgid   "Try `incus info --show-log %s%s` for more info"
 msgstr  ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid   "Type"
 msgstr  ""
 
@@ -7481,7 +7519,7 @@ msgstr  ""
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436 cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012 cmd/incus/storage_volume.go:1463
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445 cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012 cmd/incus/storage_volume.go:1463
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -7502,11 +7540,11 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid   "USB device:"
 msgstr  ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid   "USB devices:"
 msgstr  ""
 
@@ -7518,7 +7556,7 @@ msgstr  ""
 msgid   "UUID"
 msgstr  ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid   "UUID: %v"
 msgstr  ""
@@ -7595,7 +7633,7 @@ msgstr  ""
 msgid   "Unset image properties"
 msgstr  ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -7738,11 +7776,11 @@ msgstr  ""
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -7794,7 +7832,7 @@ msgstr  ""
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537 cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546 cmd/incus/info.go:552
 #, c-format
 msgid   "Used: %v"
 msgstr  ""
@@ -7811,7 +7849,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid   "VFs: %d"
 msgstr  ""
@@ -7828,37 +7866,37 @@ msgstr  ""
 msgid   "VLAN:"
 msgstr  ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, c-format
 msgid   "Vendor ID: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, c-format
 msgid   "Vendor: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385 cmd/incus/info.go:421
 #, c-format
 msgid   "Vendor: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid   "Vendor: %v (%v)"
 msgstr  ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid   "Version: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid   "Version: %v"
 msgstr  ""
@@ -7875,7 +7913,7 @@ msgstr  ""
 msgid   "WARNING: The IncusOS API and configuration is subject to change"
 msgstr  ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid   "WWN: %s"
 msgstr  ""
@@ -7907,6 +7945,10 @@ msgid   "We detected that you are running inside an unprivileged container.\n"
         "they otherwise would."
 msgstr  ""
 
+#: cmd/incus/bug.go:298
+msgid   "We will now submit your issue on GitHub. This is your last chance to review it (wording, secret leakage...) before it is published online. Do you want to review it?"
+msgstr  ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid   "Web server running at: %s"
@@ -7922,6 +7964,14 @@ msgstr  ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid   "What IPv6 address should be used?"
+msgstr  ""
+
+#: cmd/incus/bug.go:283
+msgid   "What is the current behavior?"
+msgstr  ""
+
+#: cmd/incus/bug.go:288
+msgid   "What is the expected behavior?"
 msgstr  ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -8053,7 +8103,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464 cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614 cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95 cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416 cmd/incus/network_zone.go:93 cmd/incus/operation.go:116 cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464 cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614 cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95 cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416 cmd/incus/network_zone.go:93 cmd/incus/operation.go:116 cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -8673,11 +8723,11 @@ msgstr  ""
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
@@ -8691,6 +8741,14 @@ msgstr  ""
 
 #: cmd/incus/cluster.go:1031
 msgid   "[[<remote>:]<member>]"
+msgstr  ""
+
+#: cmd/incus/bug.go:288
+msgid   "a concise description of what you expected to happen"
+msgstr  ""
+
+#: cmd/incus/bug.go:283
+msgid   "a concise description of what you're experiencing"
 msgstr  ""
 
 #: cmd/incus/info.go:646
@@ -8749,6 +8807,14 @@ msgstr  ""
 #: cmd/incus/alias.go:176
 msgid   "incus alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
+msgstr  ""
+
+#: cmd/incus/bug.go:179
+msgid   "incus bug report [<remote>:]<instance>\n"
+        "    To report an instance-related bug.\n"
+        "\n"
+        "incus bug report [<remote>:]\n"
+        "    To report a server-related bug."
 msgstr  ""
 
 #: cmd/incus/cluster.go:912
@@ -8872,7 +8938,7 @@ msgid   "incus import backup0.tar.gz\n"
         "    Create a new instance using backup0.tar.gz as the source."
 msgstr  ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid   "incus info [<remote>:]<instance> [--show-log]\n"
         "    For instance information.\n"
         "\n"
@@ -9242,6 +9308,10 @@ msgstr  ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid   "sshfs mounting %q on %q"
+msgstr  ""
+
+#: cmd/incus/bug.go:293
+msgid   "step by step instructions to reproduce the behavior"
 msgstr  ""
 
 #: cmd/incus/storage.go:573

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -18,16 +18,24 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
+msgstr ""
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
@@ -622,7 +630,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -647,7 +655,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
@@ -671,17 +679,17 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partizione %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Porta %d (%s)"
@@ -731,8 +739,8 @@ msgstr ""
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -977,12 +985,12 @@ msgstr ""
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Address: %v"
 msgstr "La periferica esiste già: %s"
@@ -1043,13 +1051,13 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
@@ -1119,7 +1127,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1141,7 +1149,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1178,7 +1186,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr ""
 
@@ -1229,7 +1237,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -1242,16 +1250,16 @@ msgstr ""
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1280,19 +1288,19 @@ msgstr "Utilizzo CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr ""
 
@@ -1305,7 +1313,7 @@ msgstr "CREATO IL"
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
@@ -1315,7 +1323,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr ""
 
@@ -1425,12 +1433,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1473,6 +1481,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1542,16 +1554,17 @@ msgstr ""
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1693,7 +1706,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1778,12 +1791,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr ""
 
@@ -1970,7 +1983,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -1991,7 +2004,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -2025,7 +2038,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -2039,7 +2052,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -2199,6 +2212,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2215,7 +2229,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2241,7 +2255,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2355,7 +2369,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr ""
@@ -2383,7 +2397,7 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Utilizzo disco:"
@@ -2403,7 +2417,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "La periferica esiste già: %s"
@@ -2436,7 +2450,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2465,21 +2479,21 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
@@ -2568,12 +2582,12 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2851,12 +2865,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
@@ -2935,7 +2949,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr ""
@@ -3043,7 +3057,7 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3394,7 +3408,7 @@ msgstr "Accetta certificato"
 msgid "Failed validation request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3546,18 +3560,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3566,11 +3580,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3800,17 +3814,21 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 #, fuzzy
 msgid "Hostname"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3838,12 +3856,12 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3856,7 +3874,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3865,7 +3883,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3905,7 +3923,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4053,7 +4071,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -4061,7 +4079,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
@@ -4222,7 +4240,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -4274,7 +4292,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -4287,7 +4313,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -4318,7 +4344,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -4342,12 +4368,12 @@ msgstr "Creazione di %s in corso"
 msgid "Launching the instance"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architettura: %s"
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -5251,11 +5277,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5264,7 +5290,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -5307,7 +5333,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -5316,7 +5342,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -5354,7 +5380,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5611,12 +5637,12 @@ msgstr "Creazione del container in corso"
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -5645,19 +5671,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5913,12 +5939,12 @@ msgstr "Il nome del container è: %s"
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -6039,11 +6065,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -6054,26 +6080,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -6134,13 +6160,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -6285,7 +6311,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -6376,7 +6402,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6395,11 +6421,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr ""
 
@@ -6449,7 +6475,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6458,7 +6484,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6470,17 +6496,17 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 #, fuzzy
 msgid "PCI device:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 #, fuzzy
 msgid "PCI devices:"
 msgstr "Creazione del container in corso"
@@ -6493,7 +6519,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6530,19 +6556,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -6608,17 +6634,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6674,7 +6704,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6684,22 +6714,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6871,7 +6901,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -6964,7 +6994,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -7143,9 +7173,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -7156,7 +7190,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -7261,7 +7295,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -7274,7 +7308,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -7349,17 +7383,17 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -7799,7 +7833,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7808,7 +7842,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -7930,6 +7964,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -7942,17 +7980,17 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -7994,7 +8032,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -8011,11 +8049,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -8044,7 +8082,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -8058,7 +8096,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -8068,11 +8106,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -8193,21 +8231,21 @@ msgstr "Creazione del container in corso"
 msgid "Successfully updated cluster certificates"
 msgstr "Accetta certificato"
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -8223,7 +8261,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -8248,7 +8286,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -8518,7 +8556,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8539,7 +8577,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8547,6 +8585,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8566,7 +8611,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8590,16 +8635,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8608,13 +8653,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8663,7 +8708,7 @@ msgstr "Password amministratore per %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8682,8 +8727,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8705,12 +8750,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 #, fuzzy
 msgid "USB device:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "USB devices:"
 msgstr "Creazione del container in corso"
@@ -8727,7 +8772,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8821,7 +8866,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -8981,11 +9026,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -9044,8 +9089,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9064,7 +9109,7 @@ msgstr "Il nome del container è: %s"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -9081,38 +9126,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -9129,7 +9174,7 @@ msgstr ""
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -9164,6 +9209,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -9179,6 +9231,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -9326,7 +9386,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -10147,12 +10207,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
@@ -10171,6 +10231,14 @@ msgstr "Creazione del container in corso"
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
+msgstr ""
 
 #: cmd/incus/info.go:646
 msgid "application"
@@ -10235,6 +10303,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -10382,7 +10459,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10829,6 +10906,10 @@ msgstr ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2025-08-09 14:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -18,17 +18,25 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.13-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  筐体:"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  ファームウェア:"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  マザーボード:"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 msgid ""
@@ -610,7 +618,7 @@ msgstr ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d（id: %d, オンライン: %v, NUMA ノード: %v）"
@@ -636,7 +644,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s（他%d個）"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d個使用可能)"
@@ -660,17 +668,17 @@ msgstr "'%s' はサポートされないタイプのファイルです"
 msgid "(none)"
 msgstr "(none)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- レベル %d（タイプ: %s）: %s"
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- パーティション %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- ポート %d（%s）"
@@ -720,8 +728,8 @@ msgstr "--refresh はインスタンスの場合のみ使えます"
 msgid "--target can only be used with clusters"
 msgstr "--target はインスタンスでは使えません"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
@@ -976,12 +984,12 @@ msgstr "バインドするアドレス (デフォルト: none)"
 msgid "Address to bind to (not including port)"
 msgstr "バインドするアドレス (ポートを含まない)"
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Address: %v"
 msgstr "アドレス: %s"
@@ -1041,13 +1049,13 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
@@ -1121,7 +1129,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "オートネゴシエーション: %v"
@@ -1143,7 +1151,7 @@ msgstr "自動（非インタラクティブ）モード"
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "平均: %.2f %.2f %.2f"
@@ -1181,7 +1189,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1234,7 +1242,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr "--all とインスタンス名を両方同時に指定することはできません"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr "ブランド: %v"
@@ -1248,16 +1256,16 @@ msgstr "ブリッジ:"
 msgid "Bucket description"
 msgstr "説明"
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1286,19 +1294,19 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 #, fuzzy
 msgid "CPUs:"
 msgstr "GPUs:"
@@ -1311,7 +1319,7 @@ msgstr "CREATED"
 msgid "CREATED AT"
 msgstr "CREATED AT"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
@@ -1321,7 +1329,7 @@ msgstr "CUDA バージョン: %v"
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr "キャッシュ:"
 
@@ -1437,12 +1445,12 @@ msgstr "スナップショットをコピーするときに --volume-only は指
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "カード: %s (%s)"
@@ -1490,6 +1498,10 @@ msgstr "デーモンが準備できていることを確認しています (試�
 #, c-format
 msgid "Choose %s:"
 msgstr "選択してください %s"
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
+msgstr ""
 
 #: cmd/incus/config_trust.go:150
 #, c-format
@@ -1557,16 +1569,17 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1717,7 +1730,7 @@ msgstr "ストレージボリュームのタイプ、block もしくは filesyst
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
@@ -1818,12 +1831,12 @@ msgstr "イメージのコピー中: %s"
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr "コア %d"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr "コア:"
 
@@ -2004,7 +2017,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -2024,7 +2037,7 @@ msgstr "%s: %%s を作成中"
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
@@ -2058,7 +2071,7 @@ msgstr "DISK USAGE"
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr "DRM:"
 
@@ -2073,7 +2086,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr "%d 秒のタイムアウトが経過しましたが、デーモンがまだ実行中です"
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "状態: %s"
@@ -2227,6 +2240,7 @@ msgstr "警告を削除します"
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2243,7 +2257,7 @@ msgstr "警告を削除します"
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2269,7 +2283,7 @@ msgstr "警告を削除します"
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2383,7 +2397,7 @@ msgstr "警告を削除します"
 msgid "Description"
 msgstr "説明"
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
@@ -2410,7 +2424,7 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "デバイス: %s"
@@ -2430,7 +2444,7 @@ msgstr "デバイス %s が %s で上書きされました"
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "アドレス: %s"
@@ -2466,7 +2480,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "プロファイルのデバイスは個々のインスタンスでは取得できません"
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr "デバイス: %s"
@@ -2498,20 +2512,20 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr "ディスク:"
 
@@ -2622,12 +2636,12 @@ msgstr "進捗情報を表示しません"
 msgid "Down delay"
 msgstr "Down delay"
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "ドライバ: %v (%v)"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
@@ -2919,12 +2933,12 @@ msgstr "プロパティの設定解除エラー: %v"
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr "エイリアスの展開の実行中にエラー発生しました: %s\n"
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr "エラー: %v\n"
@@ -3042,7 +3056,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr "失効日時"
@@ -3154,7 +3168,7 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr "FQDN"
 
@@ -3505,7 +3519,7 @@ msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 msgid "Failed validation request: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "名前: %v"
@@ -3682,18 +3696,18 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "クロック数: %vMhz"
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
@@ -3702,11 +3716,11 @@ msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr "GPU:"
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -3943,16 +3957,20 @@ msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 #, fuzzy
 msgid "Hostname"
 msgstr "名前"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
@@ -3980,12 +3998,12 @@ msgstr "sshfs からインスタンスへの I/O コピーに失敗しました:
 msgid "ID"
 msgstr "ID"
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr "ID: %d"
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
@@ -3998,7 +4016,7 @@ msgstr "IMAGES"
 msgid "INSTANCE NAME"
 msgstr "インスタンス名"
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr "IOMMU グループ: %v"
@@ -4007,7 +4025,7 @@ msgstr "IOMMU グループ: %v"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -4054,7 +4072,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 #, fuzzy
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
@@ -4210,7 +4228,7 @@ msgstr "全てのコマンドを表示します (主なコマンドだけでは�
 msgid "Incus - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
@@ -4218,7 +4236,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
@@ -4383,7 +4401,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -4433,7 +4451,15 @@ msgstr "不正な送り先 %s"
 msgid "Invalid type %q"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr "IsSM: %s (%s)"
@@ -4446,7 +4472,7 @@ msgstr "既存のクラスターに加わるには root 権限が必要です"
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr "サーバのバージョン: %s"
 
@@ -4478,7 +4504,7 @@ msgstr "LISTEN ADDRESS"
 msgid "LOCATION"
 msgstr "LOCATION"
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
@@ -4502,12 +4528,12 @@ msgstr "%s を作成中"
 msgid "Launching the instance"
 msgstr "インスタンスを作成中"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid "Link detected: %v"
 msgstr "リンクを検出: %v"
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
@@ -6093,11 +6119,11 @@ msgstr "バックグラウンド操作の一覧表示、表示、削除を行い
 msgid "Load balancer description"
 msgstr "説明"
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr "負荷:"
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -6106,7 +6132,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr "ログ:"
 
@@ -6148,7 +6174,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -6157,7 +6183,7 @@ msgstr "MAC アドレス"
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
@@ -6196,7 +6222,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr "MTU"
 
@@ -6456,12 +6482,12 @@ msgstr "警告を管理します"
 msgid "Manually trigger the generation of a client certificate"
 msgstr "クライアント証明書の生成を手動でトリガーする"
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr "VF の最大数: %d"
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
@@ -6490,19 +6516,19 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr "メモリ:"
 
@@ -6746,12 +6772,12 @@ msgstr "作成するネットワーク名を指定する必要があります"
 msgid "Mode"
 msgstr "モード"
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr "モデル: %s"
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr "モデル: %v"
@@ -6892,11 +6918,11 @@ msgstr "NETWORKS"
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr "新規: %q (バックエンド=%q, ソース=%q)"
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr "NIC:"
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr "NICs:"
 
@@ -6907,26 +6933,26 @@ msgstr "NICs:"
 msgid "NO"
 msgstr "NO"
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr "NVIDIA 情報:"
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr "名前"
@@ -6991,13 +7017,13 @@ msgstr "使用するストレージバックエンド名 (%s)"
 msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr "名前: %v"
@@ -7148,7 +7174,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -7242,7 +7268,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
@@ -7264,11 +7290,11 @@ msgstr "配置するグループの数"
 msgid "Number of placement groups"
 msgstr "配置するグループの数"
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr "OS"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 #, fuzzy
 msgid "OS Version"
 msgstr "CUDA バージョン: %v"
@@ -7322,7 +7348,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "ホストインターフェース"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Operating System:"
 msgstr "バックグラウンド操作 %s を削除しました"
@@ -7332,7 +7358,7 @@ msgstr "バックグラウンド操作 %s を削除しました"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -7344,17 +7370,17 @@ msgstr "プロジェクトを指定します"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "ターミナルモードを上書きします (auto, interactive, non-interactive)"
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 #, fuzzy
 msgid "PCI device:"
 msgstr "device"
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 #, fuzzy
 msgid "PCI devices:"
 msgstr "上位デバイス"
@@ -7367,7 +7393,7 @@ msgstr "PEER"
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
@@ -7405,19 +7431,19 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr "送信パケット"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -7483,18 +7509,22 @@ msgstr "バインドするポート"
 msgid "Port to bind to (default: %d)"
 msgstr "バインドするポート (デフォルト: %d)"
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr "ポートタイプ: %s"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr "ポート:"
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr "Pre-seed モード。標準入力から YAML で設定を入力します"
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
+msgstr ""
 
 #: cmd/incus/top.go:447
 msgid "Press 'd' + ENTER to change delay"
@@ -7551,7 +7581,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -7561,22 +7591,22 @@ msgstr "プロセス数: %d"
 msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s"
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
@@ -7747,7 +7777,7 @@ msgstr "ROLE"
 msgid "ROLES"
 msgstr "ROLES"
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
@@ -7850,7 +7880,7 @@ msgstr "リモート名にコロンを含めることはできません"
 msgid "Remote trust token"
 msgstr "信頼済みクライアントを削除します"
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr "リムーバブルディスク: %v"
@@ -8025,10 +8055,14 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
+msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
 msgid "Request a join token for adding a cluster member"
@@ -8038,7 +8072,7 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -8144,7 +8178,7 @@ msgstr "SEVERITY"
 msgid "SIZE"
 msgstr "SIZE"
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "UUID: %v"
@@ -8157,7 +8191,7 @@ msgstr "SNAPSHOTS"
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
@@ -8234,17 +8268,17 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to the server"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "合計: %v"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "合計: %v"
@@ -8765,7 +8799,7 @@ msgstr "インスタンスのメタデータファイルを表示します"
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
@@ -8774,7 +8808,7 @@ msgstr "インスタンスもしくはサーバの情報を表示します"
 msgid "Show instance snapshot configuration"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -8896,6 +8930,10 @@ msgstr ""
 "サポートされているタイプの値は \"custom\", \"container\", \"virtual-"
 "machine\" です。"
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 #, fuzzy
 msgid "Show the current project"
@@ -8909,17 +8947,17 @@ msgstr "デフォルトのリモートを表示します"
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
@@ -8960,7 +8998,7 @@ msgstr "新しい loop デバイスのサイズ (GiB)"
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr "サイズ: %s"
@@ -8978,11 +9016,11 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
@@ -9012,7 +9050,7 @@ msgstr "取得元:"
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "状態: %s"
@@ -9026,7 +9064,7 @@ msgstr "%s を起動中"
 msgid "Starting recovery..."
 msgstr "リカバリーを開始します..."
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr "状態"
 
@@ -9035,11 +9073,11 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -9161,21 +9199,21 @@ msgstr "インスタンスの状態を保存します"
 msgid "Successfully updated cluster certificates"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr "サポートするモード: %s"
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -9191,7 +9229,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr "シンボリックリンクのターゲットパスは \"symlink\" タイプにのみ使えます"
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr "システム:"
 
@@ -9216,7 +9254,7 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -9527,7 +9565,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr "サーバーに Web UI がインストールされていません"
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
@@ -9550,7 +9588,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 #, fuzzy
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
@@ -9569,6 +9607,13 @@ msgstr ""
 "うにデフォルトを設定してください。\n"
 "仮想マシン上にローカルな LXD サーバを簡単にセットアップするには、https://"
 "multipass.run の使用を検討してください。"
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
+msgstr ""
 
 #: cmd/incus/webui_windows.go:15
 #, fuzzy
@@ -9589,7 +9634,7 @@ msgstr "LXD サーバはすでにクラスターに属しています"
 msgid "This server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr "スレッド:"
 
@@ -9618,7 +9663,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, fuzzy, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
@@ -9628,9 +9673,9 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスターに属していなければ"
@@ -9641,13 +9686,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
@@ -9696,7 +9741,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr "タイプ"
 
@@ -9716,8 +9761,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr "ピアのタイプ（localまたはremote）"
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -9739,12 +9784,12 @@ msgstr "URL"
 msgid "USAGE"
 msgstr "USAGE"
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 #, fuzzy
 msgid "USB device:"
 msgstr "device"
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "USB devices:"
 msgstr "上位デバイス"
@@ -9761,7 +9806,7 @@ msgstr "USED BY"
 msgid "UUID"
 msgstr "UUID"
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr "UUID: %v"
@@ -9853,7 +9898,7 @@ msgstr "デバイスの設定を削除します"
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -10017,11 +10062,11 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr "インスタンスプロパティの設定を削除します"
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -10085,8 +10130,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
@@ -10105,7 +10150,7 @@ msgstr "ユーザが削除操作を中断しました"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr "VFs: %d"
@@ -10122,38 +10167,38 @@ msgstr "VLAN フィルタリング"
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr "ベンダ: %v (%v)"
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"
@@ -10171,7 +10216,7 @@ msgstr "説明"
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr "WWN: %s"
@@ -10219,6 +10264,13 @@ msgstr ""
 "ると理論的には、そうしない場合に比べて、親コンテナを攻撃してより多くの\n"
 "特権を得られる可能性があるため、安全性は若干低くなります。"
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -10237,6 +10289,14 @@ msgstr "どの IPv4 アドレスを使いますか?"
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr "どの IPv6 アドレスを使いますか?"
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
+msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
@@ -10389,7 +10449,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -11105,11 +11165,11 @@ msgstr "[<remote>:]<zone> <record> [key=value...]"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
@@ -11124,6 +11184,14 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 #: cmd/incus/cluster.go:1031
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
+msgstr ""
 
 #: cmd/incus/info.go:646
 #, fuzzy
@@ -11206,6 +11274,21 @@ msgid ""
 msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
+
+#: cmd/incus/bug.go:179
+#, fuzzy
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
+msgstr ""
+"lxc info [<remote>:]<instance> [--show-log]\n"
+"    インスタンスの情報を表示します。\n"
+"\n"
+"lxc info [<remote>:] [--resources]\n"
+"    LXD サーバの情報を表示します。"
 
 #: cmd/incus/cluster.go:912
 #, fuzzy
@@ -11434,7 +11517,7 @@ msgstr ""
 "lxc import backup0.tar.gz\n"
 "    backup0.tar.gz を使って新しいインスタンスを作成します。"
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 #, fuzzy
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
@@ -12105,6 +12188,10 @@ msgstr "sshfs が停止しました"
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
+msgstr ""
 
 #: cmd/incus/storage.go:573
 msgid "total space"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -19,17 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  Fastvare:"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  Hovedkort:"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 msgid ""
@@ -375,7 +383,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -400,7 +408,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
@@ -424,17 +432,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -483,8 +491,8 @@ msgstr ""
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -719,12 +727,12 @@ msgstr ""
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr ""
@@ -784,13 +792,13 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -857,7 +865,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -879,7 +887,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -916,7 +924,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr ""
 
@@ -967,7 +975,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -980,16 +988,16 @@ msgstr ""
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr ""
 
@@ -1017,19 +1025,19 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr ""
 
@@ -1041,7 +1049,7 @@ msgstr ""
 msgid "CREATED AT"
 msgstr ""
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
@@ -1051,7 +1059,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr ""
 
@@ -1161,12 +1169,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1209,6 +1217,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1276,16 +1288,17 @@ msgstr ""
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1426,7 +1439,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1510,12 +1523,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr ""
 
@@ -1690,7 +1703,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -1710,7 +1723,7 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -1744,7 +1757,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -1758,7 +1771,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1905,6 +1918,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -1921,7 +1935,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -1947,7 +1961,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2061,7 +2075,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr ""
@@ -2086,7 +2100,7 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2106,7 +2120,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
@@ -2138,7 +2152,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2167,20 +2181,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr ""
 
@@ -2262,12 +2276,12 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Driver: %v"
 msgstr ""
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2536,12 +2550,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
@@ -2619,7 +2633,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr ""
@@ -2720,7 +2734,7 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3071,7 +3085,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3221,18 +3235,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3241,11 +3255,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3457,16 +3471,20 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 #, fuzzy
 msgid "Hostname"
 msgstr "navn"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3494,12 +3512,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3512,7 +3530,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3521,7 +3539,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3561,7 +3579,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3703,7 +3721,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -3711,7 +3729,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr ""
 
@@ -3868,7 +3886,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3915,7 +3933,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3928,7 +3954,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -3959,7 +3985,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3982,12 +4008,12 @@ msgstr ""
 msgid "Launching the instance"
 msgstr ""
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -4869,11 +4895,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4882,7 +4908,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -4923,7 +4949,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -4932,7 +4958,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -4970,7 +4996,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5202,12 +5228,12 @@ msgstr ""
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -5236,19 +5262,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5484,12 +5510,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -5606,11 +5632,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -5621,26 +5647,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -5701,13 +5727,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -5852,7 +5878,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -5943,7 +5969,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5962,11 +5988,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr ""
 
@@ -6015,7 +6041,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6024,7 +6050,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6036,16 +6062,16 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid "PCI devices:"
 msgstr ""
 
@@ -6057,7 +6083,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6094,19 +6120,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6170,17 +6196,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6235,7 +6265,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6245,22 +6275,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6429,7 +6459,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -6520,7 +6550,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -6686,9 +6716,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -6699,7 +6733,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -6797,7 +6831,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6810,7 +6844,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -6884,17 +6918,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -7315,7 +7349,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7323,7 +7357,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -7433,6 +7467,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -7445,15 +7483,15 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -7494,7 +7532,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -7511,11 +7549,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7543,7 +7581,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, c-format
 msgid "Started: %s"
 msgstr ""
@@ -7557,7 +7595,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr ""
 
@@ -7566,11 +7604,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7689,21 +7727,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7719,7 +7757,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -7744,7 +7782,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8012,7 +8050,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8033,7 +8071,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8041,6 +8079,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8059,7 +8104,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8083,16 +8128,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8101,13 +8146,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8156,7 +8201,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8174,8 +8219,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8197,11 +8242,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid "USB devices:"
 msgstr ""
 
@@ -8217,7 +8262,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8307,7 +8352,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -8452,11 +8497,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8513,8 +8558,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8532,7 +8577,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -8549,38 +8594,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -8597,7 +8642,7 @@ msgstr ""
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -8632,6 +8677,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -8647,6 +8699,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -8787,7 +8847,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -9455,11 +9515,11 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -9473,6 +9533,14 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1031
 msgid "[[<remote>:]<member>]"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
 msgstr ""
 
 #: cmd/incus/info.go:646
@@ -9538,6 +9606,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -9685,7 +9762,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10131,6 +10208,10 @@ msgstr "sshfs har stoppet"
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 "
 "<nlincus@users.noreply.hosted.weblate.org>\n"
@@ -19,17 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  Chassis:"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  Firmware:"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  Moederboord:"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 msgid ""
@@ -637,7 +645,7 @@ msgstr ""
 "### Dit is een YAML weergave van een clusterlid (cluster member).\n"
 "### Elke regel beginnende met '#' zal worden genegeerd."
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
@@ -662,7 +670,7 @@ msgstr "%s %q van pool %q in project %q (bevat %d snapshots)"
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d beschikbaar)"
@@ -686,17 +694,17 @@ msgstr "'%s' is geen ondersteund bestandstype"
 msgid "(none)"
 msgstr "(geen)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Level %d (type: %s): %s"
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
@@ -751,8 +759,8 @@ msgstr "--refresh kan alleen worden gebruikt bij geïnstantieerden (instances)"
 msgid "--target can only be used with clusters"
 msgstr "--target kan alleen gebruikt worden met clusters"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr "--target kan niet gebruikt worden met: instances"
 
@@ -1002,12 +1010,12 @@ msgstr "Adres (Address) om aan te verbinden (bind) (standaard: geen)"
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr "Adres: %s"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr "Adres: %v"
@@ -1069,13 +1077,13 @@ msgstr "Alle server adressen zijn onbeschikbaar"
 msgid "Alternative certificate name"
 msgstr "Alternatieve certificaat naam"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architectuur: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "Architectuur: %v"
@@ -1149,7 +1157,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1171,7 +1179,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1208,7 +1216,7 @@ msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1259,7 +1267,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr "Beide --all en instantiatie naam (instance name) zijn gegeven"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr "Merk (Brand): %v"
@@ -1272,16 +1280,16 @@ msgstr "Brug (Bridge):"
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Bus Adres: %v"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
@@ -1309,19 +1317,19 @@ msgstr "CPU TIJD(s)"
 msgid "CPU USAGE"
 msgstr "CPU GEBRUIK"
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "CPU gebruik (in seconde)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "CPU gebruik:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr "CPUs:"
 
@@ -1333,7 +1341,7 @@ msgstr "GECREËERD"
 msgid "CREATED AT"
 msgstr "GECREËERD OM"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA Versie: %v"
@@ -1343,7 +1351,7 @@ msgstr "CUDA Versie: %v"
 msgid "Cached: %s"
 msgstr "Cached: %s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr "Caches:"
 
@@ -1455,12 +1463,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1503,6 +1511,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1570,16 +1582,17 @@ msgstr ""
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1729,7 +1742,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1813,12 +1826,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr ""
 
@@ -1994,7 +2007,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -2014,7 +2027,7 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -2048,7 +2061,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -2062,7 +2075,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, c-format
 msgid "Date: %s"
 msgstr "Datum: %s"
@@ -2210,6 +2223,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2226,7 +2240,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2252,7 +2266,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2366,7 +2380,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr ""
@@ -2391,7 +2405,7 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, c-format
 msgid "Device %d:"
 msgstr "Device: %d:"
@@ -2411,7 +2425,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid "Device Address: %v"
 msgstr "Device Adres: %v"
@@ -2443,7 +2457,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2472,20 +2486,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr ""
 
@@ -2567,12 +2581,12 @@ msgstr "Toon geen voortgang indicator/informatie"
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Driver: %v"
 msgstr "Stuurprogramma: %v"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "Stuurprogramma: %v (%v)"
@@ -2843,12 +2857,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr ""
@@ -3029,7 +3043,7 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3380,7 +3394,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3530,18 +3544,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3550,11 +3564,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3767,15 +3781,19 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3803,12 +3821,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3821,7 +3839,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3830,7 +3848,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3870,7 +3888,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4012,7 +4030,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -4020,7 +4038,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr ""
 
@@ -4177,7 +4195,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4224,7 +4242,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -4237,7 +4263,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -4268,7 +4294,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4291,12 +4317,12 @@ msgstr ""
 msgid "Launching the instance"
 msgstr ""
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -5180,11 +5206,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5193,7 +5219,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -5234,7 +5260,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -5243,7 +5269,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -5281,7 +5307,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5515,12 +5541,12 @@ msgstr ""
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -5549,19 +5575,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5802,12 +5828,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -5925,11 +5951,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -5940,26 +5966,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -6020,13 +6046,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -6171,7 +6197,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -6262,7 +6288,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6281,11 +6307,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr "OS Versie"
 
@@ -6334,7 +6360,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6343,7 +6369,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6355,16 +6381,16 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid "PCI devices:"
 msgstr ""
 
@@ -6376,7 +6402,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6413,19 +6439,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6489,17 +6515,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6555,7 +6585,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6565,22 +6595,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, c-format
 msgid "Product ID: %v"
 msgstr "Product Id: %v"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr "Product: %v"
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6749,7 +6779,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -6840,7 +6870,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -7007,9 +7037,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -7020,7 +7054,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -7118,7 +7152,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -7131,7 +7165,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -7205,17 +7239,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, c-format
 msgid "Serial Number: %v"
 msgstr "Serie Nummer: %v"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, c-format
 msgid "Serial: %s"
 msgstr "Serienummer: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr "Serienummer: %v"
@@ -7644,7 +7678,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7652,7 +7686,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -7763,6 +7797,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -7775,15 +7813,15 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -7824,7 +7862,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -7841,11 +7879,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7873,7 +7911,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, c-format
 msgid "Started: %s"
 msgstr "Gestart: %s"
@@ -7887,7 +7925,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr ""
 
@@ -7896,11 +7934,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -8019,21 +8057,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -8049,7 +8087,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -8074,7 +8112,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8342,7 +8380,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8363,7 +8401,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8371,6 +8409,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8389,7 +8434,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8413,16 +8458,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8431,13 +8476,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8486,7 +8531,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8504,8 +8549,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8527,11 +8572,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid "USB devices:"
 msgstr ""
 
@@ -8547,7 +8592,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8637,7 +8682,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -8785,11 +8830,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8846,8 +8891,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8865,7 +8910,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -8882,38 +8927,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, c-format
 msgid "Vendor ID: %v"
 msgstr "Maker ID: %v"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, c-format
 msgid "Vendor: %s"
 msgstr "Maker: %s"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr "Versie: %s"
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr "Versie: %v"
@@ -8930,7 +8975,7 @@ msgstr ""
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -8965,6 +9010,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -8980,6 +9032,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -9120,7 +9180,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -9788,11 +9848,11 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -9806,6 +9866,14 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1031
 msgid "[[<remote>:]<member>]"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
 msgstr ""
 
 #: cmd/incus/info.go:646
@@ -9871,6 +9939,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -10018,7 +10095,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10472,6 +10549,10 @@ msgstr "sshfs is gestopt"
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs koppelen van %q op %q"
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
+msgstr ""
 
 #: cmd/incus/storage.go:573
 msgid "total space"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2025-10-07 23:02+0000\n"
 "Last-Translator: Américo Monteiro <a_monteiro@gmx.com>\n"
-"Language-Team: Portuguese <https://hosted.weblate.org/projects/incus/cli/pt/>"
-"\n"
+"Language-Team: Portuguese <https://hosted.weblate.org/projects/incus/cli/pt/"
+">\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,17 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.14-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  Chassis:"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  Firmware:"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  Placa principal:"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 msgid ""
@@ -627,7 +635,7 @@ msgstr ""
 "### Esta é uma representação yaml do membro de agrupamento.\n"
 "### Qualquer linha começada com '# é ignorada."
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, nó NUMA: %v)"
@@ -652,7 +660,7 @@ msgstr "%s %q em pool %q em projeto %q (inclui %d instantâneos)"
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d disponível)"
@@ -676,17 +684,17 @@ msgstr "'%s' não é um tipo de ficheiro suportado"
 msgid "(none)"
 msgstr "(nenhum)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Nível %d (tipo: %s): %s"
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partição %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Porto %d (%s)"
@@ -736,8 +744,8 @@ msgstr "--refresh só pode ser usado com instâncias"
 msgid "--target can only be used with clusters"
 msgstr "--target só pode ser usado com agrupamentos"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr "--target não pode ser usado com instâncias"
 
@@ -992,12 +1000,12 @@ msgstr "Endereço a onde unir (predefinido: nenhum)"
 msgid "Address to bind to (not including port)"
 msgstr "Endereço a onde unir (não incluindo o porto)"
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr "Endereço: %s"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr "Endereço: %v"
@@ -1059,13 +1067,13 @@ msgstr "Todos os endereços do servidor não estão disponíveis"
 msgid "Alternative certificate name"
 msgstr "Nome de certificado alternativo"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
@@ -1140,7 +1148,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportado pelo servidor"
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "Negociação automática: %v"
@@ -1162,7 +1170,7 @@ msgstr "Modo automático (não interativo)"
 msgid "Available projects:"
 msgstr "Projetos disponíveis:"
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "Média: %.2f %.2f %.2f"
@@ -1199,7 +1207,7 @@ msgstr "A salvaguardar volume de armazenamento: %s"
 msgid "Backup exported successfully!"
 msgstr "Salvaguarda exportada com sucesso!"
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr "Salvaguardas:"
 
@@ -1252,7 +1260,7 @@ msgstr "Número de arranque"
 msgid "Both --all and instance name given"
 msgstr "Ambos --tudo e nome de instância dado"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr "Marca: %v"
@@ -1265,16 +1273,16 @@ msgstr "Ponte:"
 msgid "Bucket description"
 msgstr "Descrição de bucket"
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Endereço de barramento: %v"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Bytes recebidos"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1302,19 +1310,19 @@ msgstr "TEMPO(s) da CPU"
 msgid "CPU USAGE"
 msgstr "UTILIZAÇÃO da CPU"
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "Utilização da CPU (em segundos)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "Utilização da CPU:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr "CPUs:"
 
@@ -1326,7 +1334,7 @@ msgstr "CRIADO"
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA Versão: %v"
@@ -1336,7 +1344,7 @@ msgstr "CUDA Versão: %v"
 msgid "Cached: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr "Caches:"
 
@@ -1451,12 +1459,12 @@ msgstr "Não pode definir --volume-only quando copia um instantâneo"
 msgid "Cannot set key: %s"
 msgstr "Não pode definir a chave: %s"
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "Cartão: %s (%s)"
@@ -1504,6 +1512,10 @@ msgstr "A verificar se o daemon está pronto (tentativa %d)"
 #, c-format
 msgid "Choose %s:"
 msgstr "Escolher %s:"
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
+msgstr ""
 
 #: cmd/incus/config_trust.go:150
 #, c-format
@@ -1570,16 +1582,17 @@ msgstr "Membro do agrupamento %s removido do grupo %s"
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1730,7 +1743,7 @@ msgstr "Tipo de conteúdo, bloco ou sistema de ficheiros"
 msgid "Content type: %s"
 msgstr "Tipo de conteúdo: %s"
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "Controle: %s (%s)"
@@ -1832,12 +1845,12 @@ msgstr "A copiar a imagem: %s"
 msgid "Copying the storage volume: %s"
 msgstr "A copiar o volume de armazenamento: %s"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr "Núcleo %d"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr "Núcleos:"
 
@@ -2018,7 +2031,7 @@ msgstr "Criar pools de armazenamento"
 msgid "Create the instance with no profiles applied"
 msgstr "Criar a instância sem perfis aplicados"
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -2038,7 +2051,7 @@ msgstr "A criar %s: %%s"
 msgid "Creating the instance"
 msgstr "A criar a instância"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "Número atual de VFs: %d"
@@ -2072,7 +2085,7 @@ msgstr "UTILIZAÇÃO DO DISCO"
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr "DRM:"
 
@@ -2086,7 +2099,7 @@ msgstr "Daemon ainda não a correr após %ds tempo limite (%v)"
 msgid "Daemon still running after %ds timeout"
 msgstr "Daemon ainda a correr após o tempo limite %d"
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, c-format
 msgid "Date: %s"
 msgstr "Data: %s"
@@ -2233,6 +2246,7 @@ msgstr "Apaga aviso"
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2249,7 +2263,7 @@ msgstr "Apaga aviso"
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2275,7 +2289,7 @@ msgstr "Apaga aviso"
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2389,7 +2403,7 @@ msgstr "Apaga aviso"
 msgid "Description"
 msgstr "Descrição"
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr "Descrição: %s"
@@ -2414,7 +2428,7 @@ msgstr "Desacopla interfaces de rede de instâncias"
 msgid "Detach network interfaces from profiles"
 msgstr "Desacopla interfaces de rede de perfis"
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, c-format
 msgid "Device %d:"
 msgstr "Dispositivo %d:"
@@ -2434,7 +2448,7 @@ msgstr "Dispositivo %s sobreposto por %s"
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid "Device Address: %v"
 msgstr "Endereço do Dispositivo: %v"
@@ -2471,7 +2485,7 @@ msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 "O dispositivo do perfil(s) não pode ser recuperado para instância individual"
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
@@ -2500,20 +2514,20 @@ msgstr "Desativa alocação pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desativa stdin (lê de /dev/null)"
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "Utilização do disco:"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr "Disco:"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr "Discos:"
 
@@ -2615,12 +2629,12 @@ msgstr "Não mostra informações de progresso"
 msgid "Down delay"
 msgstr "Atraso em baixo"
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Driver: %v"
 msgstr "Driver: %v"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "Driver: %v (%v)"
@@ -2911,12 +2925,12 @@ msgstr "Erro ao remover definição: %v"
 msgid "Error updating template file: %s"
 msgstr "Erro ao atualizar ficheiro modelo: %s"
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr "Erro ao executar a expansão de alias: %s\n"
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr "Erro: %v\n"
@@ -3045,7 +3059,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Esperado uma estrutura, obtido %v"
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr "Expira em"
@@ -3154,7 +3168,7 @@ msgstr "IMPRESSÃO DIGITAL"
 msgid "FIRST SEEN"
 msgstr "VISTO PRIMEIRO"
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr "FQDN"
 
@@ -3510,7 +3524,7 @@ msgstr "Falhou ao escrever ficheiro de cerificado de servidor %q: %w"
 msgid "Failed validation request: %w"
 msgstr "Falhou ao requisitar validação: %w"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr "Família: %v"
@@ -3687,18 +3701,18 @@ msgstr "Atraso de encaminhamento"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "Encontrado alias %q a referenciar um argumento fora do número dado"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr "Livre: %v"
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "Frequência: %vMhz"
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "Frequência: %vMhz (min: %vMhz, max: %vMhz)"
@@ -3707,11 +3721,11 @@ msgstr "Frequência: %vMhz (min: %vMhz, max: %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr "GPU:"
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -3937,15 +3951,19 @@ msgstr "ID de grupo para correr o comando como (predefinição 0)"
 msgid "HOSTNAME"
 msgstr "NOME DE MÁQUINA"
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr "Interface de máquina"
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 msgid "Hostname"
 msgstr "Nome de máquina"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
@@ -3973,12 +3991,12 @@ msgstr "I/O cópia de sshfs para instância falhou: %v"
 msgid "ID"
 msgstr "ID"
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr "ID: %d"
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
@@ -3991,7 +4009,7 @@ msgstr "IMAGENS"
 msgid "INSTANCE NAME"
 msgstr "NOME DE INSTÂNCIA"
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr "Grupo IOMMU: %v"
@@ -4000,7 +4018,7 @@ msgstr "Grupo IOMMU: %v"
 msgid "IP ADDRESS"
 msgstr "ENDEREÇO IP"
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr "Endereços IP"
 
@@ -4040,7 +4058,7 @@ msgstr "Se o alias da imagem já existir, apaga e cria um novo"
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr "Se o nome do instantâneo já existir, apaga e cria um novo"
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4189,7 +4207,7 @@ msgstr "Incluir comandos menos comuns"
 msgid "Incus - Command line client"
 msgstr "Incus - Cliente de linha de comandos"
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
@@ -4197,7 +4215,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "Dados de entrada"
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr "Apenas Instância"
 
@@ -4358,7 +4376,7 @@ msgid ""
 msgstr ""
 "Nome inválido em '%s', string vazia só é permitida ao definir Largura máxima"
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr "Número inválido de argumentos"
 
@@ -4405,7 +4423,15 @@ msgstr "Alvo inválido %s"
 msgid "Invalid type %q"
 msgstr "Tipo inválido %q"
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr "IsSM: %s (%s)"
@@ -4418,7 +4444,7 @@ msgstr "A adesão a um agrupamento existente requer privilégios de root"
 msgid "Keep the image up to date after initial copy"
 msgstr "Manter a imagem atualizada após a cópia inicial"
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr "Versão do kernel"
 
@@ -4449,7 +4475,7 @@ msgstr "ENDEREÇO DE ESCUTA"
 msgid "LOCATION"
 msgstr "LOCALIZAÇÃO"
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid "Last Used: %s"
 msgstr "Última vez Usado: %s"
@@ -4472,12 +4498,12 @@ msgstr "A lançar %s"
 msgid "Launching the instance"
 msgstr "A lançar a instância"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid "Link detected: %v"
 msgstr "Link detectado: %v"
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "Velocidade do Link: %dMbit/s (%s duplex)"
@@ -6021,11 +6047,11 @@ msgstr "Lista, mostra e apaga operações dos bastidores"
 msgid "Load balancer description"
 msgstr "Carrega descrição do balanceador"
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr "Carga:"
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr "Localização: %s"
@@ -6035,7 +6061,7 @@ msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 "Filtragem de nível de relatório só pode ser usada com formatação bonita"
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr "Relatório:"
 
@@ -6078,7 +6104,7 @@ msgstr "Dispositivos baixos"
 msgid "MAC ADDRESS"
 msgstr "ENDEREÇO MAC"
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr "Endereço MAC"
 
@@ -6087,7 +6113,7 @@ msgstr "Endereço MAC"
 msgid "MAC address: %s"
 msgstr "Endereço MAC: %s"
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
@@ -6125,7 +6151,7 @@ msgstr "Frequência MII"
 msgid "MII state"
 msgstr "Estado MII"
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr "MTU"
 
@@ -6380,12 +6406,12 @@ msgstr "Gerir avisos"
 msgid "Manually trigger the generation of a client certificate"
 msgstr "Acionar manualmente a geração de um certificado de cliente"
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr "Número máximo de VFs: %d"
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr "Perfil de Mdev:"
 
@@ -6414,19 +6440,19 @@ msgstr "Membro %s removido"
 msgid "Member %s renamed to %s"
 msgstr "Membro %s renomeado para %s"
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr "Memória (atual)"
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr "Memória (pico)"
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr "Utilização de memória:"
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr "Memória:"
 
@@ -6664,12 +6690,12 @@ msgstr "Rede alvo ou integração em falta"
 msgid "Mode"
 msgstr "Modo"
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr "Modelo: %s"
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr "Modelo: %v"
@@ -6802,11 +6828,11 @@ msgstr "REDES"
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr "NOVO: %q (backend=%q, source=%q)"
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr "NIC:"
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr "NICs:"
 
@@ -6817,26 +6843,26 @@ msgstr "NICs:"
 msgid "NO"
 msgstr "NÃO"
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr "nó NUMA: %v"
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr "nós NUMA:\n"
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr "Informação da NVIDIA:"
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr "Versão NVRM: %v"
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr "Nome"
@@ -6897,13 +6923,13 @@ msgstr "Nome do backend de armazenamento a usar (%s)"
 msgid "Name of the storage pool:"
 msgstr "Nome da pool de armazenamento:"
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr "Nome: %s"
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr "Nome: %v"
@@ -7049,7 +7075,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Tipo de rede"
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr "Utilização de rede:"
 
@@ -7145,7 +7171,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "Nenhum valor encontrado em %q"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr "Nó %d:\n"
@@ -7166,11 +7192,11 @@ msgstr "Número de entradas"
 msgid "Number of placement groups"
 msgstr "Número de grupos de colocação"
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr "OS"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr "Versão do OS"
 
@@ -7221,7 +7247,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Abrir a interface web"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr "Sistema Operativo:"
 
@@ -7230,7 +7256,7 @@ msgstr "Sistema Operativo:"
 msgid "Operation %s deleted"
 msgstr "Operação %s apagada"
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr "Armazenamento Otimizado"
 
@@ -7242,16 +7268,16 @@ msgstr "Sobrepor o projeto fonte"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Sobrepor o modo do terminal (auto, interativo ou não interativo)"
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr "Endereço PCI: %v"
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid "PCI device:"
 msgstr "Dispositivo PCI:"
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid "PCI devices:"
 msgstr "Dispositivos PCI:"
 
@@ -7263,7 +7289,7 @@ msgstr "PEER"
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
@@ -7300,19 +7326,19 @@ msgstr "PROTOCOLO"
 msgid "PUBLIC"
 msgstr "PÚBLICO"
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr "Pacotes recebidos"
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr "Pacotes enviados"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr "Partições:"
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr "Palavra passe para %s : "
@@ -7377,18 +7403,22 @@ msgstr "Porto a onde unir"
 msgid "Port to bind to (default: %d)"
 msgstr "Porto a onde unir (predefinição: %d)"
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr "Tipo de porto: %s"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr "Portos:"
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr "Modo pre-seed, espera configuração YAML a partir do stdin"
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
+msgstr ""
 
 #: cmd/incus/top.go:447
 msgid "Press 'd' + ENTER to change delay"
@@ -7444,7 +7474,7 @@ msgstr "Escreve a resposta crua"
 msgid "Print version number"
 msgstr "Escreve número da versão"
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr "Processos: %d"
@@ -7454,22 +7484,22 @@ msgstr "Processos: %d"
 msgid "Processing aliases failed: %s"
 msgstr "Processamento de aliases falhou: %s"
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, c-format
 msgid "Product ID: %v"
 msgstr "ID do Produto: %v"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid "Product: %s"
 msgstr "Produto: %s"
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr "Produto: %v"
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr "Produto: %v (%v)"
@@ -7638,7 +7668,7 @@ msgstr "FUNÇÃO"
 msgid "ROLES"
 msgstr "FUNÇÕES"
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr "Só-Leitura: %v"
@@ -7740,7 +7770,7 @@ msgstr "Nomes remotos podem não conter dois pontos"
 msgid "Remote trust token"
 msgstr "Testemunho de confiança de remoto"
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr "Removível: %v"
@@ -7908,10 +7938,14 @@ msgstr "A renomear volume de armazenamento de \"%s\" para \"%s\""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Instantâneo de volume de armazenamento renomeado de \"%s\" para \"%s\""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
 msgstr "Renderização: %s (%s)"
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
+msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
 msgid "Request a join token for adding a cluster member"
@@ -7922,7 +7956,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requer confirmação do utilizador"
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr "Recursos:"
 
@@ -8023,7 +8057,7 @@ msgstr "GRAVIDADE"
 msgid "SIZE"
 msgstr "TAMANHO"
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr "SKU: %v"
@@ -8036,7 +8070,7 @@ msgstr "INSTANTÂNEOS"
 msgid "SOURCE"
 msgstr "FONTE"
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr "Informação de SR-IOV:"
 
@@ -8110,17 +8144,17 @@ msgstr "Chave secreta: %s"
 msgid "Send a raw query to the server"
 msgstr "Envia uma consulta em cru para o servidor"
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, c-format
 msgid "Serial Number: %v"
 msgstr "Número de Série: %v"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, c-format
 msgid "Serial: %s"
 msgstr "Série: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr "Série: %v"
@@ -8623,7 +8657,7 @@ msgstr "Mostra ficheiros de metadados de instância"
 msgid "Show instance or server configurations"
 msgstr "Mostra configurações de instância ou servidor"
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr "Mostra informações de instância ou servidor"
 
@@ -8631,7 +8665,7 @@ msgstr "Mostra informações de instância ou servidor"
 msgid "Show instance snapshot configuration"
 msgstr "Mostra configuração de instantâneo de instância"
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr "Mostra comandos menos comuns"
 
@@ -8754,6 +8788,10 @@ msgstr ""
 "Valores suportados para tipo são \"custom\", \"container\" e \"virtual-"
 "machine\"."
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr "Mostra o projeto atual"
@@ -8766,15 +8804,15 @@ msgstr "Mostra o remoto predefinido"
 msgid "Show the expanded configuration"
 msgstr "Mostra a configuração expandida"
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 msgid "Show the instance's access list"
 msgstr "Mostra a lista de acesso da instância"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid "Show the instance's recent log entries"
 msgstr "Mostra as entradas de relatório recentes da instância"
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr "Mostra os recursos disponíveis para o servidor"
 
@@ -8815,7 +8853,7 @@ msgstr "Tamanho em GiB do novo dispositivo de loop"
 msgid "Size: %.2fMiB"
 msgstr "Tamanho: %.2fMiB"
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr "Tamanho: %s"
@@ -8833,11 +8871,11 @@ msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 "Os instantâneos são só leitura e não se pode alterar a sua configuração"
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr "Instantâneos:"
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr "Socket %d:"
@@ -8867,7 +8905,7 @@ msgstr "Fonte:"
 msgid "Start instances"
 msgstr "Inicia instâncias"
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, c-format
 msgid "Started: %s"
 msgstr "Iniciado: %s"
@@ -8881,7 +8919,7 @@ msgstr "A iniciar %s"
 msgid "Starting recovery..."
 msgstr "A iniciar recuperação..."
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr "Estado"
 
@@ -8890,11 +8928,11 @@ msgstr "Estado"
 msgid "State: %s"
 msgstr "Estado: %s"
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr "Stateful"
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr "Estatuto: %s"
@@ -9014,21 +9052,21 @@ msgstr "Armazena o estado da instância"
 msgid "Successfully updated cluster certificates"
 msgstr "Certificados de agrupamento atualizados com sucesso"
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr "Modos suportados: %s"
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr "Portos suportados: %s"
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr "Swap (atual)"
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr "Swap (pico)"
 
@@ -9045,7 +9083,7 @@ msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 "O caminho do alvo do link simbólico só pode ser usado para o tipo \"symlink\""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr "Sistema:"
 
@@ -9070,7 +9108,7 @@ msgstr "TESTEMUNHO"
 msgid "TYPE"
 msgstr "TIPO"
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr "Tomado em"
 
@@ -9381,7 +9419,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr "O servidor não tem uma Interface de Utilizador web instalada"
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "O servidor não implementa a nova API de recursos v2"
 
@@ -9402,7 +9440,7 @@ msgstr "O tipo a criar (ficheiro, link simbólico, ou diretório)"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Não há \"nome de imagem\".  Deseja um alias?"
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -9417,6 +9455,13 @@ msgstr ""
 "\n"
 "Se você já adicionou um servidor remoto, torne-o predefinido com \"incus "
 "remote switch NOME\"."
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
+msgstr ""
 
 #: cmd/incus/webui_windows.go:15
 msgid "This command isn't supported on Windows"
@@ -9434,7 +9479,7 @@ msgstr "Este servidor já está agrupado"
 msgid "This server is not available on the network"
 msgstr "Este servidor não está disponível na rede"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr "Threads:"
 
@@ -9458,7 +9503,7 @@ msgstr "Para criar uma nova rede, use: incus network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "Para separar da consola, pressione: <ctrl>+a q"
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
@@ -9467,9 +9512,9 @@ msgstr ""
 "Para iniciar seu primeiro contentor, tente: incus launch images:%s\n"
 "Ou para uma máquina virtual: incus launch images:%s --vm"
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr "Para usar --target, o remoto alvo tem de ser um agrupamento"
 
@@ -9478,13 +9523,13 @@ msgstr "Para usar --target, o remoto alvo tem de ser um agrupamento"
 msgid "Total: %s"
 msgstr "Total: %s"
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr "Total: %v"
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr "Tipo de transceptor: %s"
@@ -9533,7 +9578,7 @@ msgstr "Testemunho de confiança para %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "Tente `incus info --show-log %s%s` para mais informação"
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr "Tipo"
 
@@ -9553,8 +9598,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr "Tipo de peer (local ou remoto)"
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -9576,11 +9621,11 @@ msgstr "URL"
 msgid "USAGE"
 msgstr "UTILIZAÇÃO"
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid "USB device:"
 msgstr "Dispositivo USB:"
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid "USB devices:"
 msgstr "Dispositivos USB:"
 
@@ -9596,7 +9641,7 @@ msgstr "USADO POR"
 msgid "UUID"
 msgstr "UUID"
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr "UUID: %v"
@@ -9689,7 +9734,7 @@ msgstr "Retira definições de chaves de configuração"
 msgid "Unset image properties"
 msgstr "Retira propriedades da imagem"
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr "Retira definições das chaves de configuração de instância ou servidor"
 
@@ -9844,11 +9889,11 @@ msgstr "Retira definições da chave como propriedade de armazenamento"
 msgid "Unset the key as a storage volume property"
 msgstr "Retira definições da chave como propriedade de volume de armazenamento"
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr "Retira definições da chave como propriedade de instância"
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "Tipo de instância não suportado: %s"
@@ -9911,8 +9956,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "Usa com ajuda ou --help para visualizar sub-comandos"
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr "Usado: %v"
@@ -9930,7 +9975,7 @@ msgstr "Configuração abortada pelo utilizador"
 msgid "User aborted delete operation"
 msgstr "Operação de apagar abortada pelo utilizador"
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr "VFs: %d"
@@ -9947,38 +9992,38 @@ msgstr "Filtragem VLAN"
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, c-format
 msgid "Vendor ID: %v"
 msgstr "ID do fornecedor: %v"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, c-format
 msgid "Vendor: %s"
 msgstr "Fornecedor: %s"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr "Fornecedor: %v"
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr "Fornecedor: %v (%v)"
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr "Versão: %s"
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr "Versão: %v"
@@ -9995,7 +10040,7 @@ msgstr "Descrição do volume"
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr "AVISO: A API IncusOS e a configuração estão sujeitas a alterações"
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr "WWN: %s"
@@ -10048,6 +10093,13 @@ msgstr ""
 "em teoria atacar o seu contentor pai e ganhar mais privilégios do que caso\n"
 "contrário poderiam."
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -10065,6 +10117,14 @@ msgstr "Que endereço IPv4 deve ser usado?"
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr "Que endereço IPv6 deve ser usado?"
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
+msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
@@ -10214,7 +10274,7 @@ msgstr "[<remoto:>]<pool> <volume> <perfil> [<nome dispositivo>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remoto:>]<pool> <volume> <perfil> [<nome dispositivo>] [<caminho>]"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -10898,11 +10958,11 @@ msgstr "[<remoto>:]<zona> <registo> [chave=valor...]"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remoto>:][<instância>[/<instantâneo>]]"
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr "[<remoto>:][<instância>]"
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remoto>:][<instância>] <chave>"
 
@@ -10917,6 +10977,14 @@ msgstr "[<remoto>] <IP|FQDN|URL|testemunho>"
 #: cmd/incus/cluster.go:1031
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remoto>:]<membro>]"
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
+msgstr ""
 
 #: cmd/incus/info.go:646
 msgid "application"
@@ -10994,6 +11062,21 @@ msgid ""
 msgstr ""
 "incus alias rename list my-list\n"
 "    Renomeia alias existente \"list\" para \"my-list\"."
+
+#: cmd/incus/bug.go:179
+#, fuzzy
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
+msgstr ""
+"incus info [<remoto>:]<instância> [--show-log]\n"
+"    Para informação da instância.\n"
+"\n"
+"incus info [<remoto>:] [--resources]\n"
+"    Para informação do servidor."
 
 #: cmd/incus/cluster.go:912
 msgid ""
@@ -11216,7 +11299,7 @@ msgstr ""
 "incus import backup0.tar.gz\n"
 "    Cria uma nova instância usando backup0.tar.gz como fonte."
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -11907,6 +11990,10 @@ msgstr "sshfs parou"
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs a montar %q em %q"
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
+msgstr ""
 
 #: cmd/incus/storage.go:573
 msgid "total space"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,16 +19,24 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
+msgstr ""
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
@@ -611,7 +619,7 @@ msgstr ""
 "### Essa é uma representação yaml do membro do cluster.\n"
 "### Qualquer linha iniciando em '# será ignorada"
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
@@ -636,7 +644,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
@@ -660,17 +668,17 @@ msgstr "'%s' não é um tipo de arquivo suportado"
 msgid "(none)"
 msgstr "(nenhum)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Nível %d (tipo: %s): %s"
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partição %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -730,8 +738,8 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--target can only be used with clusters"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -980,12 +988,12 @@ msgstr ""
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Address: %v"
 msgstr "O dispositivo já existe: %s"
@@ -1047,13 +1055,13 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
@@ -1127,7 +1135,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1150,7 +1158,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1188,7 +1196,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr ""
 
@@ -1239,7 +1247,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr "Marca: %v"
@@ -1253,16 +1261,16 @@ msgstr ""
 msgid "Bucket description"
 msgstr "Descrição"
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1291,19 +1299,19 @@ msgstr "Utilização do CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 #, fuzzy
 msgid "CPUs:"
 msgstr "CPUs:"
@@ -1316,7 +1324,7 @@ msgstr "CRIADO"
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
@@ -1326,7 +1334,7 @@ msgstr "Versão CUDA: %v"
 msgid "Cached: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 #, fuzzy
 msgid "Caches:"
 msgstr "Em cache: %s"
@@ -1438,12 +1446,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Em cache: %s"
@@ -1487,6 +1495,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1556,16 +1568,17 @@ msgstr "Dispositivo %s removido de %s"
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1719,7 +1732,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1806,12 +1819,12 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr ""
 
@@ -2004,7 +2017,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -2025,7 +2038,7 @@ msgstr "Criando %s"
 msgid "Creating the instance"
 msgstr "Criando %s"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -2073,7 +2086,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Criado: %s"
@@ -2239,6 +2252,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2255,7 +2269,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2281,7 +2295,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2395,7 +2409,7 @@ msgstr ""
 msgid "Description"
 msgstr "Descrição"
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
@@ -2424,7 +2438,7 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Em cache: %s"
@@ -2444,7 +2458,7 @@ msgstr "Dispositivo %s sobreposto em %s"
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "O dispositivo já existe: %s"
@@ -2477,7 +2491,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Em cache: %s"
@@ -2506,21 +2520,21 @@ msgstr "Desabilitar alocação de pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
@@ -2608,12 +2622,12 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2901,12 +2915,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
@@ -2985,7 +2999,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr ""
@@ -3091,7 +3105,7 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3442,7 +3456,7 @@ msgstr "Aceitar certificado"
 msgid "Failed validation request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3593,18 +3607,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3613,11 +3627,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3856,15 +3870,19 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3892,12 +3910,12 @@ msgstr "Copiar a imagem: %s"
 msgid "ID"
 msgstr "ID"
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3910,7 +3928,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3919,7 +3937,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3959,7 +3977,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4108,7 +4126,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr "Cliente de linha de comando para LXD"
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -4116,7 +4134,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr ""
 
@@ -4276,7 +4294,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4327,7 +4345,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Em cache: %s"
@@ -4340,7 +4366,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -4372,7 +4398,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
@@ -4396,12 +4422,12 @@ msgstr "Criando %s"
 msgid "Launching the instance"
 msgstr "Criando %s"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Arquitetura: %v"
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -5300,11 +5326,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5313,7 +5339,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -5356,7 +5382,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -5365,7 +5391,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
@@ -5403,7 +5429,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5665,12 +5691,12 @@ msgstr "Editar arquivos no container"
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
@@ -5700,19 +5726,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5967,12 +5993,12 @@ msgstr "Nome de membro do cluster"
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -6094,11 +6120,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -6109,26 +6135,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -6189,13 +6215,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -6344,7 +6370,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -6435,7 +6461,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6454,11 +6480,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 #, fuzzy
 msgid "OS Version"
 msgstr "Versão CUDA: %v"
@@ -6509,7 +6535,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Criando %s"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6518,7 +6544,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6530,17 +6556,17 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 #, fuzzy
 msgid "PCI device:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 #, fuzzy
 msgid "PCI devices:"
 msgstr "Editar arquivos no container"
@@ -6553,7 +6579,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6590,19 +6616,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6669,17 +6695,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6735,7 +6765,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6745,22 +6775,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6937,7 +6967,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -7032,7 +7062,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -7217,9 +7247,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -7230,7 +7264,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -7341,7 +7375,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -7354,7 +7388,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -7429,17 +7463,17 @@ msgstr "Criado: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marca: %v"
@@ -7893,7 +7927,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -7903,7 +7937,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance snapshot configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -8028,6 +8062,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -8040,17 +8078,17 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Ignorar o estado do container"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Ignorar o estado do container"
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -8093,7 +8131,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -8111,11 +8149,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -8143,7 +8181,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Criado: %s"
@@ -8157,7 +8195,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr ""
 
@@ -8166,11 +8204,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -8293,21 +8331,21 @@ msgstr "Ignorar o estado do container"
 msgid "Successfully updated cluster certificates"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -8323,7 +8361,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -8348,7 +8386,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8617,7 +8655,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8638,7 +8676,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8646,6 +8684,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8665,7 +8710,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8689,16 +8734,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8707,13 +8752,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8762,7 +8807,7 @@ msgstr "Senha de administrador para %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8781,8 +8826,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8804,12 +8849,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 #, fuzzy
 msgid "USB device:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "USB devices:"
 msgstr "Editar arquivos no container"
@@ -8826,7 +8871,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8922,7 +8967,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -9091,11 +9136,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -9154,8 +9199,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9174,7 +9219,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -9191,38 +9236,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"
@@ -9240,7 +9285,7 @@ msgstr "Descrição"
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -9275,6 +9320,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -9290,6 +9342,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -9434,7 +9494,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -10193,11 +10253,11 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -10214,6 +10274,14 @@ msgstr "Criar perfis"
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
+msgstr ""
 
 #: cmd/incus/info.go:646
 msgid "application"
@@ -10278,6 +10346,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -10425,7 +10502,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10871,6 +10948,10 @@ msgstr ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,16 +20,24 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
+msgstr ""
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
@@ -637,7 +645,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -662,7 +670,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
@@ -686,17 +694,17 @@ msgstr ""
 msgid "(none)"
 msgstr "(пусто)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Порт %d (%s)"
@@ -745,8 +753,8 @@ msgstr ""
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -999,12 +1007,12 @@ msgstr ""
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr ""
@@ -1066,13 +1074,13 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
@@ -1142,7 +1150,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -1165,7 +1173,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1202,7 +1210,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr ""
 
@@ -1253,7 +1261,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -1266,16 +1274,16 @@ msgstr ""
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1304,20 +1312,20 @@ msgstr " Использование ЦП:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr ""
 
@@ -1330,7 +1338,7 @@ msgstr "СОЗДАН"
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
@@ -1340,7 +1348,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr ""
 
@@ -1450,12 +1458,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1498,6 +1506,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1567,16 +1579,17 @@ msgstr ""
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1717,7 +1730,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1803,12 +1816,12 @@ msgstr "Копирование образа: %s"
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr ""
 
@@ -2001,7 +2014,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -2022,7 +2035,7 @@ msgstr ""
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -2056,7 +2069,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -2070,7 +2083,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Авто-обновление: %s"
@@ -2232,6 +2245,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2248,7 +2262,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2274,7 +2288,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2388,7 +2402,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr ""
@@ -2416,7 +2430,7 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr " Использование диска:"
@@ -2436,7 +2450,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
@@ -2468,7 +2482,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2497,22 +2511,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
@@ -2601,12 +2615,12 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2885,12 +2899,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
@@ -2972,7 +2986,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr ""
@@ -3082,7 +3096,7 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3433,7 +3447,7 @@ msgstr "Принять сертификат"
 msgid "Failed validation request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3584,18 +3598,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3604,11 +3618,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3843,17 +3857,21 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 #, fuzzy
 msgid "Hostname"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3881,12 +3899,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3899,7 +3917,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3908,7 +3926,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3948,7 +3966,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4098,7 +4116,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -4106,7 +4124,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
@@ -4268,7 +4286,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4319,7 +4337,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -4332,7 +4358,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -4363,7 +4389,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
@@ -4387,12 +4413,12 @@ msgstr ""
 msgid "Launching the instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Архитектура: %s"
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -5299,11 +5325,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5312,7 +5338,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -5355,7 +5381,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -5364,7 +5390,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -5402,7 +5428,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5666,12 +5692,12 @@ msgstr "Копирование образа: %s"
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -5700,20 +5726,20 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
@@ -5971,12 +5997,12 @@ msgstr "Имя контейнера: %s"
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -6096,11 +6122,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -6111,26 +6137,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -6195,13 +6221,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -6351,7 +6377,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -6444,7 +6470,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6463,11 +6489,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr ""
 
@@ -6517,7 +6543,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6526,7 +6552,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6538,17 +6564,17 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 #, fuzzy
 msgid "PCI device:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 #, fuzzy
 msgid "PCI devices:"
 msgstr "Копирование образа: %s"
@@ -6561,7 +6587,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6598,19 +6624,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -6675,17 +6701,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6741,7 +6771,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6751,22 +6781,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6935,7 +6965,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -7030,7 +7060,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -7209,9 +7239,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -7222,7 +7256,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -7328,7 +7362,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -7341,7 +7375,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -7416,17 +7450,17 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -7874,7 +7908,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7883,7 +7917,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -8007,6 +8041,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -8019,17 +8057,17 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -8072,7 +8110,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
@@ -8090,11 +8128,11 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -8122,7 +8160,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Авто-обновление: %s"
@@ -8136,7 +8174,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -8146,11 +8184,11 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -8275,21 +8313,21 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Successfully updated cluster certificates"
 msgstr "Принять сертификат"
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -8305,7 +8343,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -8330,7 +8368,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8598,7 +8636,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8619,7 +8657,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8627,6 +8665,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8646,7 +8691,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8670,16 +8715,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8688,13 +8733,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8743,7 +8788,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8762,8 +8807,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8785,12 +8830,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 #, fuzzy
 msgid "USB device:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "USB devices:"
 msgstr "Копирование образа: %s"
@@ -8807,7 +8852,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8899,7 +8944,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -9067,11 +9112,11 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -9130,8 +9175,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9150,7 +9195,7 @@ msgstr "Копирование образа: %s"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -9167,38 +9212,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -9215,7 +9260,7 @@ msgstr ""
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -9250,6 +9295,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -9265,6 +9317,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -9415,7 +9475,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -10699,7 +10759,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -10707,7 +10767,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -10738,6 +10798,14 @@ msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
+msgstr ""
 
 #: cmd/incus/info.go:646
 msgid "application"
@@ -10802,6 +10870,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -10949,7 +11026,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -11395,6 +11472,10 @@ msgstr ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,16 +16,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
+msgstr ""
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
@@ -363,7 +371,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -388,7 +396,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
@@ -412,17 +420,17 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
@@ -471,8 +479,8 @@ msgstr ""
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -707,12 +715,12 @@ msgstr ""
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr ""
@@ -772,13 +780,13 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -845,7 +853,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -867,7 +875,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -904,7 +912,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr ""
 
@@ -955,7 +963,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -968,16 +976,16 @@ msgstr ""
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr ""
 
@@ -1005,19 +1013,19 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr ""
 
@@ -1029,7 +1037,7 @@ msgstr ""
 msgid "CREATED AT"
 msgstr ""
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
@@ -1039,7 +1047,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr ""
 
@@ -1149,12 +1157,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1197,6 +1205,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1264,16 +1276,17 @@ msgstr ""
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1414,7 +1427,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1498,12 +1511,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr ""
 
@@ -1678,7 +1691,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -1698,7 +1711,7 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -1732,7 +1745,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -1746,7 +1759,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1893,6 +1906,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -1909,7 +1923,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -1935,7 +1949,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2049,7 +2063,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2094,7 +2108,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
@@ -2126,7 +2140,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2155,20 +2169,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr ""
 
@@ -2250,12 +2264,12 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Driver: %v"
 msgstr ""
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2524,12 +2538,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
@@ -2607,7 +2621,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr ""
@@ -2708,7 +2722,7 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3059,7 +3073,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3209,18 +3223,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3229,11 +3243,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3445,15 +3459,19 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3481,12 +3499,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3499,7 +3517,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3508,7 +3526,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3548,7 +3566,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3690,7 +3708,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -3698,7 +3716,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr ""
 
@@ -3855,7 +3873,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3902,7 +3920,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3915,7 +3941,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -3946,7 +3972,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3969,12 +3995,12 @@ msgstr ""
 msgid "Launching the instance"
 msgstr ""
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -4856,11 +4882,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4869,7 +4895,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -4910,7 +4936,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -4919,7 +4945,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -4957,7 +4983,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5189,12 +5215,12 @@ msgstr ""
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -5223,19 +5249,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5471,12 +5497,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -5593,11 +5619,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -5608,26 +5634,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -5688,13 +5714,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -5839,7 +5865,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -5930,7 +5956,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5949,11 +5975,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr ""
 
@@ -6002,7 +6028,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6011,7 +6037,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6023,16 +6049,16 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid "PCI devices:"
 msgstr ""
 
@@ -6044,7 +6070,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6081,19 +6107,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6157,17 +6183,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6222,7 +6252,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6232,22 +6262,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6416,7 +6446,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -6507,7 +6537,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -6673,9 +6703,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -6686,7 +6720,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -6784,7 +6818,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6797,7 +6831,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -6871,17 +6905,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -7302,7 +7336,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7310,7 +7344,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -7420,6 +7454,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -7432,15 +7470,15 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -7481,7 +7519,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -7498,11 +7536,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7530,7 +7568,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, c-format
 msgid "Started: %s"
 msgstr ""
@@ -7544,7 +7582,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr ""
 
@@ -7553,11 +7591,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7676,21 +7714,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7706,7 +7744,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -7731,7 +7769,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -7999,7 +8037,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8020,7 +8058,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8028,6 +8066,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8046,7 +8091,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8070,16 +8115,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8088,13 +8133,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8143,7 +8188,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8161,8 +8206,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8184,11 +8229,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid "USB devices:"
 msgstr ""
 
@@ -8204,7 +8249,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8293,7 +8338,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -8438,11 +8483,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8499,8 +8544,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8518,7 +8563,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -8535,38 +8580,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -8583,7 +8628,7 @@ msgstr ""
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -8618,6 +8663,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -8633,6 +8685,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -8773,7 +8833,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -9441,11 +9501,11 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -9459,6 +9519,14 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1031
 msgid "[[<remote>:]<member>]"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
 msgstr ""
 
 #: cmd/incus/info.go:646
@@ -9524,6 +9592,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -9671,7 +9748,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10117,6 +10194,10 @@ msgstr ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2025-03-01 08:01+0000\n"
 "Last-Translator: Loge X <wazolm5643@163.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -19,17 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.10.3-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  逻辑机箱（Chassis）:"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  固件:"
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  主板:"
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 msgid ""
@@ -619,7 +627,7 @@ msgstr ""
 "### 这是集群成员的 YAML 表示形式。\n"
 "### 任何以“#”开头的行都会被忽略。"
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d （id：%d，在线：%v，NUMA 节点：%v）"
@@ -644,7 +652,7 @@ msgstr "项目 %q 中 %q 池的 %s %q（包括 %d 个快照）"
 msgid "%s (%d more)"
 msgstr "%s（还有%d个）"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s（%s）（%d个可用）"
@@ -668,17 +676,17 @@ msgstr "“%s”不是受支持的文件类型"
 msgid "(none)"
 msgstr "（无）"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- 第 %d 级（类型：%s）：%s"
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- 分区 %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- 端口 %d（%s）"
@@ -727,8 +735,8 @@ msgstr "--refresh 只能与实例一起使用"
 msgid "--target can only be used with clusters"
 msgstr "--target 只能与集群一起使用"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr "--target 不能与实例一起使用"
 
@@ -980,12 +988,12 @@ msgstr "要绑定的地址（默认值：无）"
 msgid "Address to bind to (not including port)"
 msgstr "要绑定的地址（不包括端口）"
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr "地址：%s"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr "地址：%v"
@@ -1045,13 +1053,13 @@ msgstr "所有服务器地址都不可用"
 msgid "Alternative certificate name"
 msgstr "备选证书名称"
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr "架构：%s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr "架构：%v"
@@ -1121,7 +1129,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr "服务器不支持身份验证类型“%s”"
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "自动协商：%v"
@@ -1143,7 +1151,7 @@ msgstr "自动（非交互）模式"
 msgid "Available projects:"
 msgstr "可用项目："
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "平均值：%.2f %.2f %.2f"
@@ -1180,7 +1188,7 @@ msgstr "备份存储卷：%s"
 msgid "Backup exported successfully!"
 msgstr "备份导出成功！"
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr "备份："
 
@@ -1231,7 +1239,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr "给出了--all和实例名称"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr "品牌：%v"
@@ -1244,16 +1252,16 @@ msgstr "网络桥接："
 msgid "Bucket description"
 msgstr "桶描述"
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr "总线地址：%v"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr "已接收字节"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr "已发送字节"
 
@@ -1281,19 +1289,19 @@ msgstr "CPU 时间（秒）"
 msgid "CPU USAGE"
 msgstr "CPU 占用"
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr "CPU 占用（秒）"
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr "CPU 占用："
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr "CPU："
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr "CPU："
 
@@ -1305,7 +1313,7 @@ msgstr "创建"
 msgid "CREATED AT"
 msgstr "创建于"
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA 版本：%v"
@@ -1315,7 +1323,7 @@ msgstr "CUDA 版本：%v"
 msgid "Cached: %s"
 msgstr "已缓存：%s"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr "缓存："
 
@@ -1425,12 +1433,12 @@ msgstr "复制快照时无法设置 --volume-only"
 msgid "Cannot set key: %s"
 msgstr "无法设置键：%s"
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr "显卡 %d："
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1474,6 +1482,10 @@ msgstr "正在检查守护进程是否已就绪（第 %d 次尝试）"
 #, c-format
 msgid "Choose %s:"
 msgstr "选择 %s："
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
+msgstr ""
 
 #: cmd/incus/config_trust.go:150
 #, c-format
@@ -1540,16 +1552,17 @@ msgstr "已从组 %s 中移除集群成员 %s"
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1697,7 +1710,7 @@ msgstr "内容类型、块或文件系统"
 msgid "Content type: %s"
 msgstr "内容类型：%s"
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "控制：%s（%s）"
@@ -1795,12 +1808,12 @@ msgstr "正在复制镜像：%s"
 msgid "Copying the storage volume: %s"
 msgstr "正在复制储存卷：%s"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr "核心 %d"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr "核心："
 
@@ -1979,7 +1992,7 @@ msgstr "创建存储池"
 msgid "Create the instance with no profiles applied"
 msgstr "创建未应用配置文件的实例"
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -1999,7 +2012,7 @@ msgstr ""
 msgid "Creating the instance"
 msgstr "正在创建实例"
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "目前 VF 的数目：%d"
@@ -2033,7 +2046,7 @@ msgstr "磁盘利用率"
 msgid "DRIVER"
 msgstr "驱动"
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr "DRM："
 
@@ -2047,7 +2060,7 @@ msgstr "超时 %d 秒后守护进程仍未运行（%v）"
 msgid "Daemon still running after %ds timeout"
 msgstr "超时 %d 秒后，守护进程仍在运行"
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, c-format
 msgid "Date: %s"
 msgstr "日期：%s"
@@ -2195,6 +2208,7 @@ msgstr "删除警告"
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -2211,7 +2225,7 @@ msgstr "删除警告"
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -2237,7 +2251,7 @@ msgstr "删除警告"
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2351,7 +2365,7 @@ msgstr "删除警告"
 msgid "Description"
 msgstr "描述"
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr "描述：%s"
@@ -2376,7 +2390,7 @@ msgstr "从实例中分离网络接口"
 msgid "Detach network interfaces from profiles"
 msgstr "从配置文件中分离网络接口"
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, c-format
 msgid "Device %d:"
 msgstr "设备 %d："
@@ -2396,7 +2410,7 @@ msgstr "设备 %s 被 %s 覆盖"
 msgid "Device %s removed from %s"
 msgstr "设备 %s 已从 %s 中移除"
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid "Device Address: %v"
 msgstr "设备地址：%v"
@@ -2428,7 +2442,7 @@ msgstr "无法为单个实例移除配置文件中的设备。改为替代设备
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "无法为单个实例检索配置文件中的设备"
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr "设备：%s"
@@ -2457,20 +2471,20 @@ msgstr "禁用伪终端分配"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "禁用标准输入（从 /dev/null 读取）"
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr "磁盘 %d："
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr "磁盘使用情况："
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr "磁盘："
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr "磁盘："
 
@@ -2569,12 +2583,12 @@ msgstr "不显示进度信息"
 msgid "Down delay"
 msgstr "下行延迟"
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Driver: %v"
 msgstr "驱动：%v"
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "驱动：%v（%v）"
@@ -2858,12 +2872,12 @@ msgstr "取消设置属性时出错：%v"
 msgid "Error updating template file: %s"
 msgstr "更新模板文件时出错：%s"
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr "执行别名扩展时出错：%s\n"
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr "错误：%v\n"
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "需要结构体，已有 %v"
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr "过期时间"
@@ -3079,7 +3093,7 @@ msgstr "指纹"
 msgid "FIRST SEEN"
 msgstr "首次发现"
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr "FQDN"
 
@@ -3430,7 +3444,7 @@ msgstr "无法写入服务器证书文件 %q：%w"
 msgid "Failed validation request: %w"
 msgstr "验证请求失败：%w"
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3598,18 +3612,18 @@ msgstr "转发延迟"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "发现别名 %q 引用了给定数字之外的参数"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr "空闲：%v"
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "频率：%v Mhz"
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "频率：%v Mhz（最低：%v Mhz，最高：%v Mhz）"
@@ -3618,11 +3632,11 @@ msgstr "频率：%v Mhz（最低：%v Mhz，最高：%v Mhz）"
 msgid "GLOBAL"
 msgstr "全局"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr "GPU："
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr "GPU："
 
@@ -3841,15 +3855,19 @@ msgstr "运行命令的组 ID（默认为 0）"
 msgid "HOSTNAME"
 msgstr "主机名"
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr "主机接口"
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 msgid "Hostname"
 msgstr "主机名"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr "大页内存：\n"
 
@@ -3877,12 +3895,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3895,7 +3913,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3904,7 +3922,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3944,7 +3962,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4086,7 +4104,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -4094,7 +4112,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr ""
 
@@ -4251,7 +4269,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4298,7 +4316,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -4311,7 +4337,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -4342,7 +4368,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4365,12 +4391,12 @@ msgstr ""
 msgid "Launching the instance"
 msgstr ""
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -5273,11 +5299,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5286,7 +5312,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -5327,7 +5353,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -5336,7 +5362,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -5374,7 +5400,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5607,12 +5633,12 @@ msgstr ""
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -5641,19 +5667,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5889,12 +5915,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -6013,11 +6039,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -6028,26 +6054,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -6108,13 +6134,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -6260,7 +6286,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -6351,7 +6377,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6370,11 +6396,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr ""
 
@@ -6423,7 +6449,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6432,7 +6458,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6444,16 +6470,16 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid "PCI devices:"
 msgstr ""
 
@@ -6465,7 +6491,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6502,19 +6528,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6578,17 +6604,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6644,7 +6674,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6654,22 +6684,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6838,7 +6868,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr "只读: %v"
@@ -6934,7 +6964,7 @@ msgstr "远程名称不应包含冒号"
 msgid "Remote trust token"
 msgstr "远程验证令牌"
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr "是否可移除: %v"
@@ -7105,9 +7135,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -7118,7 +7152,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -7216,7 +7250,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -7229,7 +7263,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -7303,17 +7337,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -7739,7 +7773,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7747,7 +7781,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -7858,6 +7892,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -7870,15 +7908,15 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -7919,7 +7957,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -7936,11 +7974,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7968,7 +8006,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, c-format
 msgid "Started: %s"
 msgstr ""
@@ -7982,7 +8020,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr ""
 
@@ -7991,11 +8029,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -8114,21 +8152,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -8144,7 +8182,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -8169,7 +8207,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8438,7 +8476,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8459,7 +8497,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8467,6 +8505,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8485,7 +8530,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8509,16 +8554,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8527,13 +8572,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8582,7 +8627,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8600,8 +8645,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8623,11 +8668,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid "USB devices:"
 msgstr ""
 
@@ -8643,7 +8688,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8732,7 +8777,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -8879,11 +8924,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8940,8 +8985,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8959,7 +9004,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -8976,38 +9021,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -9024,7 +9069,7 @@ msgstr ""
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -9059,6 +9104,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -9074,6 +9126,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -9214,7 +9274,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -9887,11 +9947,11 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -9905,6 +9965,14 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1031
 msgid "[[<remote>:]<member>]"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
 msgstr ""
 
 #: cmd/incus/info.go:646
@@ -9970,6 +10038,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -10117,7 +10194,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10563,6 +10640,10 @@ msgstr ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-10-06 17:21-0400\n"
+"POT-Creation-Date: 2025-10-08 23:58+0000\n"
 "PO-Revision-Date: 2024-12-30 10:00+0000\n"
 "Last-Translator: pesder <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
@@ -19,17 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.10-dev\n"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:450
 msgid "  Chassis:"
 msgstr "  機櫃："
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:490
 msgid "  Firmware:"
 msgstr "  韌體："
 
-#: cmd/incus/info.go:461
+#: cmd/incus/info.go:470
 msgid "  Motherboard:"
 msgstr "  主機板："
+
+#: cmd/incus/bug.go:351
+#, c-format
+msgid ""
+"### %s\n"
+"*Pleuse write %s below the following dashes. You can use Markdown "
+"formatting.*"
+msgstr ""
 
 #: cmd/incus/storage_bucket.go:290 cmd/incus/storage_bucket.go:1290
 msgid ""
@@ -366,7 +374,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:358
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, 上線: %v, NUMA 節點: %v)"
@@ -391,7 +399,7 @@ msgstr "%s %q 於 %q 池的 %q 專案(包含 %d 快照)"
 msgid "%s (%d more)"
 msgstr "%s (還有 %d)"
 
-#: cmd/incus/info.go:191
+#: cmd/incus/info.go:200
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d 可用)"
@@ -415,17 +423,17 @@ msgstr "'%s' 不是受支援的檔案類型"
 msgid "(none)"
 msgstr "(沒有)"
 
-#: cmd/incus/info.go:339
+#: cmd/incus/info.go:348
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- 等級 %d (類型： %s)： %s"
 
-#: cmd/incus/info.go:318
+#: cmd/incus/info.go:327
 #, c-format
 msgid "- Partition %d"
 msgstr "- 分割區 %d"
 
-#: cmd/incus/info.go:227
+#: cmd/incus/info.go:236
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- 連接埠 %d (%s)"
@@ -474,8 +482,8 @@ msgstr "--refresh 只能與實體一起使用"
 msgid "--target can only be used with clusters"
 msgstr "--target 只能與叢集一起使用"
 
-#: cmd/incus/config.go:167 cmd/incus/config.go:440 cmd/incus/config.go:620
-#: cmd/incus/config.go:825 cmd/incus/info.go:627
+#: cmd/incus/bug.go:225 cmd/incus/config.go:167 cmd/incus/config.go:440
+#: cmd/incus/config.go:620 cmd/incus/config.go:827 cmd/incus/info.go:112
 msgid "--target cannot be used with instances"
 msgstr "--target 不能與實體一起使用"
 
@@ -710,12 +718,12 @@ msgstr ""
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:231
+#: cmd/incus/info.go:240
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:384
 #, c-format
 msgid "Address: %v"
 msgstr ""
@@ -775,13 +783,13 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
-#: cmd/incus/info.go:655
+#: cmd/incus/image.go:1013 cmd/incus/info.go:514 cmd/incus/info.go:518
+#: cmd/incus/info.go:659
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:166
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
@@ -848,7 +856,7 @@ msgstr ""
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:250
+#: cmd/incus/info.go:259
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
@@ -870,7 +878,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:499
+#: cmd/incus/info.go:508
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -907,7 +915,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:851 cmd/incus/storage_volume.go:1529
 msgid "Backups:"
 msgstr ""
 
@@ -958,7 +966,7 @@ msgstr ""
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:167
 #, c-format
 msgid "Brand: %v"
 msgstr ""
@@ -971,16 +979,16 @@ msgstr ""
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:367
+#: cmd/incus/info.go:376
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1027
+#: cmd/incus/info.go:774 cmd/incus/network.go:1027
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1028
+#: cmd/incus/info.go:775 cmd/incus/network.go:1028
 msgid "Bytes sent"
 msgstr ""
 
@@ -1008,19 +1016,19 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:711
+#: cmd/incus/info.go:715
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:715
+#: cmd/incus/info.go:719
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:513
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:508
+#: cmd/incus/info.go:517
 msgid "CPUs:"
 msgstr ""
 
@@ -1032,7 +1040,7 @@ msgstr ""
 msgid "CREATED AT"
 msgstr ""
 
-#: cmd/incus/info.go:160
+#: cmd/incus/info.go:169
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
@@ -1042,7 +1050,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:346
 msgid "Caches:"
 msgstr ""
 
@@ -1152,12 +1160,12 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:553 cmd/incus/info.go:565
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:143
+#: cmd/incus/info.go:152
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1200,6 +1208,10 @@ msgstr ""
 #: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
+msgstr ""
+
+#: cmd/incus/bug.go:235
+msgid "Choose an issue title:"
 msgstr ""
 
 #: cmd/incus/config_trust.go:150
@@ -1267,16 +1279,17 @@ msgstr ""
 
 #: cmd/incus/admin_os.go:186 cmd/incus/admin_os.go:285
 #: cmd/incus/admin_os.go:434 cmd/incus/admin_os.go:622
-#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/config.go:103
-#: cmd/incus/config.go:395 cmd/incus/config.go:542 cmd/incus/config.go:758
-#: cmd/incus/config.go:889 cmd/incus/copy.go:64 cmd/incus/create.go:66
-#: cmd/incus/info.go:50 cmd/incus/move.go:67 cmd/incus/network.go:364
-#: cmd/incus/network.go:871 cmd/incus/network.go:954 cmd/incus/network.go:1559
-#: cmd/incus/network.go:1652 cmd/incus/network.go:1726
-#: cmd/incus/network_forward.go:261 cmd/incus/network_forward.go:347
-#: cmd/incus/network_forward.go:544 cmd/incus/network_forward.go:698
-#: cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:948
-#: cmd/incus/network_forward.go:1035 cmd/incus/network_load_balancer.go:265
+#: cmd/incus/admin_os.go:725 cmd/incus/admin_os.go:832 cmd/incus/bug.go:63
+#: cmd/incus/bug.go:187 cmd/incus/config.go:103 cmd/incus/config.go:395
+#: cmd/incus/config.go:542 cmd/incus/config.go:758 cmd/incus/config.go:900
+#: cmd/incus/copy.go:64 cmd/incus/create.go:66 cmd/incus/info.go:49
+#: cmd/incus/move.go:67 cmd/incus/network.go:364 cmd/incus/network.go:871
+#: cmd/incus/network.go:954 cmd/incus/network.go:1559 cmd/incus/network.go:1652
+#: cmd/incus/network.go:1726 cmd/incus/network_forward.go:261
+#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:544
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:948 cmd/incus/network_forward.go:1035
+#: cmd/incus/network_load_balancer.go:265
 #: cmd/incus/network_load_balancer.go:350
 #: cmd/incus/network_load_balancer.go:530
 #: cmd/incus/network_load_balancer.go:667
@@ -1417,7 +1430,7 @@ msgstr ""
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:147
+#: cmd/incus/info.go:156
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
@@ -1501,12 +1514,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:354
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:352
 msgid "Cores:"
 msgstr ""
 
@@ -1681,7 +1694,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/image.go:1019 cmd/incus/info.go:670
 #: cmd/incus/storage_volume.go:1483
 #, c-format
 msgid "Created: %s"
@@ -1701,7 +1714,7 @@ msgstr ""
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:167 cmd/incus/info.go:276
+#: cmd/incus/info.go:176 cmd/incus/info.go:285
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
@@ -1735,7 +1748,7 @@ msgstr ""
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:139
+#: cmd/incus/info.go:148
 msgid "DRM:"
 msgstr ""
 
@@ -1749,7 +1762,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:500
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1896,6 +1909,7 @@ msgstr ""
 #: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
 #: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:63
 #: cmd/incus/alias.go:113 cmd/incus/alias.go:174 cmd/incus/alias.go:229
+#: cmd/incus/bug.go:30 cmd/incus/bug.go:59 cmd/incus/bug.go:177
 #: cmd/incus/cluster.go:39 cmd/incus/cluster.go:135 cmd/incus/cluster.go:341
 #: cmd/incus/cluster.go:400 cmd/incus/cluster.go:461 cmd/incus/cluster.go:536
 #: cmd/incus/cluster.go:616 cmd/incus/cluster.go:662 cmd/incus/cluster.go:722
@@ -1912,7 +1926,7 @@ msgstr ""
 #: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:53
 #: cmd/incus/cluster_role.go:118 cmd/incus/config.go:34 cmd/incus/config.go:97
 #: cmd/incus/config.go:390 cmd/incus/config.go:527 cmd/incus/config.go:754
-#: cmd/incus/config.go:886 cmd/incus/config_device.go:27
+#: cmd/incus/config.go:897 cmd/incus/config_device.go:27
 #: cmd/incus/config_device.go:83 cmd/incus/config_device.go:227
 #: cmd/incus/config_device.go:326 cmd/incus/config_device.go:411
 #: cmd/incus/config_device.go:515 cmd/incus/config_device.go:633
@@ -1938,7 +1952,7 @@ msgstr ""
 #: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
 #: cmd/incus/image_alias.go:72 cmd/incus/image_alias.go:141
 #: cmd/incus/image_alias.go:197 cmd/incus/image_alias.go:387
-#: cmd/incus/import.go:30 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/import.go:30 cmd/incus/info.go:36 cmd/incus/launch.go:25
 #: cmd/incus/list.go:52 cmd/incus/main.go:102 cmd/incus/manpage.go:25
 #: cmd/incus/monitor.go:35 cmd/incus/move.go:38 cmd/incus/network.go:41
 #: cmd/incus/network.go:153 cmd/incus/network.go:252 cmd/incus/network.go:354
@@ -2052,7 +2066,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1456
 #, c-format
 msgid "Description: %s"
 msgstr ""
@@ -2077,7 +2091,7 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:589 cmd/incus/info.go:601
+#: cmd/incus/info.go:598 cmd/incus/info.go:610
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2097,7 +2111,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:377
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
@@ -2129,7 +2143,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:296 cmd/incus/info.go:320
+#: cmd/incus/info.go:305 cmd/incus/info.go:329
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2158,20 +2172,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:704
+#: cmd/incus/info.go:708
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:572
+#: cmd/incus/info.go:581
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:584
 msgid "Disks:"
 msgstr ""
 
@@ -2253,12 +2267,12 @@ msgstr ""
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:382
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Driver: %v"
 msgstr ""
 
-#: cmd/incus/info.go:135 cmd/incus/info.go:221
+#: cmd/incus/info.go:144 cmd/incus/info.go:230
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
@@ -2527,12 +2541,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:366
+#: cmd/incus/main.go:370
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:369
+#: cmd/incus/main.go:373
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
@@ -2610,7 +2624,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1516
+#: cmd/incus/info.go:837 cmd/incus/info.go:888 cmd/incus/storage_volume.go:1516
 #: cmd/incus/storage_volume.go:1566
 msgid "Expires at"
 msgstr ""
@@ -2711,7 +2725,7 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:689
 msgid "FQDN"
 msgstr ""
 
@@ -3062,7 +3076,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:420
+#: cmd/incus/info.go:429
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3212,18 +3226,18 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:529 cmd/incus/info.go:540 cmd/incus/info.go:545
+#: cmd/incus/info.go:551
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:346 cmd/incus/info.go:357
+#: cmd/incus/info.go:355 cmd/incus/info.go:366
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:355
+#: cmd/incus/info.go:364
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -3232,11 +3246,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:557
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:551
+#: cmd/incus/info.go:560
 msgid "GPUs:"
 msgstr ""
 
@@ -3448,15 +3462,19 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:759
+#: cmd/incus/info.go:763
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:684
+#: cmd/incus/info.go:688
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530
+#: cmd/incus/bug.go:293
+msgid "How to reproduce this bug?"
+msgstr ""
+
+#: cmd/incus/info.go:528 cmd/incus/info.go:539
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3484,12 +3502,12 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:140
+#: cmd/incus/info.go:149
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
+#: cmd/incus/info.go:237 cmd/incus/info.go:304 cmd/incus/info.go:328
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -3502,7 +3520,7 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:381
+#: cmd/incus/info.go:390
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
@@ -3511,7 +3529,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:775
+#: cmd/incus/info.go:779
 msgid "IP addresses"
 msgstr ""
 
@@ -3551,7 +3569,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:473
+#: cmd/incus/main.go:477
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3693,7 +3711,7 @@ msgstr ""
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:257
+#: cmd/incus/info.go:266
 msgid "Infiniband:"
 msgstr ""
 
@@ -3701,7 +3719,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:885
+#: cmd/incus/info.go:889
 msgid "Instance Only"
 msgstr ""
 
@@ -3858,7 +3876,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:573 cmd/incus/storage.go:145
+#: cmd/incus/main.go:577 cmd/incus/storage.go:145
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3905,7 +3923,15 @@ msgstr ""
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:260
+#: cmd/incus/bug.go:240
+msgid "Is there an existing issue for this?"
+msgstr ""
+
+#: cmd/incus/bug.go:250
+msgid "Is this happening on an up to date version of Incus?"
+msgstr ""
+
+#: cmd/incus/info.go:269
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -3918,7 +3944,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:687
 msgid "Kernel Version"
 msgstr ""
 
@@ -3949,7 +3975,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:674
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3972,12 +3998,12 @@ msgstr ""
 msgid "Launching the instance"
 msgstr ""
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:260
 #, c-format
 msgid "Link detected: %v"
 msgstr ""
 
-#: cmd/incus/info.go:253
+#: cmd/incus/info.go:262
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
@@ -4859,11 +4885,11 @@ msgstr ""
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:505
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1472
+#: cmd/incus/info.go:662 cmd/incus/storage_volume.go:1472
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4872,7 +4898,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:916
+#: cmd/incus/info.go:920
 msgid "Log:"
 msgstr ""
 
@@ -4913,7 +4939,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:763
+#: cmd/incus/info.go:767
 msgid "MAC address"
 msgstr ""
 
@@ -4922,7 +4948,7 @@ msgstr ""
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:264
+#: cmd/incus/info.go:273
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -4960,7 +4986,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:767
+#: cmd/incus/info.go:771
 msgid "MTU"
 msgstr ""
 
@@ -5192,12 +5218,12 @@ msgstr ""
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:177 cmd/incus/info.go:286
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:179
+#: cmd/incus/info.go:188
 msgid "Mdev profiles:"
 msgstr ""
 
@@ -5226,19 +5252,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:722
+#: cmd/incus/info.go:726
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:726
+#: cmd/incus/info.go:730
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:738
+#: cmd/incus/info.go:742
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:526
 msgid "Memory:"
 msgstr ""
 
@@ -5474,12 +5500,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:299
+#: cmd/incus/info.go:308
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:168
 #, c-format
 msgid "Model: %v"
 msgstr ""
@@ -5596,11 +5622,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:560
+#: cmd/incus/info.go:569
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:563
+#: cmd/incus/info.go:572
 msgid "NICs:"
 msgstr ""
 
@@ -5611,26 +5637,26 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:129 cmd/incus/info.go:215 cmd/incus/info.go:302
+#: cmd/incus/info.go:389
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:535
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:165
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:161
+#: cmd/incus/info.go:170
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1514
+#: cmd/incus/info.go:835 cmd/incus/info.go:886 cmd/incus/storage_volume.go:1514
 #: cmd/incus/storage_volume.go:1564
 msgid "Name"
 msgstr ""
@@ -5691,13 +5717,13 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:636 cmd/incus/network.go:1004
+#: cmd/incus/info.go:655 cmd/incus/network.go:1004
 #: cmd/incus/storage_volume.go:1454
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:333
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -5842,7 +5868,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:788 cmd/incus/network.go:1026
+#: cmd/incus/info.go:792 cmd/incus/network.go:1026
 msgid "Network usage:"
 msgstr ""
 
@@ -5933,7 +5959,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:537
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5952,11 +5978,11 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:685
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:686
 msgid "OS Version"
 msgstr ""
 
@@ -6005,7 +6031,7 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:684
 msgid "Operating System:"
 msgstr ""
 
@@ -6014,7 +6040,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1568
+#: cmd/incus/info.go:890 cmd/incus/storage_volume.go:1568
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6026,16 +6052,16 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:131 cmd/incus/info.go:217
+#: cmd/incus/info.go:140 cmd/incus/info.go:226
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:605
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:599
+#: cmd/incus/info.go:608
 msgid "PCI devices:"
 msgstr ""
 
@@ -6047,7 +6073,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:666
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -6084,19 +6110,19 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:772 cmd/incus/network.go:1029
+#: cmd/incus/info.go:776 cmd/incus/network.go:1029
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/network.go:1030
+#: cmd/incus/info.go:777 cmd/incus/network.go:1030
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:325
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:434
+#: cmd/incus/main.go:438
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6160,17 +6186,21 @@ msgstr ""
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:243
+#: cmd/incus/info.go:252
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:234
 msgid "Ports:"
 msgstr ""
 
 #: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
+msgstr ""
+
+#: cmd/incus/bug.go:29 cmd/incus/bug.go:30
+msgid "Prepare bug reports"
 msgstr ""
 
 #: cmd/incus/top.go:447
@@ -6225,7 +6255,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:498 cmd/incus/info.go:691
+#: cmd/incus/info.go:507 cmd/incus/info.go:695
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6235,22 +6265,22 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:366 cmd/incus/info.go:379
+#: cmd/incus/info.go:375 cmd/incus/info.go:388
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:467
+#: cmd/incus/info.go:476
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
+#: cmd/incus/info.go:374 cmd/incus/info.go:387 cmd/incus/info.go:425
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:127 cmd/incus/info.go:213
+#: cmd/incus/info.go:136 cmd/incus/info.go:222
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
@@ -6419,7 +6449,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:312 cmd/incus/info.go:321
+#: cmd/incus/info.go:321 cmd/incus/info.go:330
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -6510,7 +6540,7 @@ msgstr ""
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:313
+#: cmd/incus/info.go:322
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -6676,9 +6706,13 @@ msgstr ""
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:151
+#: cmd/incus/info.go:160
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: cmd/incus/bug.go:176 cmd/incus/bug.go:177
+msgid "Report a bug"
 msgstr ""
 
 #: cmd/incus/cluster.go:1032 cmd/incus/cluster.go:1033
@@ -6689,7 +6723,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:693
 msgid "Resources:"
 msgstr ""
 
@@ -6787,7 +6821,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:428
+#: cmd/incus/info.go:437
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6800,7 +6834,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:175 cmd/incus/info.go:284
 msgid "SR-IOV information:"
 msgstr ""
 
@@ -6874,17 +6908,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:370
+#: cmd/incus/info.go:379
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:455 cmd/incus/info.go:471
+#: cmd/incus/info.go:464 cmd/incus/info.go:480
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:441
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -7305,7 +7339,7 @@ msgstr ""
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:36 cmd/incus/info.go:37
+#: cmd/incus/info.go:35 cmd/incus/info.go:36
 msgid "Show instance or server information"
 msgstr ""
 
@@ -7313,7 +7347,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:313 cmd/incus/main.go:314
+#: cmd/incus/main.go:317 cmd/incus/main.go:318
 msgid "Show less common commands"
 msgstr ""
 
@@ -7423,6 +7457,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/bug.go:58 cmd/incus/bug.go:59
+msgid "Show system details to include in bug reports"
+msgstr ""
+
 #: cmd/incus/project.go:1210 cmd/incus/project.go:1211
 msgid "Show the current project"
 msgstr ""
@@ -7435,15 +7473,15 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:47 cmd/incus/project.go:1097
+#: cmd/incus/info.go:46 cmd/incus/project.go:1097
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:47
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:49
+#: cmd/incus/info.go:48
 msgid "Show the resources available to the server"
 msgstr ""
 
@@ -7484,7 +7522,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:306 cmd/incus/info.go:322
+#: cmd/incus/info.go:315 cmd/incus/info.go:331
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -7501,11 +7539,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1493
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1493
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:511
+#: cmd/incus/info.go:520
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7533,7 +7571,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:679
 #, c-format
 msgid "Started: %s"
 msgstr ""
@@ -7547,7 +7585,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:761
 msgid "State"
 msgstr ""
 
@@ -7556,11 +7594,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:834
+#: cmd/incus/info.go:838
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:638
+#: cmd/incus/info.go:657
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7679,21 +7717,21 @@ msgstr ""
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:235
+#: cmd/incus/info.go:244
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:239
+#: cmd/incus/info.go:248
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:730
+#: cmd/incus/info.go:734
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:734
+#: cmd/incus/info.go:738
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7709,7 +7747,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:406
+#: cmd/incus/info.go:415
 msgid "System:"
 msgstr ""
 
@@ -7734,7 +7772,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1565
+#: cmd/incus/info.go:836 cmd/incus/info.go:887 cmd/incus/storage_volume.go:1565
 msgid "Taken at"
 msgstr ""
 
@@ -8002,7 +8040,7 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:397
+#: cmd/incus/info.go:406
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8023,7 +8061,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:357
+#: cmd/incus/main.go:361
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8031,6 +8069,13 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/bug.go:233
+msgid ""
+"This command is dedicated to reporting bugs found in Incus. For all support "
+"requests and other questions, please ask on our forum, https://"
+"discuss.linuxcontainers.org."
 msgstr ""
 
 #: cmd/incus/webui_windows.go:15
@@ -8049,7 +8094,7 @@ msgstr ""
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:356
 msgid "Threads:"
 msgstr ""
 
@@ -8073,16 +8118,16 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:481
+#: cmd/incus/main.go:485
 #, c-format
 msgid ""
 "To start your first container, try: incus launch images:%s\n"
 "Or for a virtual machine: incus launch images:%s --vm"
 msgstr ""
 
-#: cmd/incus/config.go:303 cmd/incus/config.go:496 cmd/incus/config.go:707
-#: cmd/incus/config.go:805 cmd/incus/copy.go:147 cmd/incus/info.go:389
-#: cmd/incus/network.go:992 cmd/incus/storage.go:546
+#: cmd/incus/bug.go:117 cmd/incus/config.go:303 cmd/incus/config.go:496
+#: cmd/incus/config.go:707 cmd/incus/config.go:805 cmd/incus/copy.go:147
+#: cmd/incus/info.go:398 cmd/incus/network.go:992 cmd/incus/storage.go:546
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8091,13 +8136,13 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
-#: cmd/incus/info.go:544
+#: cmd/incus/info.go:531 cmd/incus/info.go:542 cmd/incus/info.go:547
+#: cmd/incus/info.go:553
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:247
+#: cmd/incus/info.go:256
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
@@ -8146,7 +8191,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:756
+#: cmd/incus/info.go:760
 msgid "Type"
 msgstr ""
 
@@ -8164,8 +8209,8 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
-#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1012
+#: cmd/incus/image.go:1014 cmd/incus/info.go:312 cmd/incus/info.go:445
+#: cmd/incus/info.go:456 cmd/incus/info.go:658 cmd/incus/network.go:1012
 #: cmd/incus/storage_volume.go:1463
 #, c-format
 msgid "Type: %s"
@@ -8187,11 +8232,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:593
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:596
 msgid "USB devices:"
 msgstr ""
 
@@ -8207,7 +8252,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:162 cmd/incus/info.go:408
+#: cmd/incus/info.go:171 cmd/incus/info.go:417
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8296,7 +8341,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:885 cmd/incus/config.go:886
+#: cmd/incus/config.go:896 cmd/incus/config.go:897
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -8441,11 +8486,11 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:890
+#: cmd/incus/config.go:901
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:908
+#: cmd/incus/info.go:912
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8502,8 +8547,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
-#: cmd/incus/info.go:543
+#: cmd/incus/info.go:530 cmd/incus/info.go:541 cmd/incus/info.go:546
+#: cmd/incus/info.go:552
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8521,7 +8566,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:170 cmd/incus/info.go:279
+#: cmd/incus/info.go:179 cmd/incus/info.go:288
 #, c-format
 msgid "VFs: %d"
 msgstr ""
@@ -8538,38 +8583,38 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:373 cmd/incus/info.go:386
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
+#: cmd/incus/info.go:452 cmd/incus/info.go:472 cmd/incus/info.go:492
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
-#: cmd/incus/info.go:412
+#: cmd/incus/info.go:338 cmd/incus/info.go:372 cmd/incus/info.go:385
+#: cmd/incus/info.go:421
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:123 cmd/incus/info.go:209
+#: cmd/incus/info.go:132 cmd/incus/info.go:218
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:268
+#: cmd/incus/info.go:277
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
+#: cmd/incus/info.go:460 cmd/incus/info.go:484 cmd/incus/info.go:496
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:424
+#: cmd/incus/info.go:433
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -8586,7 +8631,7 @@ msgstr ""
 msgid "WARNING: The IncusOS API and configuration is subject to change"
 msgstr ""
 
-#: cmd/incus/info.go:309
+#: cmd/incus/info.go:318
 #, c-format
 msgid "WWN: %s"
 msgstr ""
@@ -8621,6 +8666,13 @@ msgid ""
 "they otherwise would."
 msgstr ""
 
+#: cmd/incus/bug.go:298
+msgid ""
+"We will now submit your issue on GitHub. This is your last chance to review "
+"it (wording, secret leakage...) before it is published online. Do you want "
+"to review it?"
+msgstr ""
+
 #: cmd/incus/webui_unix.go:120
 #, c-format
 msgid "Web server running at: %s"
@@ -8636,6 +8688,14 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "What is the current behavior?"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "What is the expected behavior?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:122
@@ -8776,7 +8836,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
+#: cmd/incus/bug.go:57 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:464
 #: cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:614
 #: cmd/incus/monitor.go:33 cmd/incus/network_acl.go:95
 #: cmd/incus/network_address_set.go:92 cmd/incus/network_integration.go:416
@@ -9444,11 +9504,11 @@ msgstr ""
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:35
+#: cmd/incus/bug.go:175 cmd/incus/info.go:34
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:388 cmd/incus/config.go:884
+#: cmd/incus/config.go:388 cmd/incus/config.go:895
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
@@ -9462,6 +9522,14 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1031
 msgid "[[<remote>:]<member>]"
+msgstr ""
+
+#: cmd/incus/bug.go:288
+msgid "a concise description of what you expected to happen"
+msgstr ""
+
+#: cmd/incus/bug.go:283
+msgid "a concise description of what you're experiencing"
 msgstr ""
 
 #: cmd/incus/info.go:646
@@ -9527,6 +9595,15 @@ msgstr ""
 msgid ""
 "incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
+msgstr ""
+
+#: cmd/incus/bug.go:179
+msgid ""
+"incus bug report [<remote>:]<instance>\n"
+"    To report an instance-related bug.\n"
+"\n"
+"incus bug report [<remote>:]\n"
+"    To report a server-related bug."
 msgstr ""
 
 #: cmd/incus/cluster.go:912
@@ -9674,7 +9751,7 @@ msgid ""
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:39
+#: cmd/incus/info.go:38
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10120,6 +10197,10 @@ msgstr ""
 #: cmd/incus/utils.go:635
 #, c-format
 msgid "sshfs mounting %q on %q"
+msgstr ""
+
+#: cmd/incus/bug.go:293
+msgid "step by step instructions to reproduce the behavior"
 msgstr ""
 
 #: cmd/incus/storage.go:573


### PR DESCRIPTION
Closes: #2337

I thought that just stripping sensitive data was a bit weak for a whole new command, so I decided to go a bit wild.

@stgraber, please create an OAuth app called “Incus” or “Incus Client” (or the like) under the `lxc` org and give me its `clientID`. In the meantime, you can test it on my personal public repo hardcoded in this PR code.

This PR doesn’t take any care about proxies, so additional patches may be needed (I’d like to be pointed to the right direction). Additionally, the issues generated by `incus bug report` don’t include a type, so you may need additional work on GitHub side to get them automatically typed as `Bug`.