### PR TITLE
devcontainer: update Go version and pipx install command

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 ARG DEBIAN_VERSION=trixie
 
 # Go development container
@@ -70,8 +70,8 @@ RUN sed -r -i 's/^Components: main$/Components: main contrib/g' /etc/apt/sources
       # zfsutils-linux
       xz-utils
 
-# With pipx >= 1.5.0, we could use pipx --global instead.
-RUN PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install codespell
+# Globally install codespell
+RUN pipx install --global codespell
 
 # Add vscode user and add it to sudoers.
 RUN groupadd -g 1000 $USERNAME && \


### PR DESCRIPTION
This PR ups the Go version to `1.25` for the dev container to match `go.mod` and replaces the `pipx` install command, since Trixie now ships `pipx==1.7.1` currently.