### PR TITLE
Fix ovn duplicate route

### DIFF
--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -2799,16 +2799,25 @@ func (n *ovn) setup(update bool) error {
 		deleteRoutes := []net.IPNet{defaultIPv4Route, defaultIPv6Route}
 		defaultRoutes := make([]networkOVN.OVNRouterRoute, 0, 2)
 
+		currentRoutes, err := n.ovnnb.GetLogicalRouterRoutes(context.TODO(), n.getRouterName())
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve currently set routes on network %s", n.name)
+		}
+
 		if routerIntPortIPv4Net != nil {
 			// If l3only mode is enabled then each instance IPv4 will get its own /32 route added when
 			// the instance NIC starts. However to stop packets toward unknown IPs within the internal
 			// subnet escaping onto the uplink network we add a less specific discard route for the
 			// whole internal subnet.
 			if util.IsTrue(n.config["ipv4.l3only"]) {
-				defaultRoutes = append(defaultRoutes, networkOVN.OVNRouterRoute{
+				route := networkOVN.OVNRouterRoute{
 					Prefix:  *routerIntPortIPv4Net,
 					Discard: true,
-				})
+				}
+
+				if !ovnRouteExists(currentRoutes, route) {
+					defaultRoutes = append(defaultRoutes, route)
+				}
 			} else {
 				deleteRoutes = append(deleteRoutes, *routerIntPortIPv4Net)
 			}
@@ -2820,10 +2829,14 @@ func (n *ovn) setup(update bool) error {
 			// subnet escaping onto the uplink network we add a less specific discard route for the
 			// whole internal subnet.
 			if util.IsTrue(n.config["ipv6.l3only"]) {
-				defaultRoutes = append(defaultRoutes, networkOVN.OVNRouterRoute{
+				route := networkOVN.OVNRouterRoute{
 					Prefix:  *routerIntPortIPv6Net,
 					Discard: true,
-				})
+				}
+
+				if !ovnRouteExists(currentRoutes, route) {
+					defaultRoutes = append(defaultRoutes, route)
+				}
 			} else {
 				deleteRoutes = append(deleteRoutes, *routerIntPortIPv6Net)
 			}

--- a/internal/server/network/network_utils.go
+++ b/internal/server/network/network_utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/lxc/incus/v6/internal/server/instance"
 	"github.com/lxc/incus/v6/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v6/internal/server/ip"
+	networkOVN "github.com/lxc/incus/v6/internal/server/network/ovn"
 	"github.com/lxc/incus/v6/internal/server/project"
 	"github.com/lxc/incus/v6/internal/server/state"
 	localUtil "github.com/lxc/incus/v6/internal/server/util"
@@ -1590,4 +1591,19 @@ func ipInPointerRanges(ipAddr net.IP, ipRanges []*iprange.Range) bool {
 	}
 
 	return false
+}
+
+// ovnRouteExists checks if the given route already exists in the provided list of current routes.
+func ovnRouteExists(currentRoutes []networkOVN.OVNRouterRoute, route networkOVN.OVNRouterRoute) bool {
+	return slices.ContainsFunc(currentRoutes, func(existing networkOVN.OVNRouterRoute) bool {
+		if existing.Prefix.String() != route.Prefix.String() {
+			return false
+		}
+
+		if route.Discard != existing.Discard {
+			return false
+		}
+
+		return existing.NextHop.Equal(route.NextHop) && existing.Port == route.Port
+	})
 }

--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -4182,6 +4182,9 @@ func (o *NB) GetLogicalRouterRoutes(ctx context.Context, routerName OVNRouter) (
 
 		routerRoute.Prefix = *prefix
 		routerRoute.NextHop = net.ParseIP(route.Nexthop)
+		if route.Nexthop == "discard" {
+			routerRoute.Discard = true
+		}
 
 		if route.OutputPort != nil {
 			routerRoute.Port = OVNRouterPort(*route.OutputPort)


### PR DESCRIPTION
Add a ovn utility function to check for existing routes within a list.
Skip adding a discard route if it already exists for that prefix.
We could probably also just always delete the route and always re-add it on every network update.
Personally i prefer the more explicit approach.

Fixes #3016 