### PR TITLE
incusd/storage/linstor: Propagate error when volume filler fails

### DIFF
--- a/internal/server/storage/drivers/driver_linstor_volumes.go
+++ b/internal/server/storage/drivers/driver_linstor_volumes.go
@@ -385,7 +385,7 @@ func (d *linstor) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 		return nil
 	}, op)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	rev.Success()


### PR DESCRIPTION
The current implementation was incorrectly suppressing errors that
occurred in the filler function when creating volumes via the Linstor
driver.

When any error ocurred in the filler function, the reversion logic would
delete the volume, but the return nil would signal to the caller that
the operation succeeded, causing a "Resource definition not found" error
when performing any subsequent Linstor operations on the volume.

Signed-off-by: Luís Simas <luissimas@protonmail.com>
