### PR TITLE
generate-database: Respect "primary" config for Identifier in mappings

### DIFF
--- a/cmd/generate-database/db/mapping.go
+++ b/cmd/generate-database/db/mapping.go
@@ -65,13 +65,19 @@ func (m *Mapping) NaturalKey() []*Field {
 
 // Identifier returns the field that uniquely identifies this entity.
 func (m *Mapping) Identifier() *Field {
+	var fallback *Field
+
 	for _, field := range m.NaturalKey() {
-		if field.Name == "Name" || field.Name == "Fingerprint" {
+		if field.Config.Get("primary") != "" {
 			return field
+		}
+
+		if field.Name == "Name" || field.Name == "Fingerprint" {
+			fallback = field
 		}
 	}
 
-	return nil
+	return fallback
 }
 
 // TableName determines the table associated to the struct.


### PR DESCRIPTION
I need to create an AssociationTable with [Updates](https://github.com/FuturFusion/operations-center/blob/main/internal/provisioning/update_model.go#L26) where the identifier is neither `Name` nor `Fingerprint` but it is defined using the `primary=yes` config. This is currently not respected by `*Mapping.Identifier`.