### PR TITLE
incusd/storage: Fix race in caching logic

### DIFF
--- a/internal/server/storage/drivers/driver_truenas_cache.go
+++ b/internal/server/storage/drivers/driver_truenas_cache.go
@@ -22,7 +22,7 @@ var (
 	truenasCacheMu             sync.Mutex
 	truenasCachePrefillQueue   map[string][]string
 	truenasCachePrefillRunning map[string]bool
-	truenasCachePrefillWait    map[string]*sync.WaitGroup
+	truenasCachePrefillMu      map[string]*sync.RWMutex
 	truenasCacheProperties     = []string{"used", "referenced"}
 )
 
@@ -32,7 +32,7 @@ func truenasCacheEnsurePool(pool string) {
 	if !ok {
 		truenasCache[pool] = map[string]map[string]truenasCacheEntry{}
 		truenasCachePrefillQueue[pool] = []string{}
-		truenasCachePrefillWait[pool] = &sync.WaitGroup{}
+		truenasCachePrefillMu[pool] = &sync.RWMutex{}
 	}
 }
 
@@ -78,12 +78,11 @@ func (d *truenas) prefillCachedProperties(dataset string) {
 
 	if !truenasCachePrefillRunning[d.name] {
 		truenasCachePrefillRunning[d.name] = true
-		truenasCachePrefillWait[d.name] = &sync.WaitGroup{}
-		truenasCachePrefillWait[d.name].Add(1)
+		truenasCachePrefillMu[d.name].Lock()
 		defer func() {
 			truenasCacheMu.Lock()
 
-			truenasCachePrefillWait[d.name].Done()
+			truenasCachePrefillMu[d.name].Unlock()
 			truenasCachePrefillRunning[d.name] = false
 
 			truenasCacheMu.Unlock()
@@ -98,11 +97,8 @@ func (d *truenas) prefillCachedProperties(dataset string) {
 	// Check if we're done.
 	if !runPrefill {
 		// Wait for current run.
-		truenasCacheMu.Lock()
-		wg := truenasCachePrefillWait[d.name]
-		truenasCacheMu.Unlock()
-
-		wg.Wait()
+		truenasCachePrefillMu[d.name].RLock()
+		defer truenasCachePrefillMu[d.name].RUnlock()
 
 		// Check that we made it.
 		truenasCacheMu.Lock()

--- a/internal/server/storage/drivers/driver_zfs_cache.go
+++ b/internal/server/storage/drivers/driver_zfs_cache.go
@@ -23,7 +23,7 @@ var (
 	zfsCacheMu             sync.Mutex
 	zfsCachePrefillQueue   []string
 	zfsCachePrefillRunning bool
-	zfsCachePrefillWait    sync.WaitGroup
+	zfsCachePrefillMu      sync.RWMutex
 	zfsCacheProperties     = []string{"used", "referenced"}
 )
 
@@ -66,12 +66,11 @@ func (d *zfs) prefillCachedProperties(dataset string) {
 
 	if !zfsCachePrefillRunning {
 		zfsCachePrefillRunning = true
-		zfsCachePrefillWait = sync.WaitGroup{}
-		zfsCachePrefillWait.Add(1)
+		zfsCachePrefillMu.Lock()
 		defer func() {
 			zfsCacheMu.Lock()
 
-			zfsCachePrefillWait.Done()
+			zfsCachePrefillMu.Unlock()
 			zfsCachePrefillRunning = false
 
 			zfsCacheMu.Unlock()
@@ -86,7 +85,8 @@ func (d *zfs) prefillCachedProperties(dataset string) {
 	// Check if we're done.
 	if !runPrefill {
 		// Wait for current run.
-		zfsCachePrefillWait.Wait()
+		zfsCachePrefillMu.RLock()
+		defer zfsCachePrefillMu.RUnlock()
 
 		// Check that we made it.
 		zfsCacheMu.Lock()

--- a/internal/server/storage/drivers/init.go
+++ b/internal/server/storage/drivers/init.go
@@ -11,5 +11,5 @@ func init() {
 	truenasCache = map[string]map[string]map[string]truenasCacheEntry{}
 	truenasCachePrefillQueue = map[string][]string{}
 	truenasCachePrefillRunning = map[string]bool{}
-	truenasCachePrefillWait = map[string]*sync.WaitGroup{}
+	truenasCachePrefillMu = map[string]*sync.RWMutex{}
 }


### PR DESCRIPTION
Waitgroups don't work well when you're resetting them and when a Wait() call may be happening prior to an Add() call.

Instead let's use a RWMutex which gives us a simpler mechanism to allow the one writer many reader situation.