### PR TITLE
instance/drivers/driver_common: Fix cat order bug in selinuxContext()

### DIFF
--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -1760,6 +1760,10 @@ func (d *common) selinuxContext(baseContext string) (string, error) {
 			continue
 		}
 
+		if c1 > c2 {
+			c1, c2 = c2, c1
+		}
+
 		seContext := baseContext + ":c" + strconv.Itoa(c1) + ",c" + strconv.Itoa(c2)
 		if slices.Contains(seContexts, seContext) {
 			continue


### PR DESCRIPTION
This change fixes a bug, where we may end up with instances having the same generated selinux context.

The order of categories does not matter to the kernel and will always be sorted. So :c1,c2 is the same as :c2,c1.

This change makes sure that c1 is always smaller than c2 to avoid a collision.

Note: even if we start a process with c1 being greater than c2 the kernel will not complain but silently order the categories properly. So if we read the context from attr/current it will always be sorted.