### PR TITLE
github: format INCUS_VERSION from tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,17 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0
 
+      - name: Format version
+        id: version
+        run: |
+          raw="${GITHUB_REF_NAME#v}"
+          IFS='.' read -r major minor patch <<< "$raw"
+          if [ "${patch}" = "0" ]; then
+            echo "value=${major}.${minor}" >> $GITHUB_OUTPUT
+          else
+            echo "value=${major}.${minor}.${patch}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -37,7 +48,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INCUS_VERSION: "6.22"
+          INCUS_VERSION: ${{ steps.version.outputs.value }}
 
       - name: Handle attestation
         uses: actions/attest@v4


### PR DESCRIPTION
This PR adjusts the `workflows/release.yaml` to not use a hardcoded version tag and instead get it directly from the tag the action is triggered from.

Outputs:
- `MAJOR.MINOR` if `PATCH` is zero
- `MAJOR.MINOR.PATCH` if `PATCH` is non-zero