### PR TITLE
Add Default Environment Variables for the Windows Agent

### DIFF
--- a/cmd/incus-agent/os_windows.go
+++ b/cmd/incus-agent/os_windows.go
@@ -237,5 +237,14 @@ func osExitStatus(err error) (int, error) {
 }
 
 func osSetEnv(post *api.InstanceExecPost, env map[string]string) {
-	env["PATH"] = "C:\\WINDOWS\\system32;C:\\WINDOWS"
+	// SystemRoot is already set by default
+	env["WINDIR"] = "C:\\WINDOWS"
+	env["TMP"] = "C:\\WINDOWS\\Temp"
+	env["TEMP"] = env["TMP"]
+	env["PATH"] = "C:\\WINDOWS\\System32;C:\\WINDOWS;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0"
+
+	// Set the default working directory.
+	if post.Cwd == "" {
+		post.Cwd = "C:\\Windows\\System32"
+	}
 }


### PR DESCRIPTION
Currently, the Windows agent did not have `WINDIR`, `TEMP` and `TMP` environment variables which are used by some cmdlets and more.

That makes the a few cmdlets fail and thus, making it mandatory to add environment variables through the Incus exec command as a parameter such as `incus exec --env WINDIR="C:\\WINDOWS" ...`. However, some of them should be present by default in a Windows environment.

Furthermore, I've updated the current working directory that is usually `C:\WINDOWS\System32\` when running as `nt authority\system`.