### PR TITLE
doc: Remove mentions of IRC

### DIFF
--- a/doc/contributing/docs.md
+++ b/doc/contributing/docs.md
@@ -17,8 +17,6 @@ Typical ways to contribute are:
   We'll evaluate the issue and update the documentation accordingly.
 - Post a question or a suggestion on the [forum](https://discuss.linuxcontainers.org).
   We'll monitor the posts and, if needed, update the documentation accordingly.
-- Ask questions or provide suggestions in the `#lxc` channel on [IRC](https://web.libera.chat/#lxc).
-  Given the dynamic nature of IRC, we cannot guarantee answers or reactions to IRC posts, but we monitor the channel and try to improve our documentation based on the received feedback.
 
 % Include content from [../README.md](../README.md)
 ```{include} ../README.md

--- a/doc/index.md
+++ b/doc/index.md
@@ -37,7 +37,6 @@ It’s an open source project that warmly welcomes community projects, contribut
 - [Release tarballs](https://github.com/lxc/incus/releases/)
 - [Get support](support.md)
 - [Watch tutorials and announcements on YouTube](https://www.youtube.com/@TheZabbly)
-- [Discuss on IRC](https://web.libera.chat/#lxc) (see [Getting started with IRC](https://discuss.linuxcontainers.org/t/getting-started-with-irc/11920) if needed)
 - [Ask and answer questions on the forum](https://discuss.linuxcontainers.org)
 
 ```{toctree}


### PR DESCRIPTION
We're pushing folks towards the forum these days as it now has a built-in user-friendly live chat.