### PR TITLE
tests/incremental_copy: Disable under Linstor

### DIFF
--- a/test/suites/incremental_copy.sh
+++ b/test/suites/incremental_copy.sh
@@ -1,4 +1,9 @@
 test_incremental_copy() {
+    if [ "${INCUS_BACKEND}" = "linstor" ]; then
+        echo "==> SKIP: Linstor is known to have issues with refresh copies in Github tests"
+        return
+    fi
+
     ensure_import_testimage
     ensure_has_localhost_remote "${INCUS_ADDR}"
 


### PR DESCRIPTION
Not ideal but still better to have all other tests run at least...