### PR TITLE
client: Omit trailing ? for /events without query parameters

### DIFF
--- a/client/incus_events.go
+++ b/client/incus_events.go
@@ -64,7 +64,12 @@ func (r *ProtocolIncus) getEvents(allProjects bool, eventTypes []string) (*Event
 		queryParams = append(queryParams, "type="+strings.Join(eventTypes, ","))
 	}
 
-	eventsURL, err := r.setQueryAttributes("/events?" + strings.Join(queryParams, "&"))
+	eventsURL := "/events"
+	if len(queryParams) > 0 {
+		eventsURL += "?" + strings.Join(queryParams, "&")
+	}
+
+	eventsURL, err := r.setQueryAttributes(eventsURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
@stgraber You have been right, having the trailing `?` in `/events?` is not clean and it is actually leaked even with the URL being parsed with url.Parse, since the trailing `?` is detected during parsing and preserved in this case (https://cs.opensource.google/go/go/+/refs/tags/go1.25.3:src/net/url/url.go;l=538). It is cleaner to actually only add it, if necessary.

Followup to #2613 