### PR TITLE
incusd/instance/lxc: Fix handling of credentials on existing instances

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -9319,7 +9319,7 @@ func (d *lxc) setupCredentials(update bool) error {
 	}
 
 	// Cleanup the credentials directory.
-	if update {
+	if update && util.PathExists(credentialsDir) {
 		credEntries, err := os.ReadDir(credentialsDir)
 		if err != nil {
 			return fmt.Errorf("Failed to list credentials directory: %w", err)


### PR DESCRIPTION
This fixes an issue where profile updates fail on instances that were started prior to the introduction of the credentials feature.


Sponsored-by: https://webdock.io