### PR TITLE
Allow setting 'vg_name' for non-clustered LVM during init

### DIFF
--- a/internal/server/storage/drivers/driver_lvm.go
+++ b/internal/server/storage/drivers/driver_lvm.go
@@ -130,7 +130,7 @@ func (d *lvm) load() error {
 func (d *lvm) init(s *state.State, name string, config map[string]string, log logger.Logger, volIDFunc func(volType VolumeType, volName string) (int64, error), commonRules *Validators) {
 	d.common.init(s, name, config, log, volIDFunc, commonRules)
 
-	if d.clustered && d.config != nil {
+	if d.config != nil {
 		_, exists := d.config["lvm.vg_name"]
 		if !exists {
 			sourceType := d.getSourceType()


### PR DESCRIPTION
This change allows setting `lvm.vg_name` for non-clustered LVM pools, aligning the behavior with clustered LVM.
This is required for operations such as recovery, where no new storage is created but `lvm.vg_name` is still expected to be present.

Closes: #2823