### PR TITLE
Re-enable LINSTOR tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,6 +140,7 @@ jobs:
           - lvm
           - zfs
           - ceph
+          - linstor
           - random
         os:
           - ubuntu-24.04


### PR DESCRIPTION
Closes: #2409

LINSTOR 1.32.3 has landed on LINBIT’s ppa