### PR TITLE
incusd/network/ovn: Drop now obsolete DNS check

### DIFF
--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -2216,10 +2216,6 @@ func (o *NB) GetLogicalSwitchPortDNS(ctx context.Context, portName OVNSwitchPort
 		return "", "", nil, nil
 	}
 
-	if len(dnsRecords[0].Records) > 1 {
-		return "", "", nil, errors.New("More than one DNS record found for logical switch port")
-	}
-
 	var ips []net.IP
 	var dnsName string
 


### PR DESCRIPTION
As we now populate PTR records, we can get up to 3 records per LSP.