### PR TITLE
Fix stateful VM snapshot failure with dependent volumes

### DIFF
--- a/cmd/incusd/storage_volumes_snapshot.go
+++ b/cmd/incusd/storage_volumes_snapshot.go
@@ -274,7 +274,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 
 	// Create the snapshot.
 	snapshot := func(op *operations.Operation) error {
-		return pool.CreateCustomVolumeSnapshot(projectName, volumeName, req.Name, expiry, op)
+		return pool.CreateCustomVolumeSnapshot(projectName, volumeName, req.Name, expiry, false, op)
 	}
 
 	resources := map[string][]api.URL{}
@@ -1500,7 +1500,7 @@ func autoCreateCustomVolumeSnapshots(ctx context.Context, s *state.State, volume
 			return fmt.Errorf("Error loading pool for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}
 
-		err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, expiry, nil)
+		err = pool.CreateCustomVolumeSnapshot(v.ProjectName, v.Name, snapshotName, expiry, false, nil)
 		if err != nil {
 			return fmt.Errorf("Error creating snapshot for volume %q (project %q, pool %q): %w", v.Name, v.ProjectName, v.PoolName, err)
 		}

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -3244,7 +3244,7 @@ func (d *disk) updateDependentConfig() (func() error, error) {
 
 			for _, snap := range snapshots {
 				_, snapName, _ := api.GetParentAndSnapshotName(snap.Name)
-				err = d.pool.CreateCustomVolumeSnapshot(storageProjectName, volName, snapName, snap.ExpiryDate.Time, nil)
+				err = d.pool.CreateCustomVolumeSnapshot(storageProjectName, volName, snapName, snap.ExpiryDate.Time, false, nil)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -3209,7 +3209,7 @@ func (b *backend) CreateInstanceSnapshot(inst instance.Instance, src instance.In
 		}
 
 		_, snapshotName, _ := api.GetParentAndSnapshotName(inst.Name())
-		err = diskPool.CreateCustomVolumeSnapshot(inst.Project().Name, dev.Config["source"], snapshotName, time.Time{}, op)
+		err = diskPool.CreateCustomVolumeSnapshot(inst.Project().Name, dev.Config["source"], snapshotName, time.Time{}, inst.IsStateful(), op)
 		if err != nil {
 			return fmt.Errorf("Failed to create device snapshot for volume %q: %w", dev.Config["source"], err)
 		}
@@ -6269,7 +6269,7 @@ func (b *backend) ImportCustomVolume(projectName string, poolVol *backupConfig.C
 }
 
 // CreateCustomVolumeSnapshot creates a snapshot of a custom volume.
-func (b *backend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, newExpiryDate time.Time, op *operations.Operation) error {
+func (b *backend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, newExpiryDate time.Time, instanceStateful bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName, "newExpiryDate": newExpiryDate})
 	l.Debug("CreateCustomVolumeSnapshot started")
 	defer l.Debug("CreateCustomVolumeSnapshot finished")
@@ -6359,7 +6359,7 @@ func (b *backend) CreateCustomVolumeSnapshot(projectName, volName string, newSna
 
 		// parentVol should already be prepared as an overlay by CreateVolumeSnapshot.
 		// vol will be used as the base.
-		err = b.qcow2CreateSnapshot(parentVolume, vol, projectName, inst, devName, false, op)
+		err = b.qcow2CreateSnapshot(parentVolume, vol, projectName, inst, devName, instanceStateful, op)
 		if err != nil {
 			return err
 		}

--- a/internal/server/storage/backend_mock.go
+++ b/internal/server/storage/backend_mock.go
@@ -325,7 +325,8 @@ func (b *mockBackend) ImportCustomVolume(projectName string, poolVol *backupConf
 	return nil, nil
 }
 
-func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, expiryDate time.Time, op *operations.Operation) error {
+// CreateCustomVolumeSnapshot creates a snapshot of a custom volume.
+func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, expiryDate time.Time, instanceStateful bool, op *operations.Operation) error {
 	return nil
 }
 

--- a/internal/server/storage/pool_interface.go
+++ b/internal/server/storage/pool_interface.go
@@ -135,7 +135,7 @@ type Pool interface {
 	CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
 
 	// Custom volume snapshots.
-	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newExpiryDate time.Time, op *operations.Operation) error
+	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, newExpiryDate time.Time, instanceStateful bool, op *operations.Operation) error
 	RenameCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error
 	DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error
 	UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, newExpiryDate time.Time, op *operations.Operation) error


### PR DESCRIPTION
Introduce an `instanceStateful` flag to volume snapshot operations to indicate that the snapshot is part of a stateful instance snapshot.
This ensures dependent volumes follow the correct snapshot behavior when the instance is snapshotted in stateful mode, where backing file change is handled without QMP.