### PR TITLE
Use 'allow-related' instead of 'allow' for default egress action

### DIFF
--- a/internal/server/network/acl/acl_ovn.go
+++ b/internal/server/network/acl/acl_ovn.go
@@ -1285,6 +1285,10 @@ func OVNApplyInstanceNICDefaultRules(client *ovn.NB, switchPortGroup ovn.OVNPort
 		return fmt.Errorf("Invalid egress action %q", egressAction)
 	}
 
+	if egressAction == "allow" {
+		egressAction = "allow-related"
+	}
+
 	rules := []ovn.OVNACLRule{
 		{
 			Direction: "to-lport",


### PR DESCRIPTION
Changed the default egress ACL action from `allow` to `allow-related` in the OVN network. This ensures that reply traffic from external sources is permitted while maintaining consistent behavior with custom rules, where any `allow` action is translated to `allow-related` on the OVN side.

Closes: https://github.com/lxc/incus/issues/2851