### PR TITLE
Revert "github: Disable Linstor tests for now"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,6 +140,7 @@ jobs:
           - lvm
           - zfs
           - ceph
+          - linstor
           - random
         os:
           - ubuntu-24.04


### PR DESCRIPTION
This reverts commit 9baf88b37b6df003bd4f8ade553b9b560e406ca0.

Closes #2409