### PR TITLE
Prevent concurrent snapshot deletions

### DIFF
--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -3314,6 +3314,15 @@ func (b *backend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.
 		return err
 	}
 
+	// Lock this operation to ensure only one snapshot is deleted at a time.
+	// Other operations will wait until this one completes.
+	unlock, err := locking.Lock(context.TODO(), drivers.OperationLockName("DeleteInstanceSnapshot", b.name, vol.Type(), vol.ContentType(), parentName))
+	if err != nil {
+		return err
+	}
+
+	defer unlock()
+
 	if volExists {
 		if srcDBVol.Config["block.type"] == drivers.BlockVolumeTypeQcow2 {
 			parentVol := b.GetVolume(volType, contentType, parentStorageName, srcDBVol.Config)
@@ -7914,16 +7923,7 @@ func (b *backend) qcow2RenameSnapshot(vol drivers.Volume, snapVol drivers.Volume
 
 // qcow2DeleteSnapshot deletes the QCOW2 volume snapshot.
 func (b *backend) qcow2DeleteSnapshot(vol drivers.Volume, snapVol drivers.Volume, inst instance.Instance, op *operations.Operation) error {
-	// Lock this operation to ensure only one snapshot is deleted at a time.
-	// Other operations will wait until this one completes.
-	unlock, err := locking.Lock(context.TODO(), drivers.OperationLockName("Qcow2DeleteInstanceSnapshot", b.name, vol.Type(), vol.ContentType(), vol.Name()))
-	if err != nil {
-		return err
-	}
-
-	defer unlock()
-
-	l := b.logger.AddContext(logger.Ctx{"name": b.name, "instance": vol.Name()})
+	l := b.logger.AddContext(logger.Ctx{"backend": b.name, "instance": vol.Name()})
 	l.Debug("qcow2DeleteInstanceSnapshot started")
 	defer l.Debug("qcow2DeleteInstanceSnapshot finished")
 


### PR DESCRIPTION
This is a follow-up to the change (#2941) that prevents parallel snapshot deletion for QCOW2, extending it to all snapshot types.