### PR TITLE
incusd/instance/qemu: Scale SCSI queues with CPUs

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4048,7 +4048,7 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuType string, cpuI
 		multifunction: multi,
 	}
 
-	conf = append(conf, qemuSCSI(&scsiOpts)...)
+	conf = append(conf, qemuSCSI(&scsiOpts, cpuInfo.sockets*cpuInfo.cores)...)
 
 	// Export the config directory and agent as 9p drives when supported.
 	if !isWindows && plan9 {

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -235,6 +235,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			addr = "00.0"
 			bus = "qemu_pcie1"
 			driver = "virtio-scsi-pci"
+			num_queues = "4"
 			`,
 		}, {
 			qemuDevOpts{"ccw", "qemu_pcie2", "00.2", true},
@@ -242,10 +243,11 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[device "qemu_scsi"]
 			driver = "virtio-scsi-ccw"
 			multifunction = "on"
+			num_queues = "4"
 			`,
 		}}
 		for _, tc := range testCases {
-			runTest(tc.expected, qemuSCSI(&tc.opts))
+			runTest(tc.expected, qemuSCSI(&tc.opts, 4))
 		}
 	})
 

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -314,17 +314,18 @@ func qemuPCIe(opts *qemuPCIeOpts) []cfg.Section {
 	}}
 }
 
-func qemuSCSI(opts *qemuDevOpts) []cfg.Section {
-	entriesOpts := qemuDevEntriesOpts{
+func qemuSCSI(opts *qemuDevOpts, numQueues int) []cfg.Section {
+	entries := qemuDeviceEntries(&qemuDevEntriesOpts{
 		dev:     *opts,
 		pciName: "virtio-scsi-pci",
 		ccwName: "virtio-scsi-ccw",
-	}
+	})
+	entries["num_queues"] = fmt.Sprintf("%d", numQueues)
 
 	return []cfg.Section{{
 		Name:    `device "qemu_scsi"`,
 		Comment: "SCSI controller",
-		Entries: qemuDeviceEntries(&entriesOpts),
+		Entries: entries,
 	}}
 }
 


### PR DESCRIPTION
Similar to what we do for networking, setup one queue per core.


Sponsored-by: Magalu Cloud (https://magalu.cloud)