### PR TITLE
incusd/instance/qemu: Fix macOS agent

### DIFF
--- a/internal/server/instance/drivers/agent-loader/incus-agent-setup-macos
+++ b/internal/server/instance/drivers/agent-loader/incus-agent-setup-macos
@@ -34,7 +34,7 @@ mount_tmpfs -s 50M "$PREFIX"
 chmod 0700 "$PREFIX"
 
 # Copy the data.
-cp -Ra "$VOLUME/"* "$PREFIX"
+cp -RaX "$VOLUME/"* "$PREFIX"
 
 # Unmount the temporary mount.
 umount "$VOLUME"

--- a/internal/server/instance/drivers/agent-loader/install-macos.sh
+++ b/internal/server/instance/drivers/agent-loader/install-macos.sh
@@ -19,6 +19,7 @@ fi
 # Install the daemon.
 cp "launchd/$AGENT.plist" /Library/LaunchDaemons/
 chown root:wheel "/Library/LaunchDaemons/$AGENT.plist"
+mkdir -p /usr/local/bin
 cp incus-agent-setup /usr/local/bin/
 chown root:wheel /usr/local/bin/incus-agent-setup
 


### PR DESCRIPTION
This commit allows the installer to create /usr/local/bin, which doesn’t exist on brand new installs. It also copies the config share data without extended attributes, which cause problems.