### PR TITLE
incusd/network/zone: Allow trailing dot in NS records

### DIFF
--- a/internal/server/network/zone/zone.go
+++ b/internal/server/network/zone/zone.go
@@ -563,7 +563,7 @@ func (d *zone) Content() (*strings.Builder, error) {
 	// Get the nameservers.
 	nameservers := []string{}
 	for _, entry := range strings.Split(d.info.Config["dns.nameservers"], ",") {
-		entry = strings.TrimSpace(entry)
+		entry = strings.TrimSuffix(strings.TrimSpace(entry), ".")
 		if entry == "" {
 			continue
 		}


### PR DESCRIPTION
We've been expecting a list of FQDNs (no trailing dots) and so were always prepending a dot in the template. Let's allow the user to feed us a list of NS values (canonical with trailing dot) and make the resulting zone valid.