### PR TITLE
Fix backing block device ordering when fetching from QEMU

### DIFF
--- a/internal/server/instance/drivers/util.go
+++ b/internal/server/instance/drivers/util.go
@@ -331,6 +331,7 @@ func classifyQcow2Blockdev(name string, rootDevName string) (*qcow2BlockdevInfo,
 }
 
 // filterAndSortQcow2Blockdevs selects qcow2 related block devices and sorts them in the correct order.
+// Backing blockdevs with higher indices represent older layers, while higher-index overlays represent newer layers.
 func filterAndSortQcow2Blockdevs(names []string, rootDevName string) []string {
 	items := make([]qcow2BlockdevInfo, 0, len(names))
 
@@ -344,6 +345,10 @@ func filterAndSortQcow2Blockdevs(names []string, rootDevName string) []string {
 	sort.Slice(items, func(i, j int) bool {
 		if items[i].kind != items[j].kind {
 			return items[i].kind < items[j].kind
+		}
+
+		if items[i].kind == backingBlockdevKind {
+			return items[i].index > items[j].index
 		}
 
 		return items[i].index < items[j].index


### PR DESCRIPTION
Backing nodes with the highest index represent the oldest layers and should be ordered first. This change also fixes an issue where the correct root block node was not fetched when creating a snapshot of a running instance.