### PR TITLE
incusd/device/unix_hotplug: Prevent duplicate uevent injection

### DIFF
--- a/internal/server/device/unix_hotplug.go
+++ b/internal/server/device/unix_hotplug.go
@@ -140,6 +140,10 @@ func (d *unixHotplug) Register() error {
 			if err != nil {
 				return nil, err
 			}
+			// Return early to prevent injecting duplicate uevents.
+			if len(runConf.Mounts) == 0 {
+				return nil, nil
+			}
 
 			// Add a post hook function to remove the specific unix hotplug device file after unmount.
 			runConf.PostHooks = []func() error{func() error {


### PR DESCRIPTION
Duplicate remove uevents are injected into LXC containers when more than one unix-hotplug device is configured. The add uevent has a guard for the correct vendor/product device uevents but this doesn't work with remove because it lacks these fields. But, if no devices are marked for unmounting, we can exit early and avoid duplication.

Example scenario: two unix-hotplugs where one matches the hidraw0 device
Before (container udevadm monitor -k):
```
KERNEL[1297805.870598] add      /devices/platform/vhci_hcd.0/usb1/1-2 (usb)
KERNEL[1297805.972898] add      /devices/platform/vhci_hcd.0/usb1/1-2/1-2:1.0/0003:1050:0402.0008/hidraw/hidraw0 (hidraw)

KERNEL[1297728.343559] remove   /devices/platform/vhci_hcd.0/usb1/1-2/1-2:1.0/usbmisc/hiddev0 (usbmisc)
KERNEL[1297728.355734] remove   /devices/platform/vhci_hcd.0/usb1/1-2/1-2:1.0/usbmisc/hiddev0 (usbmisc)
KERNEL[1297728.410647] remove   /devices/platform/vhci_hcd.0/usb1/1-2/1-2:1.0/0003:1050:0402.0007/hidraw/hidraw0 (hidraw)
KERNEL[1297728.424289] remove   /devices/platform/vhci_hcd.0/usb1/1-2/1-2:1.0/0003:1050:0402.0007/hidraw/hidraw0 (hidraw)
KERNEL[1297728.559130] remove   /devices/platform/vhci_hcd.0/usb1/1-2 (usb)
KERNEL[1297728.593145] remove   /devices/platform/vhci_hcd.0/usb1/1-2 (usb)
```
After:
```
KERNEL[1302813.707669] add      /devices/platform/vhci_hcd.0/usb1/1-1 (usb)
KERNEL[1302813.796387] add      /devices/platform/vhci_hcd.0/usb1/1-1/1-1:1.0/0003:1050:0402.000C/hidraw/hidraw0 (hidraw)

KERNEL[1302839.881288] remove   /devices/platform/vhci_hcd.0/usb1/1-1/1-1:1.0/0003:1050:0402.000C/hidraw/hidraw0 (hidraw)
KERNEL[1302839.968908] remove   /devices/platform/vhci_hcd.0/usb1/1-1 (usb)
```