### PR TITLE
feat: feature gate spice behind security.spice flag

### DIFF
--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -1137,6 +1137,16 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	//  shortdesc: Whether to use a firmware that supports UEFI-incompatible operating systems
 	"security.csm": validate.Optional(validate.IsBool),
 
+	// gendoc:generate(entity=instance, group=security, key=security.spice)
+	//
+	// ---
+	//  type: bool
+	//  defaultdesc: `true`
+	//  liveupdate: no
+	//  condition: virtual machine
+	//  shortdesc: Whether SPICE support is enabled
+	"security.spice": validate.Optional(validate.IsBool),
+
 	// gendoc:generate(entity=instance, group=security, key=security.iommu)
 	//
 	// ---

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1842,9 +1842,12 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		"-no-user-config",
 		"-sandbox", "on,obsolete=deny,elevateprivileges=allow,spawn=allow,resourcecontrol=deny",
 		"-readconfig", confFile,
-		"-spice", d.spiceCmdlineConfig(),
 		"-pidfile", d.pidFilePath(),
 		"-D", d.LogFilePath(),
+	}
+
+	if util.IsTrueOrEmpty(d.expandedConfig["security.spice"]) {
+		qemuArgs = append(qemuArgs, "-spice", d.spiceCmdlineConfig())
 	}
 
 	// If stateful, restore now.
@@ -3976,6 +3979,8 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuType string, cpuI
 
 	conf = append(conf, qemuVsock(&vsockOpts)...)
 
+	spice := util.IsTrueOrEmpty(d.expandedConfig["security.spice"])
+
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 	serialOpts := qemuSerialOpts{
 		dev: qemuDevOpts{
@@ -3986,6 +3991,7 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuType string, cpuI
 		},
 		charDevName:      qemuSerialChardevName,
 		ringbufSizeBytes: qmp.RingbufSize,
+		spice:            spice,
 	}
 
 	conf = append(conf, qemuSerial(&serialOpts)...)
@@ -3998,13 +4004,14 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuType string, cpuI
 			devAddr:       devAddr,
 			multifunction: multi,
 			ports:         qemuSparseUSBPorts,
+			spice:         spice,
 		}
 
 		conf = append(conf, qemuUSB(&usbOpts)...)
 	}
 
 	// virtio-sound-pci devices can't be migrated and don't have a CCW equivalent.
-	if !isWindows && !d.CanLiveMigrate() && d.architecture != osarch.ARCH_64BIT_S390_BIG_ENDIAN {
+	if spice && !isWindows && !d.CanLiveMigrate() && d.architecture != osarch.ARCH_64BIT_S390_BIG_ENDIAN {
 		devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 		audioOpts := qemuDevOpts{
 			busName:       bus.name,
@@ -9125,6 +9132,10 @@ func (d *qemu) Console(protocol string) (*os.File, chan error, error) {
 	case instance.ConsoleTypeConsole:
 		path = d.consolePath()
 	case instance.ConsoleTypeVGA:
+		if !util.IsTrueOrEmpty(d.expandedConfig["security.spice"]) {
+			return nil, nil, fmt.Errorf("SPICE is disabled")
+		}
+
 		path = d.spicePath()
 	default:
 		return nil, nil, fmt.Errorf("Unknown protocol %q", protocol)

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -122,7 +122,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			opts     qemuSerialOpts
 			expected string
 		}{{
-			qemuSerialOpts{qemuDevOpts{"pci", "qemu_pcie0", "00.5", false}, "qemu_serial-chardev", 32},
+			qemuSerialOpts{qemuDevOpts{"pci", "qemu_pcie0", "00.5", false}, "qemu_serial-chardev", 32, true},
 			`# Virtual serial bus
 			[device "dev-qemu_serial"]
 			addr = "00.5"
@@ -166,6 +166,30 @@ func TestQemuConfigTemplates(t *testing.T) {
 			chardev = "qemu_spicedir-chardev"
 			driver = "virtserialport"
 			name = "org.spice-space.webdav.0"
+			`,
+		}, {
+			qemuSerialOpts{qemuDevOpts{"pci", "qemu_pcie0", "00.5", false}, "qemu_serial-chardev", 32, false},
+			`# Virtual serial bus
+			[device "dev-qemu_serial"]
+			addr = "00.5"
+			bus = "qemu_pcie0"
+			driver = "virtio-serial-pci"
+
+			# Serial identifier
+			[chardev "qemu_serial-chardev"]
+			backend = "ringbuf"
+			size = "32B"
+
+			[device "qemu_serial"]
+			bus = "dev-qemu_serial.0"
+			chardev = "qemu_serial-chardev"
+			driver = "virtserialport"
+			name = "org.linuxcontainers.incus"
+
+			[device "qemu_serial_legacy"]
+			bus = "dev-qemu_serial.0"
+			driver = "virtserialport"
+			name = "org.linuxcontainers.lxd"
 			`,
 		}}
 		for _, tc := range testCases {
@@ -1024,6 +1048,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				devAddr:       "00.0",
 				multifunction: true,
 				ports:         3,
+				spice:         true,
 			},
 			`# USB controller
 			[device "qemu_usb"]
@@ -1057,6 +1082,22 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[device "qemu_spice-usb3"]
 			chardev = "qemu_spice-usb-chardev3"
 			driver = "usb-redir"`,
+		}, {
+			qemuUSBOpts{
+				devBus:        "qemu_pcie1",
+				devAddr:       "00.0",
+				multifunction: true,
+				ports:         3,
+				spice:         false,
+			},
+			`# USB controller
+			[device "qemu_usb"]
+			addr = "00.0"
+			bus = "qemu_pcie1"
+			driver = "qemu-xhci"
+			multifunction = "on"
+			p2 = "3"
+			p3 = "3"`,
 		}}
 		for _, tc := range testCases {
 			runTest(tc.expected, qemuUSB(&tc.opts))

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -207,6 +207,7 @@ type qemuSerialOpts struct {
 	dev              qemuDevOpts
 	charDevName      string
 	ringbufSizeBytes int
+	spice            bool
 }
 
 func qemuSerial(opts *qemuSerialOpts) []cfg.Section {
@@ -216,7 +217,7 @@ func qemuSerial(opts *qemuSerialOpts) []cfg.Section {
 		ccwName: "virtio-serial-ccw",
 	}
 
-	return []cfg.Section{{
+	sections := []cfg.Section{{
 		Name:    `device "dev-qemu_serial"`,
 		Comment: "Virtual serial bus",
 		Entries: qemuDeviceEntries(&entriesOpts),
@@ -249,37 +250,43 @@ func qemuSerial(opts *qemuSerialOpts) []cfg.Section {
 			"name":   "org.linuxcontainers.lxd",
 			"bus":    "dev-qemu_serial.0",
 		},
-	}, {
-		Name:    `chardev "qemu_spice-chardev"`,
-		Comment: "Spice agent",
-		Entries: map[string]string{
-			"backend": "spicevmc",
-			"name":    "vdagent",
-		},
-	}, {
-		Name: `device "qemu_spice"`,
-		Entries: map[string]string{
-			"driver":  "virtserialport",
-			"name":    "com.redhat.spice.0",
-			"chardev": "qemu_spice-chardev",
-			"bus":     "dev-qemu_serial.0",
-		},
-	}, {
-		Name:    `chardev "qemu_spicedir-chardev"`,
-		Comment: "Spice folder",
-		Entries: map[string]string{
-			"backend": "spiceport",
-			"name":    "org.spice-space.webdav.0",
-		},
-	}, {
-		Name: `device "qemu_spicedir"`,
-		Entries: map[string]string{
-			"driver":  "virtserialport",
-			"name":    "org.spice-space.webdav.0",
-			"chardev": "qemu_spicedir-chardev",
-			"bus":     "dev-qemu_serial.0",
-		},
 	}}
+
+	if opts.spice {
+		sections = append(sections, []cfg.Section{{
+			Name:    `chardev "qemu_spice-chardev"`,
+			Comment: "Spice agent",
+			Entries: map[string]string{
+				"backend": "spicevmc",
+				"name":    "vdagent",
+			},
+		}, {
+			Name: `device "qemu_spice"`,
+			Entries: map[string]string{
+				"driver":  "virtserialport",
+				"name":    "com.redhat.spice.0",
+				"chardev": "qemu_spice-chardev",
+				"bus":     "dev-qemu_serial.0",
+			},
+		}, {
+			Name:    `chardev "qemu_spicedir-chardev"`,
+			Comment: "Spice folder",
+			Entries: map[string]string{
+				"backend": "spiceport",
+				"name":    "org.spice-space.webdav.0",
+			},
+		}, {
+			Name: `device "qemu_spicedir"`,
+			Entries: map[string]string{
+				"driver":  "virtserialport",
+				"name":    "org.spice-space.webdav.0",
+				"chardev": "qemu_spicedir-chardev",
+				"bus":     "dev-qemu_serial.0",
+			},
+		}}...)
+	}
+
+	return sections
 }
 
 type qemuPCIeOpts struct {
@@ -891,6 +898,7 @@ type qemuUSBOpts struct {
 	devAddr       string
 	multifunction bool
 	ports         int
+	spice         bool
 }
 
 func qemuUSB(opts *qemuUSBOpts) []cfg.Section {
@@ -913,21 +921,23 @@ func qemuUSB(opts *qemuUSBOpts) []cfg.Section {
 		Entries: entries,
 	}}
 
-	for i := 1; i <= 3; i++ {
-		chardev := fmt.Sprintf("qemu_spice-usb-chardev%d", i)
-		sections = append(sections, []cfg.Section{{
-			Name: fmt.Sprintf(`chardev "%s"`, chardev),
-			Entries: map[string]string{
-				"backend": "spicevmc",
-				"name":    "usbredir",
-			},
-		}, {
-			Name: fmt.Sprintf(`device "qemu_spice-usb%d"`, i),
-			Entries: map[string]string{
-				"driver":  "usb-redir",
-				"chardev": chardev,
-			},
-		}}...)
+	if opts.spice {
+		for i := 1; i <= 3; i++ {
+			chardev := fmt.Sprintf("qemu_spice-usb-chardev%d", i)
+			sections = append(sections, []cfg.Section{{
+				Name: fmt.Sprintf(`chardev "%s"`, chardev),
+				Entries: map[string]string{
+					"backend": "spicevmc",
+					"name":    "usbredir",
+				},
+			}, {
+				Name: fmt.Sprintf(`device "qemu_spice-usb%d"`, i),
+				Entries: map[string]string{
+					"driver":  "usb-redir",
+					"chardev": chardev,
+				},
+			}}...)
+		}
 	}
 
 	return sections


### PR DESCRIPTION
here we introduce security.spice flag which defauls to true
  the same way it was working before this introduction.
setting security.spice = false makes those spice devices along
  with -spice command line flag absent.