### PR TITLE
mount sysfs as read-only

### DIFF
--- a/cmd/incusd/main_forknet.go
+++ b/cmd/incusd/main_forknet.go
@@ -64,7 +64,7 @@ static void forkdonetdetach(char *file) {
 		_exit(1);
 	}
 
-	if (mount("sysfs", "/sys", "sysfs", 0, NULL) < 0) {
+	if (mount("sysfs", "/sys", "sysfs", MS_RDONLY, NULL) < 0) {
 		fprintf(stderr, "Failed mounting new sysfs: %s\n", strerror(errno));
 		_exit(1);
 	}

--- a/internal/server/apparmor/instance_lxc.profile.go
+++ b/internal/server/apparmor/instance_lxc.profile.go
@@ -88,7 +88,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 
   # Handle sysfs (access handled below)
   mount fstype=sysfs -> /sys/,
-  mount options=(rw,nosuid,nodev,noexec,remount) -> /sys/,
+  mount options=(ro,nosuid,nodev,noexec,remount) -> /sys/,
 
   # Handle /run remounts.
   mount options=(rw,nosuid,nodev,remount) -> /run/,

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -772,7 +772,7 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 		mounts = append(mounts, "sys:mixed")
 	} else {
 		mounts = append(mounts, "proc:rw")
-		mounts = append(mounts, "sys:rw")
+		mounts = append(mounts, "sys:ro")
 	}
 
 	cgInfo := cgroup.GetInfo()


### PR DESCRIPTION
With a recent update to systemd 258 in my containers, I noticed `console-getty.service` not working anymore with some kind of spawn error. With help from the lovely people over at systemd (https://github.com/systemd/systemd/issues/39036), I tracked this down to incus mounting `/sys/` as read-write which does not comply with systemd's specified container interface described in https://systemd.io/CONTAINER_INTERFACE/.

For this PR, I found all places (hopefully) that mount /sys as read-write and changed them to readonly which has fixed the issues with systemd for me so far. I personally never used either the hidden `forknet` command or the apparmor feature so I can't tell if those respective changes even work. Some more testing is definitely required.