### PR TITLE
incusd/instance/qemu: Fix regression in reported state

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -8871,6 +8871,10 @@ func (d *qemu) renderState(statusCode api.StatusCode) (*api.InstanceState, error
 		}
 	}
 
+	// Override VM state back to QEMU state.
+	status.Status = statusCode.String()
+	status.StatusCode = statusCode
+
 	// Add the network details if missing.
 	if len(status.Network) == 0 {
 		networkState, err := d.getNetworkState()


### PR DESCRIPTION
The agent reported status and status_code is typically empty, so we need to re-apply the correct status (from QEMU) after getting the agent data.