### PR TITLE
Make /var/lib/incus/devices a tmpfs

### DIFF
--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1163,22 +1163,6 @@ func (d *Daemon) init() error {
 		}
 	}
 
-	// Validate the devices storage.
-	testDev := internalUtil.VarPath("devices", ".test")
-	testDevNum := int(unix.Mkdev(0, 0))
-	_ = os.Remove(testDev)
-	err = unix.Mknod(testDev, 0o600|unix.S_IFCHR, testDevNum)
-	if err == nil {
-		fd, err := os.Open(testDev)
-		if err != nil && os.IsPermission(err) {
-			logger.Warn("Unable to access device nodes, likely running on a nodev mount")
-			d.os.Nodev = true
-		}
-
-		_ = fd.Close()
-		_ = os.Remove(testDev)
-	}
-
 	/* Initialize the database */
 	err = initializeDbObject(d)
 	if err != nil {


### PR DESCRIPTION
By making it a tmpfs, it ensures that we can always create device nodes on it instead of having to hope that the filesystem backing /var/lib/incus happens to allow it.