### PR TITLE
incusd/device/nic_bridged: Handle physical NICs

### DIFF
--- a/internal/server/device/nic_bridged.go
+++ b/internal/server/device/nic_bridged.go
@@ -342,7 +342,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 			return errors.New("Specified network is not fully created")
 		}
 
-		if n.Type() != "bridge" {
+		if n.Type() != "bridge" && (n.Type() != "physical" || !util.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", d.config["parent"]))) {
 			return errors.New("Specified network must be of type bridge")
 		}
 


### PR DESCRIPTION
Physical NICs now can jump into the bridged NIC logic for config validation. We therefore can't solely rely on the NIC type during validation anymore.

This is the missing piece to getting physical NICs behaving normally again. This was missed in the most recent fix due to testing happening on pre-existing instances and therefore not running through full validation.

Closes #3155