### PR TITLE
incus/instance: Add missing godocs

### DIFF
--- a/internal/instance/snapshot.go
+++ b/internal/instance/snapshot.go
@@ -4,8 +4,10 @@ import (
 	"strings"
 )
 
+// SnapshotDelimiter is used to separate instance name from snapshot name.
 const SnapshotDelimiter = "/"
 
+// IsSnapshot checks if provided name is a snapshot name.
 func IsSnapshot(name string) bool {
 	return strings.Contains(name, SnapshotDelimiter)
 }


### PR DESCRIPTION
🏷️ #2636

## Description

There were two documentation-related linting issues in the `internal/instance` package.

Since both of them are using in other packages as well - I've decided to add brief godoc.
Hopefully it's not too `// THIS IS BRIDGE`-y.

---

  - First, rays of appreciation to all maintainers - Incus is awesome (for me as a homelab enthusiast at least 😄).
  - Second, I grabbed small and simple issue in small and simple package to go through all non-technical procedures first before cleaning up more complex linter issues.

## Before changes

```
internal/instance ❯ golangci-lint run
internal/instance/snapshot.go:7:7: exported: exported const SnapshotDelimiter should have comment or be unexported (revive)
const SnapshotDelimiter = "/"
      ^
internal/instance/snapshot.go:9:1: exported: exported function IsSnapshot should have comment or be unexported (revive)
func IsSnapshot(name string) bool {
^
2 issues:
* revive: 2
```

## After changes

```
internal/instance ❯ golangci-lint run
0 issues.
```

---

_[my PRs meta :)](https://github.com/dector/respect-busy-maintainers)_