### PR TITLE
shared/tls: implement Happy Eyeballs (RFC 8305) in RFC3493Dialer

### DIFF
--- a/shared/tls/tls_test.go
+++ b/shared/tls/tls_test.go
@@ -1,0 +1,66 @@
+package tls
+
+import (
+	"testing"
+)
+
+func TestSortAddressesByFamily(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "IPv4 only",
+			input:    []string{"192.168.1.1", "10.0.0.1"},
+			expected: []string{"192.168.1.1", "10.0.0.1"},
+		},
+		{
+			name:     "IPv6 only",
+			input:    []string{"2001:db8::1", "2001:db8::2"},
+			expected: []string{"2001:db8::1", "2001:db8::2"},
+		},
+		{
+			name:     "Mixed - IPv4 first in input",
+			input:    []string{"192.168.1.1", "2001:db8::1", "10.0.0.1", "2001:db8::2"},
+			expected: []string{"2001:db8::1", "2001:db8::2", "192.168.1.1", "10.0.0.1"},
+		},
+		{
+			name:     "Mixed - IPv6 first in input",
+			input:    []string{"2001:db8::1", "192.168.1.1", "2001:db8::2", "10.0.0.1"},
+			expected: []string{"2001:db8::1", "2001:db8::2", "192.168.1.1", "10.0.0.1"},
+		},
+		{
+			name:     "Empty input",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "Single IPv4",
+			input:    []string{"192.168.1.1"},
+			expected: []string{"192.168.1.1"},
+		},
+		{
+			name:     "Single IPv6",
+			input:    []string{"2001:db8::1"},
+			expected: []string{"2001:db8::1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sortAddressesByFamily(tt.input)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("length mismatch: got %d, expected %d", len(result), len(tt.expected))
+				return
+			}
+
+			for i, addr := range result {
+				if addr != tt.expected[i] {
+					t.Errorf("address mismatch at index %d: got %s, expected %s", i, addr, tt.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The RFC3493Dialer function, before this, tried addresses sequentially with a 10-second timeout per address. This causes problems in dual-stack environments where one address family is unreachable:

- If DNS returns IPv4 addresses first but IPv4 is unreachable (e.g., in IPv6-only environments), the dialer would spend 10+ seconds timing out on each IPv4 address before trying IPv6.
- This exceeded typical HTTP client timeouts, causing connection failures even when IPv6 connectivity was available.
  For example, [cluster-api-provider-incus](https://github.com/lxc/cluster-api-provider-incus) would end up with `Context Deadline Exceeded` since it seems to have a 10-second timeout when fetching the list of images.

This change basically implements Happy Eyeballs (RFC 8305):

1. Sort addresses with IPv6 first (RFC 8305 recommends preferring IPv6)
2. Start connection attempts with a 250ms staggered delay (per RFC 8305)
3. Return the first successful connection immediately
4. Finally clean up unused connections