### PR TITLE
incusd/storage: Fix potential deadlock

### DIFF
--- a/internal/server/storage/drivers/driver_truenas_cache.go
+++ b/internal/server/storage/drivers/driver_truenas_cache.go
@@ -98,7 +98,7 @@ func (d *truenas) prefillCachedProperties(dataset string) {
 	if !runPrefill {
 		// Wait for current run.
 		truenasCachePrefillMu[d.name].RLock()
-		defer truenasCachePrefillMu[d.name].RUnlock()
+		truenasCachePrefillMu[d.name].RUnlock() //nolint:staticcheck
 
 		// Check that we made it.
 		truenasCacheMu.Lock()

--- a/internal/server/storage/drivers/driver_zfs_cache.go
+++ b/internal/server/storage/drivers/driver_zfs_cache.go
@@ -86,7 +86,7 @@ func (d *zfs) prefillCachedProperties(dataset string) {
 	if !runPrefill {
 		// Wait for current run.
 		zfsCachePrefillMu.RLock()
-		defer zfsCachePrefillMu.RUnlock()
+		zfsCachePrefillMu.RUnlock() //nolint:staticcheck
 
 		// Check that we made it.
 		zfsCacheMu.Lock()


### PR DESCRIPTION
Don't use defer to unlock the read lock when the same code path can call back the parent logic causing a deadlock.