### PR TITLE
OpenFGA: Documentation now explains that the api_token is needed if you want to activate OpenFGA.

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -5279,7 +5279,7 @@ This value is required by some providers.
 :scope: "global"
 :shortdesc: "API token of the OpenFGA server"
 :type: "string"
-
+This value is required to activate the OpenFGA integration.
 ```
 
 ```{config:option} openfga.api.url server-openfga


### PR DESCRIPTION
Signed-off-by: Tim Beermann <tibeer@berryit.de>
