### PR TITLE
incus/create: Allow reading Ephemeral flag from stdin

### DIFF
--- a/cmd/incus/create.go
+++ b/cmd/incus/create.go
@@ -288,7 +288,10 @@ func (c *cmdCreate) create(conf *config.Config, args []string, launch bool) (inc
 	}
 
 	req.Config = configMap
-	req.Ephemeral = c.flagEphemeral
+
+	if c.flagEphemeral {
+		req.Ephemeral = c.flagEphemeral
+	}
 
 	if c.flagDescription != "" {
 		req.Description = c.flagDescription


### PR DESCRIPTION
The current logic was always overriding the value.