### PR TITLE
incusd/network/ovn: Tweak port removal logic

### DIFF
--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -47,7 +47,7 @@ type ovnNet interface {
 	InstanceDevicePortAdd(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
 	InstanceDevicePortStart(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (ovn.OVNSwitchPort, []net.IP, error)
 	InstanceDevicePortStop(ovsExternalOVNPort ovn.OVNSwitchPort, opts *network.OVNInstanceNICStopOpts) error
-	InstanceDevicePortRemove(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
+	InstanceDevicePortRemove(instanceUUID string, devName string, devConfig deviceConfig.Device, hasDuplicate bool) error
 	InstanceDevicePortIPs(instanceUUID string, deviceName string) ([]net.IP, error)
 }
 
@@ -1247,7 +1247,7 @@ func (d *nicOVN) Remove() error {
 		}
 	}
 
-	return d.network.InstanceDevicePortRemove(d.inst.LocalConfig()["volatile.uuid"], d.name, d.config)
+	return d.network.InstanceDevicePortRemove(d.inst.LocalConfig()["volatile.uuid"], d.name, d.config, d.checkAddressConflict() != nil)
 }
 
 // State gets the state of an OVN NIC by querying the OVN Northbound logical switch port record.


### PR DESCRIPTION
We used to rely on the DNS record existing to know whether a given instance was the original owner of an IPv4 address or was a secondary owner (as in causing a conflict), then only the primary would cause the deletion of the DNS record and IP allocation.

A recent bugfix changed the DNS logic to always release the allocation when the logical switch port goes away as we'd otherwise end up breaking OVN's ability to generate DNS records in the Southbound database.

That bugfix then effectively broke the logic around IP reservations by making it such that if two instances are conflicting, deleting the first one and then the second one leads to a ghost IP allocation preventing that address from being used again.

The fix here is to have the NIC perform the usual address conflict check and then pass on that result to the port remove logic so the OVN function can clear the IP allocation if no conflict exists but retain it otherwise.

This issue was discovered through our automated daily OVN tests.