### PR TITLE
incusd/seccomp: Limit the new mount API system calls we block

### DIFF
--- a/internal/server/seccomp/seccomp.go
+++ b/internal/server/seccomp/seccomp.go
@@ -531,12 +531,6 @@ const seccompNotifySysinfo = `sysinfo notify
 
 const seccompBlockNewMountAPI = `fsopen errno 38
 fsconfig errno 38
-fsinfo errno 38
-fsmount errno 38
-fspick errno 38
-open_tree errno 38
-move_mount errno 38
-openat2 errno 38
 `
 
 // We don't want to filter any of the following flag combinations since they do
@@ -814,10 +808,9 @@ func seccompGetPolicyContent(s *state.State, c Instance) (string, error) {
 
 		if util.IsTrue(config["security.syscalls.intercept.mount"]) {
 			policy += seccompNotifyMount
-			// We block the new mount api for now to simplify mount
-			// syscall interception. Since it keeps state over
-			// multiple syscalls we'd need more invasive changes to
-			// make this work.
+			// We block a subset of the new mount api as we can't easily intercept those mounts.
+			// Specifically, we're blocking fsopen and fsconfig which is
+			// enough to get /sbin/mount to fallback to the old mount API.
 			policy += seccompBlockNewMountAPI
 		}
 


### PR DESCRIPTION
We only really need to block fsconfig and fsopen to effectively trigger a fallback to the old mount API in most applications.

So only block those two and allow the rest to still be used, allowing modern features in such containers.