### PR TITLE
Propagate error when adding qcow2 backing block device

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4893,7 +4893,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 				if len(driveConf.BackingPath) > 0 {
 					backingBlockDev, err := d.qcow2BlockDev(m, nodeName, aioMode, directCache, noFlushCache, permissions, readonly, driveConf.BackingPath, 0)
 					if err != nil {
-						return nil
+						return err
 					}
 
 					blockDev["backing"] = backingBlockDev


### PR DESCRIPTION
In case of failure, nil was returned instead of err, which could mask the underlying error.