### PR TITLE
incus/server/network/ovn/nb: Fix static gateway hwaddr update

### DIFF
--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -530,6 +530,9 @@ func (o *NB) CreateStaticMACBinding(ctx context.Context, portName OVNRouterPort,
 			return err
 		}
 	} else {
+		binding.LogicalPort = string(portName)
+		binding.IP = ip.String()
+		binding.MAC = mac.String()
 		operations, err = o.client.Where(&binding).Update(&binding)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR fixes #2980 

There was a small bug in the nb_actions that was always overwriting the binding with the old values if it already existed.
As a quick fix I just overwrote them again if any values are updated.

I noticed a bug where a second binding in the `Static_MAC_Binding` table appeared if the IP address of the gateway has been changes and a `hwaddr` is added.
I can take up a proper refactor of the `CreateStaticMACBinding` function or we could create an additional `UpdateStaticMACBinding` function to properly split the desired action into different functions.
Unfortunately I won't be able to do this before the upcoming release.