### PR TITLE
agent-loader/install-linux.sh Fix SELinux issue with agent run path

### DIFF
--- a/internal/server/instance/drivers/agent-loader/install-linux.sh
+++ b/internal/server/instance/drivers/agent-loader/install-linux.sh
@@ -36,7 +36,10 @@ systemctl daemon-reload
 
 # SELinux handling.
 if getenforce >/dev/null 2>&1 && type semanage >/dev/null 2>&1; then
-    semanage fcontext -a -t bin_t /var/run/incus_agent/incus-agent
+    # Run semanage for both /var/run and /run due to different distro policies
+    for run_path in /var/run /run; do
+        semanage fcontext -a -t bin_t "${run_path}/incus_agent/incus-agent"
+    done
 fi
 
 echo ""


### PR DESCRIPTION
Run semanage for both /var/run and /run due to different distro policies

Closes #2717 