### PR TITLE
Update Rocky Linux instructions

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -198,12 +198,12 @@ Make sure to mark the bug as being in the "Containers" component, to make sure t
 ```
 
 ```{group-tab} Rocky Linux
-RPM packages and their dependencies are not yet available from the Extra Packages for Enterprise Linux (EPEL) repository, but via the [`neil/incus`](https://copr.fedorainfracloud.org/coprs/neil/incus/) Community Project (COPR) repository for Rocky Linux 9 and the [`neelc/incus`](https://copr.fedorainfracloud.org/coprs/neelc/incus/) repository for Rocky Linux 10.
+RPM packages and their dependencies are not yet available from the Extra Packages for Enterprise Linux (EPEL) repository, but via the [`neelc/incus`](https://copr.fedorainfracloud.org/coprs/neelc/incus/) Community Project (COPR) repository for Rocky Linux 9 and 10.
 
 On Rocky Linux 9, ensure that the EPEL repository is installed for package dependencies and then install the COPR repository:
 
     dnf -y install epel-release
-    dnf copr enable neil/incus
+    dnf copr enable neelc/incus
 
 Ensure that the `CodeReady Builder` (`CRB`) is available for other package dependencies:
 
@@ -211,7 +211,7 @@ Ensure that the `CodeReady Builder` (`CRB`) is available for other package depen
 
 On Rocky Linux 10, ensure that the EPEL repository is installed for package dependencies and then install the COPR repository:
 
-    dnf config-manager --enable crb
+    dnf -y install epel-release
     cd /etc/yum.repos.d
     wget https://copr.fedorainfracloud.org/coprs/neelc/incus/repo/rhel+epel-10/neelc-incus-rhel+epel-10.repo
 


### PR DESCRIPTION
I maintain an updated Incus package in Copr for Rocky Linux 9/10 (and Alma/RHEL). The `neil/incus` package is out-of-date.

Also, `epel-release` is required on Rocky 10 also.