### PR TITLE
incusd/instance/drivers: Add limits.memory.balloon config option

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -2393,6 +2393,17 @@ Various suffixes are supported.
 See {ref}`instances-limit-units` for details.
 ```
 
+```{config:option} limits.memory.balloon instance-resource-limits
+:condition: "virtual machine"
+:defaultdesc: "`true`"
+:liveupdate: "no"
+:shortdesc: "Whether to enable the memory balloon device"
+:type: "bool"
+Set this option to `false` to disable the memory balloon device.
+This can help with guests (such as FreeBSD) that don't handle ballooning well.
+Note that this also disables live memory reduction for the VM.
+```
+
 ```{config:option} limits.memory.enforce instance-resource-limits
 :condition: "container"
 :defaultdesc: "`hard`"

--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -105,6 +105,9 @@ When that happens, re-applying the lower value will trigger another attempt.
 As each attempt will cause the effective memory available to the guest to be reduced,
 it should eventually succeed and lead to the guest having the desired memory limit applied.
 
+If the memory balloon device causes issues with a guest OS (for example, FreeBSD), it can be disabled by setting {config:option}`instance-resource-limits:limits.memory.balloon` to `false`.
+Note that this also disables live memory reduction for the VM.
+
 ### CPU limits
 
 You have different options to limit CPU usage:

--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -1061,6 +1061,18 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	//  shortdesc: Whether to back the instance using huge pages
 	"limits.memory.hugepages": validate.Optional(validate.IsBool),
 
+	// gendoc:generate(entity=instance, group=resource-limits, key=limits.memory.balloon)
+	// Set this option to `false` to disable the memory balloon device.
+	// This can help with guests (such as FreeBSD) that don't handle ballooning well.
+	// Note that this also disables live memory reduction for the VM.
+	// ---
+	//  type: bool
+	//  defaultdesc: `true`
+	//  liveupdate: no
+	//  condition: virtual machine
+	//  shortdesc: Whether to enable the memory balloon device
+	"limits.memory.balloon": validate.Optional(validate.IsBool),
+
 	// Caller is responsible for full validation of any raw.* value.
 
 	// gendoc:generate(entity=instance, group=raw, key=raw.qemu)

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -2682,6 +2682,16 @@
 						}
 					},
 					{
+						"limits.memory.balloon": {
+							"condition": "virtual machine",
+							"defaultdesc": "`true`",
+							"liveupdate": "no",
+							"longdesc": "Set this option to `false` to disable the memory balloon device.\nThis can help with guests (such as FreeBSD) that don't handle ballooning well.\nNote that this also disables live memory reduction for the VM.",
+							"shortdesc": "Whether to enable the memory balloon device",
+							"type": "bool"
+						}
+					},
+					{
 						"limits.memory.enforce": {
 							"condition": "container",
 							"defaultdesc": "`hard`",


### PR DESCRIPTION
## What this PR does

Adds a new VM-only configuration option `limits.memory.balloon` (bool, default `true`) that allows disabling the `virtio-balloon` device on QEMU VMs.

Fixes https://github.com/lxc/incus/issues/2909

### What are you currently unable to do

Currently there's no ability to disable ballooning, as `virtio_balloon` is added as a fixed device on QEMU config generation.

Under some circumstances (e.g. VM instances of FreeBSD/OPNsense), ballooning performs weirdly and reserves the entire memory limit — meanwhile real memory consumption is way lower.

In Proxmox it's possible to disable the balloon device, and it solves the issue, but with Incus there's no way to do the same.

### What was added

A new `limits.memory.balloon` option. When set to `false`:

- The balloon device (`virtio-balloon-pci`/`virtio-balloon-ccw`) is **not** added to the QEMU config
- The PCI bus slot is still consumed to preserve device address ordering (stable NIC naming like `enp5s0`)
- Memory **increase** via hotplug continues to work normally
- Memory **decrease** returns an error since balloon is unavailable

### Usage

```
incus config set <vm> limits.memory.balloon=false
incus restart <vm>
```

### Files changed

- `internal/instance/config.go` — new config key in `InstanceConfigKeysVM`
- `internal/server/instance/drivers/driver_qemu.go` — conditional balloon device, restructured `updateMemoryLimit` to separate hotplug/balloon paths
- `doc/reference/instance_options.md` — documentation note
- `doc/config_options.txt` — auto-regenerated
- `internal/server/metadata/configuration.json` — auto-regenerated