### PR TITLE
incus/io: #2636 fix linter complaints in `internal/io`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,10 @@ linters:
         source: '^//generate-database:mapper '
       - linters:
           - revive
+        text: "avoid package names that conflict with Go standard library package names"
+        path: "^internal/io/"
+      - linters:
+          - revive
           - godot
         path: "^test/mini-oidc/storage/"
       - linters:

--- a/internal/io/filesystem_unix.go
+++ b/internal/io/filesystem_unix.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 )
 
+// GetOwnerMode returns the file mode, owner UID, and owner GID for the given file.
 func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
 	mode := fInfo.Mode()
 	uid := int(fInfo.Sys().(*syscall.Stat_t).Uid)

--- a/internal/io/readseeker.go
+++ b/internal/io/readseeker.go
@@ -14,10 +14,12 @@ func NewReadSeeker(reader io.Reader, seeker io.Seeker) io.ReadSeeker {
 	return &readSeeker{Reader: reader, Seeker: seeker}
 }
 
+// Read reads data from the reader.
 func (r *readSeeker) Read(p []byte) (n int, err error) {
 	return r.Reader.Read(p)
 }
 
+// Seek seeks to the specified offset.
 func (r *readSeeker) Seek(offset int64, whence int) (int64, error) {
 	return r.Seeker.Seek(offset, whence)
 }

--- a/internal/io/writer.go
+++ b/internal/io/writer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// WriteAll copies content of data to specified writer.
 func WriteAll(w io.Writer, data []byte) error {
 	buf := bytes.NewBuffer(data)
 

--- a/internal/rsync/rsync.go
+++ b/internal/rsync/rsync.go
@@ -440,7 +440,7 @@ func rsyncFeatureArgs(features []string) []string {
 }
 
 // AtLeast compares the local version to a minimum version.
-func AtLeast(min string) bool {
+func AtLeast(minimum string) bool {
 	// Parse the current version.
 	out, err := subprocess.RunCommand("rsync", "--version")
 	if err != nil {
@@ -460,7 +460,7 @@ func AtLeast(min string) bool {
 	}
 
 	// Load minimum version.
-	minVer, err := version.NewDottedVersion(min)
+	minVer, err := version.NewDottedVersion(minimum)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Changes:

  - Added missing docstrings.
  - Renamed `min` function parameter to `minimum`.