### PR TITLE
incusd/device/nic_physical: Fix VLAN for VMs

### DIFF
--- a/internal/server/device/nic_physical.go
+++ b/internal/server/device/nic_physical.go
@@ -147,7 +147,7 @@ func (d *nicPhysical) validateConfig(instConf instance.ConfigReader) error {
 		//  default: randomly assigned
 		//  managed: no
 		//  shortdesc: The MAC address of the new interface
-		optionalFields = append(optionalFields, "hwaddr")
+		optionalFields = append(optionalFields, "hwaddr", "vlan")
 
 		// Copy certain keys verbatim from the network's settings.
 		for _, field := range optionalFields {


### PR DESCRIPTION
Traditionally VLANs can't be set for VMs as they get a full PCIe card when in physical mode. But that ignores the fact that we allow using a managed physical network entry with external bridges these days, in which case we can in fact apply VLANs just fine.