### PR TITLE
incusd/storage/truenas: Fix SetVolumeQuota issue when growing FS volumes

### DIFF
--- a/internal/server/storage/drivers/driver_truenas.go
+++ b/internal/server/storage/drivers/driver_truenas.go
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	tnVersion string
-	tnLoaded  bool
+	tnVersion         string
+	tnLoaded          bool
+	tnHasIscsiRefresh bool
 )
 
 var tnDefaultSettings = map[string]string{
@@ -74,6 +75,9 @@ func (d *truenas) initVersionAndCapabilities() error {
 	if !d.isVersionGE(*ourVer, tnMinVersion) {
 		return fmt.Errorf("TrueNAS driver requires %s v%s or later, but the currently installed version is v%s", tnToolName, tnMinVersion, tnVersion)
 	}
+
+	// iscsi refresh allows rescanning the iscsi bus
+	tnHasIscsiRefresh = d.isVersionGE(*ourVer, "0.7.5")
 
 	return nil
 }

--- a/internal/server/storage/drivers/driver_truenas_utils.go
+++ b/internal/server/storage/drivers/driver_truenas_utils.go
@@ -540,6 +540,20 @@ func (d *truenas) deactivateIscsiDataset(dataset string) error {
 	return nil
 }
 
+// refreshIscsiBus refreshes the iscsi bus.
+func (d *truenas) refreshIscsiBus() error {
+	if !tnHasIscsiRefresh {
+		return fmt.Errorf("TrueNAS: iSCSI Refresh requires tool version 0.7.5, current version: %s", tnVersion)
+	}
+
+	_, err := d.runTool("share", "iscsi", "refresh")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (d *truenas) deleteSnapshot(snapshot string, recursive bool, options ...string) error {
 	if strings.Count(snapshot, "@") != 1 {
 		return fmt.Errorf("invalid snapshot name: %s", snapshot)


### PR DESCRIPTION
Fixes #2776 

When growing an FS volume, the remote volume was resized, but the change was not visible until the remote volume was re-activated.

Thus the filesystem was only expanded to the visible size, but since the visible size was still the old size, this would cause a quiet failure.

The first thing to do was to actually check the device size after the resize to determine if the resize had succeeded before attempting a FS resize, which should then succeed

The second part of the fix is to simply activate the volume after resizing it rather than before, which means it can succeed.

Unfortunately, this means we could no longer grow an inUse filesystem, as we must de-activate in order to re-activate.

To rectify this, `iscsi refresh` support was added to the TrueNAS tool, and when using version >=0.7.5, the driver can refresh the iscsi bus to pickup a size change without having to de-activate an inUse volume.

When the `iscsi refresh` command is not available, and the volume is not in use, the driver will atttempt to de-activate the volume before changing the size.