### PR TITLE
incusd/devices/tpm: Make incompatible with live-migration

### DIFF
--- a/internal/server/device/tpm.go
+++ b/internal/server/device/tpm.go
@@ -209,6 +209,10 @@ func (d *tpm) startContainer() (*deviceConfig.RunConfig, error) {
 }
 
 func (d *tpm) startVM() (*deviceConfig.RunConfig, error) {
+	if d.inst.Type() == instancetype.VM && util.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return nil, errors.New("TPM devices cannot be used when migration.stateful is enabled")
+	}
+
 	tpmDevPath := filepath.Join(d.inst.Path(), fmt.Sprintf("tpm.%s", d.name))
 	socketPath := filepath.Join(tpmDevPath, fmt.Sprintf("swtpm-%s.sock", d.name))
 	runConf := deviceConfig.RunConfig{


### PR DESCRIPTION
We don't currently support swtpm register live migration, so even if the VM can be moved successfully, we'll be left with a freshly started TPM which will confuse the guest OS.