### PR TITLE
incusd/device/nic_physical: Fix inheritance from network

### DIFF
--- a/internal/server/device/nic_physical.go
+++ b/internal/server/device/nic_physical.go
@@ -141,9 +141,12 @@ func (d *nicPhysical) validateConfig(instConf instance.ConfigReader, partialVali
 	//  managed: no
 	//  shortdesc: The managed network to link the device to (instead of specifying the `nictype` directly)
 	if d.config["network"] != "" {
+		// List of properties we import from the parent network.
+		networkFields := []string{"gvrp", "mtu", "vlan", "vlan.tagged"}
+
 		requiredFields = append(requiredFields, "network")
 
-		bannedKeys := []string{"nictype", "parent", "mtu", "vlan", "vlan.tagged", "gvrp"}
+		bannedKeys := append([]string{"nictype", "parent"}, networkFields...)
 		for _, bannedKey := range bannedKeys {
 			if d.config[bannedKey] != "" {
 				return fmt.Errorf("Cannot use %q property in conjunction with %q property", bannedKey, "network")
@@ -171,8 +174,8 @@ func (d *nicPhysical) validateConfig(instConf instance.ConfigReader, partialVali
 		// Get actual parent device from network's parent setting.
 		d.config["parent"] = netConfig["parent"]
 
-		// Copy certain keys verbatim from the network's settings.
-		for _, field := range optionalFields {
+		// Copy certain keys verbatim from the parent network's settings.
+		for _, field := range networkFields {
 			_, found := netConfig[field]
 			if found {
 				d.config[field] = netConfig[field]


### PR DESCRIPTION
With the reworked validation we weren't correctly pulling in network-wide settings anymore as the list of optional fields has now been trimmed down to correctly align with the type of instances being run.

Introduce an internal networkFields list which lists the properties to be inherited from the network, then ensure the user doesn't get to set those when linked to a managed network and finally use that list to import those properties from the network if set there.