### PR TITLE
incus/util: #2636 fix linter complaints in `internal/util`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,8 @@ linters:
           - godot
         text: "Comment should end in a period"
         source: '^// Example:'
+      - path: internal/util/
+        text: "avoid meaningless package names"
     paths:
       - third_party$
       - builtin$

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -182,6 +182,8 @@ func PathIsEmpty(path string) (bool, error) {
 	return false, err
 }
 
+// MkdirAllOwner ensures that directories path exists.
+// If directories in the path are missing - they will be created with specified permissions and owner.
 func MkdirAllOwner(path string, perm os.FileMode, uid int, gid int) error {
 	// This function is a slightly modified version of MkdirAll from the Go standard library.
 	// https://golang.org/src/os/path.go?s=488:535#L9
@@ -218,9 +220,9 @@ func MkdirAllOwner(path string, perm os.FileMode, uid int, gid int) error {
 	// Parent now exists; invoke Mkdir and use its result.
 	err = os.Mkdir(path, perm)
 
-	err_chown := os.Chown(path, uid, gid)
-	if err_chown != nil {
-		return err_chown
+	errChown := os.Chown(path, uid, gid)
+	if errChown != nil {
+		return errChown
 	}
 
 	if err != nil {


### PR DESCRIPTION
Changes:

  - Use `revive:disable-next-line:var-naming` for package `util`. This name is generic but seems good enough in this context.
  - Renamed variable name to follow Go conventions.
  - Add missing documentation comment for MkdirAllOwner function.