### PR TITLE
incusd/instances/qemu: Skip vmcoreinfo on ppc64le

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3897,7 +3897,9 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuType string, cpuI
 	conf = append(conf, qemuConsole()...)
 
 	// VM core info (memory dump).
-	conf = append(conf, qemuCoreInfo()...)
+	if !slices.Contains([]int{osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN, osarch.ARCH_64BIT_S390_BIG_ENDIAN}, d.architecture) {
+		conf = append(conf, qemuCoreInfo()...)
+	}
 
 	// Setup the bus allocator.
 	bus := qemuNewBus(busName, &conf)


### PR DESCRIPTION
Apparently that QEMU device doesn't exist on ppc64le, so just skip it. Only impact should be limited memory layout info on dump.