### PR TITLE
shared/archive: Improve detection and error handling

### DIFF
--- a/cmd/incusd/migrate.go
+++ b/cmd/incusd/migrate.go
@@ -60,7 +60,7 @@ func (c *migrationFields) send(m proto.Message) error {
 		return fmt.Errorf("Control connection not initialized: %w", err)
 	}
 
-	_ = conn.SetWriteDeadline(time.Now().Add(time.Second * 5))
+	_ = conn.SetWriteDeadline(time.Now().Add(time.Second * 10))
 	err = migration.ProtoSend(conn, m)
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func (c *migrationFields) recv(m proto.Message) error {
 		return fmt.Errorf("Control connection not initialized: %w", err)
 	}
 
-	_ = conn.SetReadDeadline(time.Now().Add(time.Second * 5))
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second * 10))
 	return migration.ProtoRecv(conn, m)
 }
 

--- a/internal/server/seccomp/seccomp.go
+++ b/internal/server/seccomp/seccomp.go
@@ -964,7 +964,7 @@ func (siov *Iovec) PutSeccompIovec() {
 // ReceiveSeccompIovec receives a seccomp iovec.
 func (siov *Iovec) ReceiveSeccompIovec(fd int) (uint64, error) {
 	bytes, fds, err := netutils.AbstractUnixReceiveFdData(fd, 3, netutils.UnixFdsAcceptLess, unsafe.Pointer(siov.iov), 4)
-	if err != nil || err == io.EOF {
+	if err != nil {
 		return 0, err
 	}
 

--- a/shared/archive/archive.go
+++ b/shared/archive/archive.go
@@ -109,6 +109,12 @@ func CompressedTarReader(ctx context.Context, r io.ReadSeeker, unpacker []string
 			return nil, cancelFunc, subprocess.NewRunError(unpacker[0], unpacker[1:], err, nil, &buffer)
 		}
 
+		// Close the pipe upon completion.
+		go func() {
+			err := cmd.Wait()
+			_ = pipeWriter.CloseWithError(err)
+		}()
+
 		ctxCancelFunc := cancelFunc
 
 		// Now that unpacker process has started, wrap context cancel function with one that waits for

--- a/shared/archive/detect.go
+++ b/shared/archive/detect.go
@@ -31,34 +31,39 @@ func DetectCompressionFile(f io.Reader) ([]string, string, []string, error) {
 	// tar - 263 bytes, trying to get ustar from 257 - 262
 	// lz4 - 4 bytes 0x04 0x22 0x4d 0x18, magic number
 	header := make([]byte, 263)
-	_, err := f.Read(header)
+	n, err := f.Read(header)
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	switch {
-	case bytes.Equal(header[0:2], []byte{'B', 'Z'}):
+	// Compressed tar handling.
+	case n >= 2 && bytes.Equal(header[0:2], []byte{'B', 'Z'}):
 		return []string{"-jxf"}, ".tar.bz2", []string{"bzip2", "-d"}, nil
-	case bytes.Equal(header[0:2], []byte{0x1f, 0x8b}):
+	case n >= 2 && bytes.Equal(header[0:2], []byte{0x1f, 0x8b}):
 		return []string{"-zxf"}, ".tar.gz", []string{"gzip", "-d"}, nil
-	case (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] == 0xFD):
+	case n >= 5 && (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] == 0xFD):
 		return []string{"-Jxf"}, ".tar.xz", []string{"xz", "-d"}, nil
-	case (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] != 0xFD):
+	case n >= 5 && (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] != 0xFD):
 		return []string{"--lzma", "-xf"}, ".tar.lzma", []string{"lzma", "-d"}, nil
-	case bytes.Equal(header[0:3], []byte{0x5d, 0x00, 0x00}):
+	case n >= 3 && bytes.Equal(header[0:3], []byte{0x5d, 0x00, 0x00}):
 		return []string{"--lzma", "-xf"}, ".tar.lzma", []string{"lzma", "-d"}, nil
-	case bytes.Equal(header[257:262], []byte{'u', 's', 't', 'a', 'r'}):
-		return []string{"-xf"}, ".tar", []string{}, nil
-	case bytes.Equal(header[0:4], []byte{'h', 's', 'q', 's'}):
-		return []string{"-xf"}, ".squashfs", []string{"sqfs2tar", "--no-skip"}, nil
-	case bytes.Equal(header[0:3], []byte{'Q', 'F', 'I'}):
-		return []string{""}, ".qcow2", []string{"qemu-img", "convert", "-O", "raw"}, nil
-	case bytes.Equal(header[0:4], []byte{'K', 'D', 'M', 'V'}):
-		return []string{""}, ".vmdk", []string{"qemu-img", "convert", "-O", "raw"}, nil
-	case bytes.Equal(header[0:4], []byte{0x28, 0xb5, 0x2f, 0xfd}):
+	case n >= 4 && bytes.Equal(header[0:4], []byte{0x28, 0xb5, 0x2f, 0xfd}):
 		return []string{"--zstd", "-xf"}, ".tar.zst", []string{"zstd", "-d"}, nil
-	case bytes.Equal(header[0:4], []byte{0x04, 0x22, 0x4d, 0x18}):
+	case n >= 4 && bytes.Equal(header[0:4], []byte{0x04, 0x22, 0x4d, 0x18}):
 		return []string{"-Ilz4", "-xf"}, ".tar.lz4", []string{"lz4", "-d"}, nil
+
+	// Uncompressed tar handling.
+	case n >= 262 && bytes.Equal(header[257:262], []byte{'u', 's', 't', 'a', 'r'}):
+		return []string{"-xf"}, ".tar", []string{}, nil
+
+	// Other formats.
+	case n >= 4 && bytes.Equal(header[0:4], []byte{'h', 's', 'q', 's'}):
+		return []string{"-xf"}, ".squashfs", []string{"sqfs2tar", "--no-skip"}, nil
+	case n >= 3 && bytes.Equal(header[0:3], []byte{'Q', 'F', 'I'}):
+		return []string{""}, ".qcow2", []string{"qemu-img", "convert", "-O", "raw"}, nil
+	case n >= 4 && bytes.Equal(header[0:4], []byte{'K', 'D', 'M', 'V'}):
+		return []string{""}, ".vmdk", []string{"qemu-img", "convert", "-O", "raw"}, nil
 	default:
 		return nil, "", nil, errors.New("Unsupported compression")
 	}

--- a/shared/subprocess/bgpm_test.go
+++ b/shared/subprocess/bgpm_test.go
@@ -60,7 +60,7 @@ func TestSignalHandling(t *testing.T) {
 		}
 
 		// Break if error occurred
-		if err != nil && err != io.EOF {
+		if err != nil {
 			t.Error("Error in reading file ", err)
 		}
 	}
@@ -172,7 +172,7 @@ func TestProcessStartWaitExit(t *testing.T) {
 			break
 		}
 		// Break if error occurred
-		if err != nil && err != io.EOF {
+		if err != nil {
 			t.Error("Error reading file: ", err)
 		}
 	}


### PR DESCRIPTION
Fuzzing by the 7asecurity team has discovered a few issues with our handling of compressed images and backups.

This fixes 3 different issues:
 - We weren't checking that 0 bytes at the trailing end of a header were in fact 0 in the file itself (checking read length).
 - In case of unpacker error, the client may hang reading from the uncompressed pipe unless it implements its own timeout/context mechanism calling the canceler.
 - The signature of an uncompressed tarball is based on trailing bytes and so should be checked after all of those using leading bytes.

No crashes would result from such bad input but some of the consumers of those archive functions would be left hanging indefinitely, wasting a few goroutines.

Reported-by: https://7asecurity.com