### PR TITLE
Tweak dnsmasq startup condition

### DIFF
--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -3448,7 +3448,7 @@ func (n *bridge) UsesDNSMasq() bool {
 	}
 
 	// Start dnsmassq if IPv6 is used (needed for SLAAC or DHCPv6).
-	if !util.IsNoneOrEmpty(n.config["ipv6.address"]) {
+	if !util.IsNoneOrEmpty(n.config["ipv6.address"]) && (util.IsTrueOrEmpty(n.config["ipv6.dhcp"]) || util.IsTrueOrEmpty(n.config["ipv6.routing"])) {
 		ipAddress, _, err := net.ParseCIDR(n.config["ipv6.address"])
 		if err != nil {
 			return true


### PR DESCRIPTION
We want to avoid starting dnsmasq when an IPv6 network is configured but has no DHCP nor routing enabled.