### PR TITLE
incusd: Don't expose the API extension list pre-authentication

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -239,12 +239,11 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	}
 
 	srv := api.ServerUntrusted{
-		APIExtensions: version.APIExtensions[:d.apiExtensions],
-		APIStatus:     "stable",
-		APIVersion:    version.APIVersion,
-		Public:        false,
-		Auth:          "untrusted",
-		AuthMethods:   authMethods,
+		APIStatus:   "stable",
+		APIVersion:  version.APIVersion,
+		Public:      false,
+		Auth:        "untrusted",
+		AuthMethods: authMethods,
 	}
 
 	// Populate the untrusted config (user.ui.XYZ).
@@ -265,6 +264,9 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	// Add the API extensions to authenticated requests.
+	srv.APIExtensions = version.APIExtensions[:d.apiExtensions]
 
 	// If a target was specified, forward the request to the relevant node.
 	resp := forwardedResponseIfTargetIsRemote(s, r)


### PR DESCRIPTION
Having access to the whole list of API extensions prior to authentication makes it easier to target specific Incus features for specific bugs or security issues.

While backports and cherry-picks, especially into LTS releases makes it harder to get an exact match for a specific Incus version, it certainly makes it easier to target a specific range of vulnerable Incus releases.

Reported-by: https://7asecurity.com