### PR TITLE
incus: fix log in sftpRecursiveMkdir

### DIFF
--- a/cmd/incus/utils_sftp.go
+++ b/cmd/incus/utils_sftp.go
@@ -404,7 +404,7 @@ func sftpRecursiveMkdir(sftpConn *sftp.Client, p string, mode *os.FileMode, uid 
 			Type: "directory",
 		}
 
-		logger.Errorf("Creating %s (%s)", cur, args.Type)
+		logger.Infof("Creating %s (%s)", cur, args.Type)
 		err := sftpCreateFile(sftpConn, cur, args, false)
 		if err != nil {
 			return err


### PR DESCRIPTION
Resolves: #2994

### Before:

```
$ echo "Hello" > baz
$ incus file push baz c1/foo/bar/ -p
ERROR  [2026-03-13T16:54:31+01:00] Creating foo (directory)                     
ERROR  [2026-03-13T16:54:31+01:00] Creating foo/bar (directory)                 
$ incus file create c1/foo2/bar/buz -p
ERROR  [2026-03-13T16:54:45+01:00] Creating foo2 (directory)                    
ERROR  [2026-03-13T16:54:45+01:00] Creating foo2/bar (directory)  
```

### After:

```
$ incus file push baz c1/foo/bar/ -p
$ incus file create c1/foo2/bar/buz -p    
```

With `--verbose` :
```
$ incus file push baz c1/foo/bar/ -p --verbose 
INFO   [2026-03-13T17:02:32+01:00] Creating foo (directory)                     
INFO   [2026-03-13T17:02:32+01:00] Creating foo/bar (directory)                 
INFO   [2026-03-13T17:02:32+01:00] Pushing baz to foo/bar/baz (file)            
$ incus file create c1/foo2/bar/buz -p --verbose 
INFO   [2026-03-13T17:02:40+01:00] Creating foo2 (directory)                    
INFO   [2026-03-13T17:02:40+01:00] Creating foo2/bar (directory)    
```