### PR TITLE
Introduce goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  issues: write
+  id-token: write
+  attestations: write
+
+jobs:
+  goreleaser:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INCUS_VERSION: "6.22"
+
+      - name: Handle attestation
+        uses: actions/attest@v4
+        with:
+          subject-checksums: ./dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,209 @@
+version: 2
+
+archives:
+  - id: incus
+    ids:
+      - incus
+    formats:
+      - binary
+    name_template: >-
+      bin.
+      {{- if eq .Os "darwin" }}macos
+      {{- else }}{{ .Os }}{{ end }}.incus.
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else }}{{ .Arch }}{{ end }}
+
+  - id: incus-agent
+    ids:
+      - incus-agent
+    formats:
+      - binary
+    name_template: >-
+      bin.
+      {{- if eq .Os "darwin" }}macos
+      {{- else }}{{ .Os }}{{ end }}.incus-agent.
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else }}{{ .Arch }}{{ end }}
+
+  - id: incus-benchmark
+    ids:
+      - incus-benchmark
+    formats:
+      - binary
+    name_template: >-
+      bin.
+      {{- if eq .Os "darwin" }}macos
+      {{- else }}{{ .Os }}{{ end }}.incus-benchmark.
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else }}{{ .Arch }}{{ end }}
+
+  - id: incus-migrate
+    ids:
+      - incus-migrate
+    formats:
+      - binary
+    name_template: >-
+      bin.
+      {{- if eq .Os "darwin" }}macos
+      {{- else }}{{ .Os }}{{ end }}.incus-migrate.
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else }}{{ .Arch }}{{ end }}
+
+  - id: incus-simplestreams
+    ids:
+      - incus-simplestreams
+    formats:
+      - binary
+    name_template: >-
+      bin.
+      {{- if eq .Os "darwin" }}macos
+      {{- else }}{{ .Os }}{{ end }}.incus-simplestreams.
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else }}{{ .Arch }}{{ end }}
+
+  - id: lxd-to-incus
+    ids:
+      - lxd-to-incus
+    formats:
+      - binary
+    name_template: >-
+      bin.
+      {{- if eq .Os "darwin" }}macos
+      {{- else }}{{ .Os }}{{ end }}.lxd-to-incus.
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm64" }}aarch64
+      {{- else }}{{ .Arch }}{{ end }}
+
+before:
+  hooks:
+    - go mod download
+    - go mod vendor
+    - sh -c "git show-ref HEAD | cut -d' ' -f1 > .gitref"
+    - git clone --depth=1 https://github.com/cowsql/cowsql vendor/cowsql
+    - sh -c "cd vendor/cowsql && git show-ref HEAD | cut -d' ' -f1 > .gitref"
+    - rm -Rf vendor/cowsql/.git
+    - git clone --depth=1 https://github.com/cowsql/raft vendor/raft
+    - sh -c "cd vendor/raft && git show-ref HEAD | cut -d' ' -f1 > .gitref"
+    - rm -Rf vendor/raft/.git
+    - make doc
+
+builds:
+ - id: incus
+   main: ./cmd/incus
+   env:
+    - CGO_ENABLED=0
+   goos:
+    - darwin
+    - freebsd
+    - linux
+    - windows
+   goarch:
+    - amd64
+    - arm64
+
+ - id: incus-agent
+   main: ./cmd/incus-agent
+   env:
+    - CGO_ENABLED=0
+   goos:
+    - darwin
+    - freebsd
+    - linux
+    - windows
+   goarch:
+    - amd64
+    - arm64
+
+ - id: incus-benchmark
+   main: ./cmd/incus-benchmark
+   env:
+    - CGO_ENABLED=0
+   goos:
+    - darwin
+    - freebsd
+    - linux
+    - windows
+   goarch:
+    - amd64
+    - arm64
+
+ - id: incus-migrate
+   main: ./cmd/incus-migrate
+   env:
+    - CGO_ENABLED=0
+   goos:
+    - linux
+   goarch:
+    - amd64
+    - arm64
+
+ - id: incus-simplestreams
+   main: ./cmd/incus-simplestreams
+   env:
+    - CGO_ENABLED=0
+   goos:
+    - linux
+   goarch:
+    - amd64
+    - arm64
+
+ - id: lxd-to-incus
+   main: ./cmd/lxd-to-incus
+   env:
+    - CGO_ENABLED=0
+   goos:
+    - linux
+   goarch:
+    - amd64
+    - arm64
+
+changelog:
+  use: "github-native"
+
+checksum:
+  name_template: "checksums.txt"
+
+gomod:
+  proxy: true
+  mod: mod
+
+milestones:
+  - repo:
+      owner: lxc
+      name: incus
+    close: true
+    fail_on_error: false
+    name_template: "incus-{{ .Env.INCUS_VERSION }}"
+
+release:
+  github:
+    owner: lxc
+    name: incus
+  name_template: "Incus {{ .Env.INCUS_VERSION }}"
+
+sboms:
+  - id: archive
+    artifacts: archive
+    ids:
+    - incus
+    - incus-agent
+    - incus-benchmark
+    - incus-migrate
+    - incus-simplestreams
+    - lxd-to-incus
+  - id: source
+    artifacts: source
+
+source:
+  enabled: true
+  format: "tar.gz"
+  prefix_template: "{{ .ProjectName }}-{{ .Env.INCUS_VERSION }}/"
+  files:
+    - ".gitref"
+    - "doc/html"
+    - "vendor/*"


### PR DESCRIPTION
This replaces our manual release workflow with goreleaser so we just need to push a signed release commit + tag at release time to trigger the build and upload of all the artifacts, including generation of basic SBOM data.