### PR TITLE
Allow limiting storage pools to project

### DIFF
--- a/cmd/incusd/api_project.go
+++ b/cmd/incusd/api_project.go
@@ -1815,6 +1815,14 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		//  defaultdesc: `block`
 		//  shortdesc: Whether to prevent creating instance or volume snapshots
 		"restricted.snapshots": isEitherAllowOrBlock,
+
+		// gendoc:generate(entity=project, group=restricted, key=restricted.storage-pools.access)
+		// Specify a comma-delimited list of storage pool names that are allowed for use in this project.
+		// If this option is not set, all storage pools are accessible.
+		// ---
+		//  type: string
+		//  shortdesc: Which storage pool names are allowed for use in this project
+		"restricted.storage-pools.access": validate.Optional(validate.IsListOf(validate.IsAny)),
 	}
 
 	// Add the storage pool keys.

--- a/cmd/incusd/storage_pools.go
+++ b/cmd/incusd/storage_pools.go
@@ -182,7 +182,7 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Load the project limits.
-		hiddenPoolNames, err = project.HiddenStoragePools(ctx, tx, request.ProjectParam(r))
+		hiddenPoolNames, err = project.HiddenStoragePools(ctx, tx, request.ProjectParam(r), poolNames)
 		if err != nil {
 			return err
 		}
@@ -736,7 +736,7 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 		var err error
 
 		// Load the project limits.
-		hiddenPoolNames, err = project.HiddenStoragePools(ctx, tx, request.ProjectParam(r))
+		hiddenPoolNames, err = project.HiddenStoragePools(ctx, tx, request.ProjectParam(r), []string{poolName})
 		if err != nil {
 			return err
 		}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3065,3 +3065,13 @@ This adds a few new APIs for storage volumes and instances:
 This introduces the ability to get a raw `NBD` connection to an Incus block storage volume.
 It also allows interacting with dirty bitmaps on those volumes which can then be used as the basis for incremental backups.
 The instance level endpoint allows for consistent bitmap creation across the VM and its dependent volumes.
+
+## `projects_restricted_storage_pool_access`
+
+Adds the `restricted.storage-pools.access` project configuration key to
+indicate (as a comma-delimited list) which storage pools can be accessed
+inside the project. If not specified, all storage pools are accessible.
+
+Storage pools that are not in the list are treated as equivalent to
+having a pool size limit of 0 (`limits.disk.pool.POOLNAME=0`), making
+them inaccessible and hidden from the project.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -4705,6 +4705,13 @@ Specify a comma-delimited list of network zones that can be used (or something u
 
 ```
 
+```{config:option} restricted.storage-pools.access project-restricted
+:shortdesc: "Which storage pool names are allowed for use in this project"
+:type: "string"
+Specify a comma-delimited list of storage pool names that are allowed for use in this project.
+If this option is not set, all storage pools are accessible.
+```
+
 ```{config:option} restricted.virtual-machines.lowlevel project-restricted
 :defaultdesc: "`block`"
 :shortdesc: "Whether to prevent using low-level VM options"

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -5309,6 +5309,13 @@
 						}
 					},
 					{
+						"restricted.storage-pools.access": {
+							"longdesc": "Specify a comma-delimited list of storage pool names that are allowed for use in this project.\nIf this option is not set, all storage pools are accessible.",
+							"shortdesc": "Which storage pool names are allowed for use in this project",
+							"type": "string"
+						}
+					},
+					{
 						"restricted.virtual-machines.lowlevel": {
 							"defaultdesc": "`block`",
 							"longdesc": "Possible values are `allow` or `block`.\nWhen set to `allow`, low-level VM options like {config:option}`instance-raw:raw.qemu`, `volatile.*`, etc. can be used.",

--- a/internal/server/project/permissions.go
+++ b/internal/server/project/permissions.go
@@ -313,11 +313,6 @@ func AllowVolumeCreation(tx *db.ClusterTx, projectName string, poolName string, 
 		return errors.New("Restricted projects aren't allowed to use pull mode migration")
 	}
 
-	// If "limits.disk" is not set, there's nothing to do.
-	if info.Project.Config["limits.disk"] == "" {
-		return nil
-	}
-
 	// Add the volume being created.
 	info.Volumes = append(info.Volumes, db.StorageVolumeArgs{
 		Name:     req.Name,
@@ -404,6 +399,39 @@ func checkRestrictionsAndAggregateLimits(tx *db.ClusterTx, info *projectInfo) er
 
 	if len(aggregateKeys) == 0 && !isRestricted {
 		return nil
+	}
+
+	// Check pool usage restrictions.
+	if isRestricted && info.Project.Config["restricted.storage-pools.access"] != "" {
+		// Build a list of all the storage pools in use.
+		pools := map[string]int{}
+
+		for _, profile := range info.Profiles {
+			for _, dev := range profile.Devices {
+				if dev["type"] == "disk" && dev["pool"] != "" {
+					pools[dev["pool"]]++
+				}
+			}
+		}
+
+		for _, inst := range info.Instances {
+			for _, dev := range inst.Devices {
+				if dev["type"] == "disk" && dev["pool"] != "" {
+					pools[dev["pool"]]++
+				}
+			}
+		}
+
+		for _, vol := range info.Volumes {
+			pools[vol.PoolName]++
+		}
+
+		// Check that those pools are allowed.
+		for poolName := range pools {
+			if !StoragePoolAllowed(info.Project.Config, poolName) {
+				return fmt.Errorf("Storage pool %q is not accessible from this project", poolName)
+			}
+		}
 	}
 
 	instances, err := expandInstancesConfigAndDevices(info.Instances, info.Profiles)

--- a/internal/server/project/permissions.go
+++ b/internal/server/project/permissions.go
@@ -24,7 +24,7 @@ import (
 )
 
 // HiddenStoragePools returns a list of storage pools that should be hidden from users of the project.
-func HiddenStoragePools(ctx context.Context, tx *db.ClusterTx, projectName string) ([]string, error) {
+func HiddenStoragePools(ctx context.Context, tx *db.ClusterTx, projectName string, allPoolNames []string) ([]string, error) {
 	dbProject, err := cluster.GetProject(ctx, tx.Tx(), projectName)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting project: %w", err)
@@ -36,14 +36,9 @@ func HiddenStoragePools(ctx context.Context, tx *db.ClusterTx, projectName strin
 	}
 
 	hiddenPools := []string{}
-	for k, v := range project.Config {
-		if !strings.HasPrefix(k, projectLimitDiskPool) || v != "0" {
-			continue
-		}
-
-		fields := strings.SplitN(k, projectLimitDiskPool, 2)
-		if len(fields) == 2 {
-			hiddenPools = append(hiddenPools, fields[1])
+	for _, poolName := range allPoolNames {
+		if !StoragePoolAllowed(project.Config, poolName) {
+			hiddenPools = append(hiddenPools, poolName)
 		}
 	}
 
@@ -698,8 +693,13 @@ func checkRestrictions(project api.Project, instances []api.Instance, profiles [
 
 		case "restricted.devices.disk":
 			devicesChecks["disk"] = func(device map[string]string) error {
-				// The root device is always allowed.
+				// The root device is always allowed, but the pool it references
+				// must still be accessible (not equivalent to a size limit of 0).
 				if device["path"] == "/" && device["pool"] != "" {
+					if !StoragePoolAllowed(project.Config, device["pool"]) {
+						return fmt.Errorf("Storage pool %q is not accessible from this project", device["pool"])
+					}
+
 					return nil
 				}
 
@@ -728,6 +728,10 @@ func checkRestrictions(project api.Project, instances []api.Instance, profiles [
 							return fmt.Errorf("Disk source path %q not allowed", device["source"])
 						}
 					}
+				}
+
+				if device["pool"] != "" && !StoragePoolAllowed(project.Config, device["pool"]) {
+					return fmt.Errorf("Storage pool %q is not accessible from this project", device["pool"])
 				}
 
 				return nil
@@ -913,6 +917,7 @@ var allRestrictions = map[string]string{
 	"restricted.images.servers":            "",
 	"restricted.networks.access":           "",
 	"restricted.snapshots":                 "block",
+	"restricted.storage-pools.access":      "",
 }
 
 // allowableIntercept lists all syscall interception keys which may be allowed.

--- a/internal/server/project/project.go
+++ b/internal/server/project/project.go
@@ -166,6 +166,31 @@ func StorageBucketProjectFromRecord(p *api.Project) string {
 	return api.ProjectDefaultName
 }
 
+// StoragePoolAllowed returns whether access is allowed to a particular storage pool based on project limits and restrictions.
+// A pool is inaccessible if it has an explicit size limit of 0 (limits.disk.pool.POOLNAME=0) or if restricted.storage-pools.access
+// is set and the pool is not in the allowlist (treated as equivalent to a size limit of 0).
+func StoragePoolAllowed(reqProjectConfig map[string]string, poolName string) bool {
+	// A pool with an explicit size limit of 0 is never accessible.
+	if reqProjectConfig[projectLimitDiskPool+poolName] == "0" {
+		return false
+	}
+
+	// If the project isn't restricted, then access to the pool is allowed.
+	if util.IsFalseOrEmpty(reqProjectConfig["restricted"]) {
+		return true
+	}
+
+	// If restricted.storage-pools.access is not set then allow access to all pools.
+	if reqProjectConfig["restricted.storage-pools.access"] == "" {
+		return true
+	}
+
+	// Check if requested pool is in list of allowed pools.
+	allowedPools := util.SplitNTrimSpace(reqProjectConfig["restricted.storage-pools.access"], ",", -1, false)
+
+	return slices.Contains(allowedPools, poolName)
+}
+
 // NetworkProject returns the effective project name to use for the network based on the requested project.
 // If the requested project has the "features.networks" flag enabled then the requested project's name is returned,
 // otherwise the default project name is returned.

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -532,6 +532,7 @@ var APIExtensions = []string{
 	"dependent",
 	"metrics_project_resources",
 	"storage_volume_nbd",
+	"projects_restricted_storage_pool_access",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Resolves: https://github.com/lxc/incus/issues/3060

This PR involves:

1. Registering a restriction `restricted.storage-pools.access`
2. Write  a new function `StoragePoolAllowed` similar to `NetworkAllowed` which checks if access is allowed to a particular storage pool.
3. Update existing permissions, `HiddenStoragePools` now does a additional check if the pool is present/absent in access list (Also as a case where root is always allowed we still need to check with storage pool allowlist)
4. Update use of `HiddenStoragePools` while loading project limits in `storagePoolGet` & `storagePoolsGet` as these are ones project-restricted users can access.