### PR TITLE
Remove project name from operation response

### DIFF
--- a/internal/server/operations/response.go
+++ b/internal/server/operations/response.go
@@ -85,9 +85,6 @@ func ForwardedOperationResponse(project string, op *api.Operation) response.Resp
 
 func (r *forwardedOperationResponse) Render(w http.ResponseWriter) error {
 	url := fmt.Sprintf("/%s/operations/%s", version.APIVersion, r.op.ID)
-	if r.project != "" {
-		url += fmt.Sprintf("?project=%s", r.project)
-	}
 
 	body := api.ResponseRaw{
 		Type:       api.AsyncResponse,


### PR DESCRIPTION
Fixes https://github.com/lxc/incus/issues/2563

This PR removes the project name which is added as a query parameter whenever an async operation is executed on another node.
This is not according to the OpenAPI spec.