### PR TITLE
incusd/instance/lxc: Don't apply credentials update on stopped contai…

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -9286,6 +9286,11 @@ func (d *lxc) CanLiveMigrate() bool {
 
 // setupCredentials sets up the systemd credentials directory.
 func (d *lxc) setupCredentials(update bool) error {
+	// Skip updating if the container isn't running.
+	if update && !d.IsRunning() {
+		return nil
+	}
+
 	credentialsDir := filepath.Join(d.Path(), "credentials")
 	credentials := map[string][]byte{}
 	oldCredentials := map[string]bool{}


### PR DESCRIPTION
…ners

This avoids an issue where the credentials directory would get created during the revert/failure case of a profile update affecting stopped containers.