### PR TITLE
incus: Fix get-client-certificate ignoring per-remote certs

### DIFF
--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -781,7 +781,7 @@ func (c *cmdRemoteGetClientCertificate) Run(cmd *cobra.Command, args []string) e
 	}
 
 	// Read the certificate.
-	tlsClientCert, tlsClientKey, _, err := conf.GetClientCertificate("")
+	tlsClientCert, tlsClientKey, _, err := conf.GetClientCertificate(conf.DefaultRemote)
 	if err != nil {
 		return fmt.Errorf("Failed to get certificate: %w", err)
 	}


### PR DESCRIPTION
Fixes #2850

This PR fixes an issue where `incus remote get-client-certificate` would always return the global client certificate (`~/.config/incus/client.crt`), ignoring specific certificates defined for remotes in `~/.config/incus/clientcerts/`.

By passing `conf.DefaultRemote` instead of an empty string to `GetClientCertificate`, the CLI now correctly attempts to resolve the certificate associated with the current default remote first, preserving the fallback behavior if none is found.
