### PR TITLE
Fix determination of target path for `storage volume file mount` command

### DIFF
--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -2748,7 +2748,7 @@ func (c *cmdStorageVolumeFileMount) Run(cmd *cobra.Command, args []string) error
 	var targetPath string
 
 	// Determine the target if specified.
-	if len(args) >= 2 {
+	if len(args) >= 3 {
 		targetPath = filepath.Clean(args[len(args)-1])
 		sb, err := os.Stat(targetPath)
 		if err != nil {


### PR DESCRIPTION
`storage volume file mount` requires at least two arguments (storage and volume), so the previous `targetPath` determination was incorrect. As a result, `os.Stat` was executed on the volume name, because it was incorrectly treated as the `targetPath`.

Fixes: #2681