### PR TITLE
Refactor live migration - extract common logic

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -997,6 +997,37 @@ func (d *qemu) restoreStateHandle(ctx context.Context, monitor *qmp.Monitor, f *
 	return nil
 }
 
+// receiveMigrationSnapshot handles an incoming disk snapshot during migration.
+func (d *qemu) receiveMigrationSnapshot(monitor *qmp.Monitor, blockExport string, filesystemConn io.ReadWriteCloser) error {
+	nbdConn, err := monitor.NBDServerStart()
+	if err != nil {
+		return fmt.Errorf("Failed starting NBD server: %w", err)
+	}
+
+	d.logger.Debug("Migration NBD server started")
+
+	defer func() {
+		_ = nbdConn.Close()
+		_ = monitor.NBDServerStop()
+	}()
+
+	err = monitor.NBDBlockExportAdd(blockExport, true)
+	if err != nil {
+		return fmt.Errorf("Failed adding root disk to NBD server: %w", err)
+	}
+
+	d.logger.Debug("Migration storage NBD export starting")
+
+	go func() { _, _ = io.Copy(filesystemConn, nbdConn) }()
+
+	_, _ = io.Copy(nbdConn, filesystemConn)
+
+	filesystemConn.Close()
+	d.logger.Debug("Migration storage NBD export finished")
+
+	return nil
+}
+
 // restoreState restores VM state from state file or from migration source if d.migrationReceiveStateful set.
 func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 	if d.migrationReceiveStateful != nil {
@@ -1008,35 +1039,19 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 		// Perform non-shared storage transfer if requested.
 		filesystemConn := d.migrationReceiveStateful[api.SecretNameFilesystem]
 		if filesystemConn != nil {
-			nbdConn, err := monitor.NBDServerStart()
-			if err != nil {
-				return fmt.Errorf("Failed starting NBD server: %w", err)
-			}
-
-			d.logger.Debug("Migration NBD server started")
-
-			defer func() {
-				_ = nbdConn.Close()
-				_ = monitor.NBDServerStop()
-			}()
-
-			err = monitor.NBDBlockExportAdd(qemuMigrationNBDExportName, true)
-			if err != nil {
-				return fmt.Errorf("Failed adding root disk to NBD server: %w", err)
-			}
-
 			go func() {
-				d.logger.Debug("Migration storage NBD export starting")
+				blockDevs, err := d.fetchRootBlockDeviceChain(monitor)
+				if err != nil {
+					d.logger.Error("Failed fetching block device chain", logger.Ctx{"err": err})
+				}
 
-				go func() { _, _ = io.Copy(filesystemConn, nbdConn) }()
-
-				_, _ = io.Copy(nbdConn, filesystemConn)
-				_ = nbdConn.Close()
-
-				d.logger.Debug("Migration storage NBD export finished")
+				rootDiskName := blockDevs[len(blockDevs)-1]
+				err = d.receiveMigrationSnapshot(monitor, rootDiskName, filesystemConn)
+				if err != nil {
+					d.logger.Error("Failed receiving migration snapshot", logger.Ctx{"err": err})
+					return
+				}
 			}()
-
-			defer func() { _ = filesystemConn.Close() }()
 		}
 
 		// Receive checkpoint from QEMU process on source.
@@ -7891,6 +7906,228 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 	}
 }
 
+// createMigrationSnapshot creates a disk snapshot for migration.
+func (d *qemu) createMigrationSnapshot(diskName string, diskSize int64) (func(), error) {
+	monitor, err := d.qmpConnect()
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotDiskName := migrationSnapshotName(diskName)
+
+	// Create snapshot of the disk.
+	// We use the VM's config volume for this so that the maximum size of the snapshot can be limited
+	// by setting the root disk's `size.state` property.
+	snapshotFile := filepath.Join(d.Path(), fmt.Sprintf("%s.qcow2", snapshotDiskName))
+
+	// Ensure there are no existing migration snapshot files.
+	err = os.Remove(snapshotFile)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
+	// Create qcow2 disk image with the maximum size set to the instance's root disk size for use as
+	// a CoW target for the migration snapshot. This will be used during migration to store writes in
+	// the guest whilst the storage driver is transferring the root disk and snapshots to the target.
+	_, err = subprocess.RunCommand("qemu-img", "create", "-f", "qcow2", snapshotFile, fmt.Sprintf("%d", diskSize))
+	if err != nil {
+		return nil, fmt.Errorf("Failed opening file image for migration storage snapshot %q: %w", snapshotFile, err)
+	}
+
+	defer func() { _ = os.Remove(snapshotFile) }()
+
+	// Pass the snapshot file to the running QEMU process.
+	snapFile, err := os.OpenFile(snapshotFile, unix.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("Failed opening file descriptor for migration storage snapshot %q: %w", snapshotFile, err)
+	}
+
+	defer func() { _ = snapFile.Close() }()
+
+	// Remove the snapshot file as we don't want to sync this to the target.
+	err = os.Remove(snapshotFile)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := monitor.SendFileWithFDSet(snapshotDiskName, snapFile, false)
+	if err != nil {
+		return nil, fmt.Errorf("Failed sending file descriptor of %q for migration storage snapshot: %w", snapFile.Name(), err)
+	}
+
+	defer func() { _ = monitor.RemoveFDFromFDSet(snapshotDiskName) }()
+
+	_ = snapFile.Close() // Don't prevent clean unmount when instance is stopped.
+
+	// Add the snapshot file as a block device (not visible to the guest OS).
+	err = monitor.AddBlockDevice(map[string]any{
+		"driver":    "qcow2",
+		"node-name": snapshotDiskName,
+		"read-only": false,
+		"file": map[string]any{
+			"driver":   "file",
+			"filename": fmt.Sprintf("/dev/fdset/%d", info.ID),
+		},
+	}, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("Failed adding migration storage snapshot block device: %w", err)
+	}
+
+	// Take a snapshot of the root disk and redirect writes to the snapshot disk.
+	err = monitor.BlockDevSnapshot(diskName, snapshotDiskName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed taking temporary migration storage snapshot: %w", err)
+	}
+
+	cleanup := func() {
+		// Resume guest (this is needed as it will prevent merging the snapshot if paused).
+		err = monitor.Start()
+		if err != nil {
+			d.logger.Warn("Failed resuming instance", logger.Ctx{"err": err})
+		}
+
+		// Try and merge snapshot back to the source disk on failure so we don't lose writes.
+		err = monitor.BlockCommit(snapshotDiskName, "", "")
+		if err != nil {
+			d.logger.Error("Failed merging migration storage snapshot", logger.Ctx{"err": err})
+		}
+	}
+
+	return cleanup, nil
+}
+
+// sendMigrationSnapshot transfers the snapshot to the target.
+// If finalize is true, it performs cleanup after migration.
+// Otherwise, it returns a finalize function that can be called later.
+func (d *qemu) sendMigrationSnapshot(diskName string, filesystemConn io.ReadWriteCloser, finalize bool) (func() error, error) {
+	monitor, err := d.qmpConnect()
+	if err != nil {
+		return nil, err
+	}
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	targetDiskName := migrationNBDTarget(diskName)
+	snapshotDiskName := migrationSnapshotName(diskName)
+
+	listener, err := net.Listen("unix", "")
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating NBD unix listener: %w", err)
+	}
+
+	defer func() { _ = listener.Close() }()
+
+	g, _ := errgroup.WithContext(context.Background())
+
+	g.Go(func() error {
+		d.logger.Debug("NBD listener waiting for accept")
+		nbdConn, err := listener.Accept()
+		if err != nil {
+			return fmt.Errorf("Failed accepting connection to NBD client unix listener: %w", err)
+		}
+
+		defer func() { _ = nbdConn.Close() }()
+
+		d.logger.Debug("NBD connection on source started")
+		go func() { _, _ = io.Copy(filesystemConn, nbdConn) }()
+
+		_, _ = io.Copy(nbdConn, filesystemConn)
+		d.logger.Debug("NBD connection on source finished")
+
+		return nil
+	})
+
+	// Connect to NBD migration target and add it the source instance as a disk device.
+	d.logger.Debug("Connecting to migration NBD storage target")
+	err = monitor.AddBlockDevice(map[string]any{
+		"node-name": targetDiskName,
+		"driver":    "raw",
+		"file": map[string]any{
+			"driver": "nbd",
+			"export": diskName,
+			"server": map[string]any{
+				"type":     "unix",
+				"abstract": true,
+				"path":     strings.TrimPrefix(listener.Addr().String(), "@"),
+			},
+		},
+	}, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("Failed adding NBD device: %w", err)
+	}
+
+	reverter.Add(func() {
+		time.Sleep(time.Second) // Wait for it to be released.
+		err := monitor.RemoveBlockDevice(targetDiskName)
+		if err != nil {
+			d.logger.Warn("Failed removing NBD storage target device", logger.Ctx{"err": err})
+		}
+	})
+
+	d.logger.Debug("Connected to migration NBD storage target")
+
+	// Begin transferring any writes that occurred during the storage migration by transferring the
+	// contents of the (top) migration snapshot to the target disk to bring them into sync.
+	// Once this has completed the guest OS will be paused.
+	d.logger.Debug("Migration storage snapshot transfer started")
+	err = monitor.BlockDevMirror(snapshotDiskName, targetDiskName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed transferring migration storage snapshot: %w", err)
+	}
+
+	reverter.Add(func() {
+		err = monitor.BlockJobCancel(snapshotDiskName)
+		if err != nil {
+			d.logger.Error("Failed cancelling block job", logger.Ctx{"err": err})
+		}
+	})
+
+	d.logger.Debug("Migration storage snapshot transfer finished")
+
+	finalizeFunc := func() error {
+		filesystemConn.Close()
+		_ = g.Wait()
+
+		// Complete the migration snapshot sync process (the guest OS will remain paused).
+		d.logger.Debug("Migration storage snapshot transfer commit started")
+		err = monitor.BlockJobCancel(snapshotDiskName)
+		if err != nil {
+			return fmt.Errorf("Failed cancelling block job: %w", err)
+		}
+
+		d.logger.Debug("Migration storage snapshot transfer commit finished")
+
+		time.Sleep(time.Second) // Wait for it to be released.
+
+		// Remove the NBD client disk.
+		err = monitor.RemoveBlockDevice(targetDiskName)
+		if err != nil {
+			d.logger.Warn("Failed removing NBD storage target device", logger.Ctx{"err": err})
+		}
+
+		d.logger.Debug("Removed NBD storage target device")
+
+		// Merge snapshot back to the source disk so we don't lose the writes.
+		err = monitor.BlockCommit(snapshotDiskName, "", "")
+		if err != nil {
+			return fmt.Errorf("Failed merging migration storage snapshot: %w", err)
+		}
+
+		return nil
+	}
+
+	if finalize {
+		err = finalizeFunc()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	reverter.Success()
+	return finalizeFunc, nil
+}
+
 // migrateSendLive performs live migration send process.
 func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clusterMoveSourceName string, storagePool string, rootDiskSize int64, filesystemConn io.ReadWriteCloser, stateConn io.ReadWriteCloser, volSourceArgs *localMigration.VolumeSourceArgs) error {
 	monitor, err := d.qmpConnect()
@@ -7904,9 +8141,7 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 		return err
 	}
 
-	rootDiskName := blockDevs[len(blockDevs)-1]   // Name of source disk device to sync from. Last block device is the current root disk.
-	nbdTargetDiskName := "incus_root_nbd"         // Name of NBD disk device added to local VM to sync to.
-	rootSnapshotDiskName := "incus_root_snapshot" // Name of snapshot disk device to use.
+	rootDiskName := blockDevs[len(blockDevs)-1] // Name of source disk device to sync from. Last block device is the current root disk.
 
 	// If we are performing an intra-cluster member move on a Ceph storage pool without storage change
 	// then we can treat this as shared storage and avoid needing to sync the root disk.
@@ -7946,89 +8181,12 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 			return fmt.Errorf("Failed setting migration parameters: %w", err)
 		}
 
-		// Create snapshot of the root disk.
-		// We use the VM's config volume for this so that the maximum size of the snapshot can be limited
-		// by setting the root disk's `size.state` property.
-		snapshotFile := filepath.Join(d.Path(), "migration_snapshot.qcow2")
-
-		// Ensure there are no existing migration snapshot files.
-		err = os.Remove(snapshotFile)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return err
-		}
-
-		// Create qcow2 disk image with the maximum size set to the instance's root disk size for use as
-		// a CoW target for the migration snapshot. This will be used during migration to store writes in
-		// the guest whilst the storage driver is transferring the root disk and snapshots to the target.
-		_, err = subprocess.RunCommand("qemu-img", "create", "-f", "qcow2", snapshotFile, fmt.Sprintf("%d", rootDiskSize))
+		cleanup, err := d.createMigrationSnapshot(rootDiskName, rootDiskSize)
 		if err != nil {
-			return fmt.Errorf("Failed opening file image for migration storage snapshot %q: %w", snapshotFile, err)
+			return fmt.Errorf("Failed creating migration snapshot: %w", err)
 		}
 
-		defer func() { _ = os.Remove(snapshotFile) }()
-
-		// Pass the snapshot file to the running QEMU process.
-		snapFile, err := os.OpenFile(snapshotFile, unix.O_RDWR, 0)
-		if err != nil {
-			return fmt.Errorf("Failed opening file descriptor for migration storage snapshot %q: %w", snapshotFile, err)
-		}
-
-		defer func() { _ = snapFile.Close() }()
-
-		// Remove the snapshot file as we don't want to sync this to the target.
-		err = os.Remove(snapshotFile)
-		if err != nil {
-			return err
-		}
-
-		info, err := monitor.SendFileWithFDSet(rootSnapshotDiskName, snapFile, false)
-		if err != nil {
-			return fmt.Errorf("Failed sending file descriptor of %q for migration storage snapshot: %w", snapFile.Name(), err)
-		}
-
-		defer func() { _ = monitor.RemoveFDFromFDSet(rootSnapshotDiskName) }()
-
-		_ = snapFile.Close() // Don't prevent clean unmount when instance is stopped.
-
-		// Add the snapshot file as a block device (not visible to the guest OS).
-		err = monitor.AddBlockDevice(map[string]any{
-			"driver":    "qcow2",
-			"node-name": rootSnapshotDiskName,
-			"read-only": false,
-			"file": map[string]any{
-				"driver":   "file",
-				"filename": fmt.Sprintf("/dev/fdset/%d", info.ID),
-			},
-		}, nil, false)
-		if err != nil {
-			return fmt.Errorf("Failed adding migration storage snapshot block device: %w", err)
-		}
-
-		defer func() {
-			_ = monitor.RemoveBlockDevice(rootSnapshotDiskName)
-		}()
-
-		// Take a snapshot of the root disk and redirect writes to the snapshot disk.
-		err = monitor.BlockDevSnapshot(rootDiskName, rootSnapshotDiskName)
-		if err != nil {
-			return fmt.Errorf("Failed taking temporary migration storage snapshot: %w", err)
-		}
-
-		reverter.Add(func() {
-			// Resume guest (this is needed as it will prevent merging the snapshot if paused).
-			err = monitor.Start()
-			if err != nil {
-				d.logger.Warn("Failed resuming instance", logger.Ctx{"err": err})
-			}
-
-			// Try and merge snapshot back to the source disk on failure so we don't lose writes.
-			err = monitor.BlockCommit(rootSnapshotDiskName, "", "")
-			if err != nil {
-				d.logger.Error("Failed merging migration storage snapshot", logger.Ctx{"err": err})
-			}
-		})
-
-		defer reverter.Fail() // Run the revert fail before the earlier defers.
+		reverter.Add(cleanup)
 
 		d.logger.Debug("Setup temporary migration storage snapshot")
 	} else {
@@ -8105,78 +8263,12 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 		}
 	}
 
-	// Non-shared storage snapshot transfer.
+	var finalizeRootTransfer func() error
 	if !sameSharedStorage {
-		listener, err := net.Listen("unix", "")
+		finalizeRootTransfer, err = d.sendMigrationSnapshot(rootDiskName, filesystemConn, false)
 		if err != nil {
-			return fmt.Errorf("Failed creating NBD unix listener: %w", err)
+			return fmt.Errorf("Failed transferring snapshot disk: %w", err)
 		}
-
-		defer func() { _ = listener.Close() }()
-
-		go func() {
-			d.logger.Debug("NBD listener waiting for accept")
-			nbdConn, err := listener.Accept()
-			if err != nil {
-				d.logger.Error("Failed accepting connection to NBD client unix listener", logger.Ctx{"err": err})
-				return
-			}
-
-			defer func() { _ = nbdConn.Close() }()
-
-			d.logger.Debug("NBD connection on source started")
-			go func() { _, _ = io.Copy(filesystemConn, nbdConn) }()
-
-			_, _ = io.Copy(nbdConn, filesystemConn)
-			d.logger.Debug("NBD connection on source finished")
-		}()
-
-		// Connect to NBD migration target and add it the source instance as a disk device.
-		d.logger.Debug("Connecting to migration NBD storage target")
-		err = monitor.AddBlockDevice(map[string]any{
-			"node-name": nbdTargetDiskName,
-			"driver":    "raw",
-			"file": map[string]any{
-				"driver": "nbd",
-				"export": qemuMigrationNBDExportName,
-				"server": map[string]any{
-					"type":     "unix",
-					"abstract": true,
-					"path":     strings.TrimPrefix(listener.Addr().String(), "@"),
-				},
-			},
-		}, nil, false)
-		if err != nil {
-			return fmt.Errorf("Failed adding NBD device: %w", err)
-		}
-
-		reverter.Add(func() {
-			time.Sleep(time.Second) // Wait for it to be released.
-			err := monitor.RemoveBlockDevice(nbdTargetDiskName)
-			if err != nil {
-				d.logger.Warn("Failed removing NBD storage target device", logger.Ctx{"err": err})
-			}
-		})
-
-		d.logger.Debug("Connected to migration NBD storage target")
-
-		// Begin transferring any writes that occurred during the storage migration by transferring the
-		// contents of the (top) migration snapshot to the target disk to bring them into sync.
-		// Once this has completed the guest OS will be paused.
-		d.logger.Debug("Migration storage snapshot transfer started")
-		err = monitor.BlockDevMirror(rootSnapshotDiskName, nbdTargetDiskName)
-		if err != nil {
-			return fmt.Errorf("Failed transferring migration storage snapshot: %w", err)
-		}
-
-		reverter.Add(func() {
-			err = monitor.BlockJobCancel(rootSnapshotDiskName)
-			if err != nil {
-				d.logger.Error("Failed cancelling block job", logger.Ctx{"err": err})
-			}
-		})
-
-		d.logger.Debug("Migration storage snapshot transfer finished")
 	}
 
 	d.logger.Debug("Stateful migration checkpoint send starting")
@@ -8248,14 +8340,12 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 
 		d.logger.Debug("Stateful migration checkpoint reached pre-switchover phase")
 
-		// Complete the migration snapshot sync process (the guest OS will remain paused).
-		d.logger.Debug("Migration storage snapshot transfer commit started")
-		err = monitor.BlockJobCancel(rootSnapshotDiskName)
-		if err != nil {
-			return fmt.Errorf("Failed cancelling block job: %w", err)
+		if finalizeRootTransfer != nil {
+			err = finalizeRootTransfer()
+			if err != nil {
+				return fmt.Errorf("Failed transferring root snapshot disk: %w", err)
+			}
 		}
-
-		d.logger.Debug("Migration storage snapshot transfer commit finished")
 
 		// Finalise the migration state transfer (the guest OS will remain paused).
 		err = monitor.MigrateContinue("pre-switchover")
@@ -8284,14 +8374,6 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 			return fmt.Errorf("Failed stopping instance: %w", err)
 		}
 	} else {
-		// Remove the NBD client disk.
-		err := monitor.RemoveBlockDevice(nbdTargetDiskName)
-		if err != nil {
-			d.logger.Warn("Failed removing NBD storage target device", logger.Ctx{"err": err})
-		}
-
-		d.logger.Debug("Removed NBD storage target device")
-
 		// Resume guest.
 		err = monitor.Start()
 		if err != nil {
@@ -8299,15 +8381,6 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 		}
 
 		d.logger.Debug("Resumed instance")
-
-		// Merge snapshot back to the source disk so we don't lose the writes.
-		d.logger.Debug("Merge migration storage snapshot on source started")
-		err = monitor.BlockCommit(rootSnapshotDiskName, "", "")
-		if err != nil {
-			return fmt.Errorf("Failed merging migration storage snapshot: %w", err)
-		}
-
-		d.logger.Debug("Merge migration storage snapshot on source finished")
 	}
 
 	reverter.Success()

--- a/internal/server/instance/drivers/util.go
+++ b/internal/server/instance/drivers/util.go
@@ -378,3 +378,13 @@ func hashValue(value string, maxLength int) string {
 
 	return value
 }
+
+// migrationSnapshotName returns a snapshot name derived from the disk name.
+func migrationSnapshotName(diskName string) string {
+	return fmt.Sprintf("%s_snap", diskName)
+}
+
+// migrationNBDTarget returns a name for a disk exposed via the NBD server.
+func migrationNBDTarget(diskName string) string {
+	return fmt.Sprintf("%s_nbd", diskName)
+}


### PR DESCRIPTION
Introduce `createMigrationSnapshot`, `sendMigrationSnapshot`, and `receiveMigrationSnapshot` for reuse.