### PR TITLE
Use io.CopyN with 4MiB buffer everywhere

### DIFF
--- a/client/incus_images.go
+++ b/client/incus_images.go
@@ -300,7 +300,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 			return nil, errors.New("Invalid multipart image")
 		}
 
-		size, err := io.Copy(io.MultiWriter(req.MetaFile, hash256), part)
+		size, err := util.SafeCopy(io.MultiWriter(req.MetaFile, hash256), part)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +318,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 			return nil, errors.New("Invalid multipart image")
 		}
 
-		size, err = io.Copy(io.MultiWriter(req.RootfsFile, hash256), part)
+		size, err = util.SafeCopy(io.MultiWriter(req.RootfsFile, hash256), part)
 		if err != nil {
 			return nil, err
 		}
@@ -346,7 +346,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 		return nil, errors.New("No filename in Content-Disposition header")
 	}
 
-	size, err := io.Copy(io.MultiWriter(req.MetaFile, hash256), body)
+	size, err := util.SafeCopy(io.MultiWriter(req.MetaFile, hash256), body)
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (r *ProtocolIncus) CreateImage(image api.ImagesPost, args *ImageCreateArgs)
 				return
 			}
 
-			_, ioErr = io.Copy(fw, args.MetaFile)
+			_, ioErr = util.SafeCopy(fw, args.MetaFile)
 			if ioErr != nil {
 				return
 			}
@@ -507,7 +507,7 @@ func (r *ProtocolIncus) CreateImage(image api.ImagesPost, args *ImageCreateArgs)
 				return
 			}
 
-			_, ioErr = io.Copy(fw, args.RootfsFile)
+			_, ioErr = util.SafeCopy(fw, args.RootfsFile)
 			if ioErr != nil {
 				return
 			}

--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lxc/incus/v6/shared/tcp"
 	localtls "github.com/lxc/incus/v6/shared/tls"
 	"github.com/lxc/incus/v6/shared/units"
+	"github.com/lxc/incus/v6/shared/util"
 	"github.com/lxc/incus/v6/shared/ws"
 )
 
@@ -1254,7 +1255,7 @@ func (r *ProtocolIncus) ExecInstance(instanceName string, exec api.InstanceExecP
 		if outputFiles["1"] != "" {
 			reader, _ := r.getInstanceExecOutputLogFile(instanceName, filepath.Base(outputFiles["1"]))
 			if args.Stdout != nil {
-				_, errCopy := io.Copy(args.Stdout, reader)
+				_, errCopy := util.SafeCopy(args.Stdout, reader)
 				// Regardless of errCopy value, we want to delete the file after a copy operation
 				errDelete := r.deleteInstanceExecOutputLogFile(instanceName, filepath.Base(outputFiles["1"]))
 				if errDelete != nil {
@@ -1275,7 +1276,7 @@ func (r *ProtocolIncus) ExecInstance(instanceName string, exec api.InstanceExecP
 		if outputFiles["2"] != "" {
 			reader, _ := r.getInstanceExecOutputLogFile(instanceName, filepath.Base(outputFiles["2"]))
 			if args.Stderr != nil {
-				_, errCopy := io.Copy(args.Stderr, reader)
+				_, errCopy := util.SafeCopy(args.Stderr, reader)
 				errDelete := r.deleteInstanceExecOutputLogFile(instanceName, filepath.Base(outputFiles["1"]))
 				if errDelete != nil {
 					return nil, errDelete
@@ -2995,7 +2996,7 @@ func (r *ProtocolIncus) GetInstanceBackupFile(instanceName string, name string, 
 		}
 	}
 
-	size, err := io.Copy(req.BackupFile, body)
+	size, err := util.SafeCopy(req.BackupFile, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3071,7 +3072,7 @@ func (r *ProtocolIncus) CreateInstanceBackupStream(instanceName string, backup a
 		}
 	}
 
-	_, err = io.Copy(req.BackupFile, body)
+	_, err = util.SafeCopy(req.BackupFile, body)
 	return err
 }
 

--- a/client/incus_storage_buckets.go
+++ b/client/incus_storage_buckets.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/lxc/incus/v6/shared/cancel"
 	"github.com/lxc/incus/v6/shared/ioprogress"
 	"github.com/lxc/incus/v6/shared/units"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // GetStoragePoolBucketNames returns a list of storage bucket names.
@@ -496,7 +496,7 @@ func (r *ProtocolIncus) GetStoragePoolBucketBackupFile(pool string, bucketName s
 		}
 	}
 
-	size, err := io.Copy(req.BackupFile, body)
+	size, err := util.SafeCopy(req.BackupFile, body)
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +567,7 @@ func (r *ProtocolIncus) CreateStoragePoolBucketBackupStream(poolName string, buc
 		}
 	}
 
-	_, err = io.Copy(req.BackupFile, body)
+	_, err = util.SafeCopy(req.BackupFile, body)
 	return err
 }
 

--- a/client/incus_storage_volumes.go
+++ b/client/incus_storage_volumes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lxc/incus/v6/shared/ioprogress"
 	localtls "github.com/lxc/incus/v6/shared/tls"
 	"github.com/lxc/incus/v6/shared/units"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // Storage volumes handling function
@@ -1085,7 +1086,7 @@ func (r *ProtocolIncus) GetStorageVolumeBackupFile(pool string, volName string, 
 		}
 	}
 
-	size, err := io.Copy(req.BackupFile, body)
+	size, err := util.SafeCopy(req.BackupFile, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1156,7 +1157,7 @@ func (r *ProtocolIncus) CreateStorageVolumeBackupStream(pool string, volName str
 		}
 	}
 
-	_, err = io.Copy(req.BackupFile, body)
+	_, err = util.SafeCopy(req.BackupFile, body)
 	return err
 }
 

--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lxc/incus/v6/shared/osarch"
 	"github.com/lxc/incus/v6/shared/subprocess"
 	"github.com/lxc/incus/v6/shared/units"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 type ociInfo struct {
@@ -259,7 +260,7 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 		pipeWrite.Close()
 	}()
 
-	size, err := io.Copy(req.MetaFile, pipeRead)
+	size, err := util.SafeCopy(req.MetaFile, pipeRead)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +296,7 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 		pipeWrite.Close()
 	}()
 
-	size, err = io.Copy(req.RootfsFile, pipeRead)
+	size, err = util.SafeCopy(req.RootfsFile, pipeRead)
 	if err != nil {
 		return nil, err
 	}

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -203,7 +203,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 				}
 
 				// Copy to the target
-				size, err := io.Copy(req.RootfsFile, patchedFile)
+				size, err := util.SafeCopy(req.RootfsFile, patchedFile)
 				if err != nil {
 					return -1, err
 				}
@@ -263,7 +263,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 			return nil, err
 		}
 
-		_, err := io.Copy(hash256, req.MetaFile)
+		_, err := util.SafeCopy(hash256, req.MetaFile)
 		if err != nil {
 			return nil, err
 		}
@@ -275,7 +275,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 			return nil, err
 		}
 
-		_, err := io.Copy(hash256, req.RootfsFile)
+		_, err := util.SafeCopy(hash256, req.RootfsFile)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/incus-agent/main_agent.go
+++ b/cmd/incus-agent/main_agent.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -79,7 +78,7 @@ func (c *cmdAgent) run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Copy the data.
-		_, err = io.Copy(dst, src)
+		_, err = util.SafeCopy(dst, src)
 		if err != nil {
 			return err
 		}

--- a/cmd/incus-agent/server.go
+++ b/cmd/incus-agent/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lxc/incus/v6/internal/server/response"
 	localUtil "github.com/lxc/incus/v6/internal/server/util"
 	"github.com/lxc/incus/v6/shared/logger"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 func restServer(tlsConfig *tls.Config, cert *x509.Certificate, debug bool, d *Daemon) *http.Server {
@@ -58,7 +59,7 @@ func createCmd(restAPI *http.ServeMux, version string, c APIEndpoint, cert *x509
 			newBody := &bytes.Buffer{}
 			captured := &bytes.Buffer{}
 			multiW := io.MultiWriter(newBody, captured)
-			_, err := io.Copy(multiW, r.Body)
+			_, err := util.SafeCopy(multiW, r.Body)
 			if err != nil {
 				_ = response.InternalError(err).Render(w)
 				return

--- a/cmd/incus-agent/templates.go
+++ b/cmd/incus-agent/templates.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -125,7 +124,7 @@ func templatesApply(path string) ([]string, error) {
 
 			defer func() { _ = src.Close() }()
 
-			_, err = io.Copy(w, src)
+			_, err = util.SafeCopy(w, src)
 			if err != nil {
 				return err
 			}

--- a/cmd/incus-migrate/main_migrate.go
+++ b/cmd/incus-migrate/main_migrate.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -260,18 +259,11 @@ func (m *Migration) askPath(question string) (string, error) {
 
 		fmt.Printf("Downloading %q\n", path)
 
-		for {
-			// Read 4MB at a time.
-			_, err = io.CopyN(f, resp.Body, 4*1024*1024)
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
+		_, err = util.SafeCopy(f, resp.Body)
+		if err != nil {
+			_ = os.Remove(f.Name())
 
-				_ = os.Remove(f.Name())
-
-				return "", err
-			}
+			return "", err
 		}
 
 		path = f.Name()

--- a/cmd/incus-migrate/main_netcat.go
+++ b/cmd/incus-migrate/main_netcat.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"io"
 	"net"
 	"os"
 	"sync"
@@ -10,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/incus/v6/internal/eagain"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 type cmdNetcat struct {
@@ -56,13 +56,13 @@ func (c *cmdNetcat) run(cmd *cobra.Command, args []string) error {
 	wg.Add(1)
 
 	go func() {
-		_, err = io.Copy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
+		_, err = util.SafeCopy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
 		_ = conn.Close()
 		wg.Done()
 	}()
 
 	go func() {
-		_, _ = io.Copy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
+		_, _ = util.SafeCopy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
 	}()
 
 	// Wait

--- a/cmd/incus-migrate/migrate_ova.go
+++ b/cmd/incus-migrate/migrate_ova.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/archive"
 	"github.com/lxc/incus/v6/shared/ask"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // VHResourceType defines what kind of resource this is (e.g., CPU, memory).
@@ -294,16 +295,10 @@ func (m *OVAMigration) unpackOVA(outPath string) error {
 			return fmt.Errorf("Error creating file: %v", err)
 		}
 
-		for {
-			_, err = io.CopyN(outFile, tarReader, 4*1024*1024)
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-
-				outFile.Close()
-				return fmt.Errorf("Error unpacking file: %v", err)
-			}
+		_, err = util.SafeCopy(outFile, tarReader)
+		if err != nil {
+			outFile.Close()
+			return fmt.Errorf("Error unpacking file: %v", err)
 		}
 
 		outFile.Close()

--- a/cmd/incus-migrate/utils.go
+++ b/cmd/incus-migrate/utils.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -24,6 +23,7 @@ import (
 	"github.com/lxc/incus/v6/internal/version"
 	"github.com/lxc/incus/v6/shared/api"
 	localtls "github.com/lxc/incus/v6/shared/tls"
+	"github.com/lxc/incus/v6/shared/util"
 	"github.com/lxc/incus/v6/shared/ws"
 )
 
@@ -136,15 +136,9 @@ func transferRootfs(ctx context.Context, op incus.Operation, rootfs string, rsyn
 			_ = f.Close()
 		}()
 
-		for {
-			_, err = io.CopyN(conn, f, 4*1024*1024)
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-
-				return abort(err)
-			}
+		_, err = util.SafeCopy(conn, f)
+		if err != nil {
+			return abort(err)
 		}
 
 		err = conn.Close()

--- a/cmd/incus-simplestreams/main_add.go
+++ b/cmd/incus-simplestreams/main_add.go
@@ -22,6 +22,7 @@ import (
 	cli "github.com/lxc/incus/v6/shared/cmd"
 	"github.com/lxc/incus/v6/shared/osarch"
 	"github.com/lxc/incus/v6/shared/simplestreams"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 type cmdAdd struct {
@@ -119,7 +120,7 @@ func (c *cmdAdd) parseImage(metaFile *os.File, dataFile *os.File) (*dataItem, er
 	}
 
 	hash256 := sha256.New()
-	_, err = io.Copy(hash256, dataFile)
+	_, err = util.SafeCopy(hash256, dataFile)
 	if err != nil {
 		return nil, err
 	}
@@ -138,12 +139,12 @@ func (c *cmdAdd) parseImage(metaFile *os.File, dataFile *os.File) (*dataItem, er
 	}
 
 	hash256 = sha256.New()
-	_, err = io.Copy(hash256, metaFile)
+	_, err = util.SafeCopy(hash256, metaFile)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = io.Copy(hash256, dataFile)
+	_, err = util.SafeCopy(hash256, dataFile)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +192,7 @@ func (c *cmdAdd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	hash256 := sha256.New()
-	_, err = io.Copy(hash256, metaFile)
+	_, err = util.SafeCopy(hash256, metaFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/incus-simplestreams/main_verify.go
+++ b/cmd/incus-simplestreams/main_verify.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 
@@ -13,6 +12,7 @@ import (
 
 	cli "github.com/lxc/incus/v6/shared/cmd"
 	"github.com/lxc/incus/v6/shared/simplestreams"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 type cmdVerify struct {
@@ -91,7 +91,7 @@ func (c *cmdVerify) run(cmd *cobra.Command, args []string) error {
 				}
 
 				hash256 := sha256.New()
-				_, err = io.Copy(hash256, dataFile)
+				_, err = util.SafeCopy(hash256, dataFile)
 				if err != nil {
 					return err
 				}

--- a/cmd/incus-user/proxy.go
+++ b/cmd/incus-user/proxy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"slices"
@@ -131,6 +130,6 @@ func proxyConnection(conn *net.UnixConn, serverUnixPath string) {
 	}
 
 	// Start proxying.
-	go func() { _, _ = io.Copy(conn, tlsClient) }()
-	_, _ = io.Copy(tlsClient, conn)
+	go func() { _, _ = util.SafeCopy(conn, tlsClient) }()
+	_, _ = util.SafeCopy(tlsClient, conn)
 }

--- a/cmd/incus/debug.go
+++ b/cmd/incus/debug.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -11,6 +10,7 @@ import (
 	u "github.com/lxc/incus/v6/cmd/incus/usage"
 	"github.com/lxc/incus/v6/internal/i18n"
 	cli "github.com/lxc/incus/v6/shared/cmd"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 type cmdDebug struct {
@@ -76,7 +76,7 @@ func (c *cmdDebugMemory) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("Failed to dump instance memory: %w"), err)
 	}
 
-	_, err = io.Copy(target, rc)
+	_, err = util.SafeCopy(target, rc)
 	if err != nil {
 		return err
 	}

--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -614,17 +614,10 @@ func (c *cmdFilePull) pull(parsedFiles []*u.Parsed, target string) error {
 
 				defer func() { _ = src.Close() }()
 
-				for {
-					// Read 1MB at a time.
-					_, err = io.CopyN(writer, src, 1024*1024)
-					if err != nil {
-						if err == io.EOF {
-							break
-						}
-
-						progress.Done("")
-						return err
-					}
+				_, err = util.SafeCopy(writer, src)
+				if err != nil {
+					progress.Done("")
+					return err
 				}
 			}
 

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	cli "github.com/lxc/incus/v6/shared/cmd"
 	"github.com/lxc/incus/v6/shared/termios"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 type cmdNetworkACL struct {
@@ -264,7 +265,7 @@ func (c *cmdNetworkACLShowLog) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = io.Copy(os.Stdout, log)
+	_, err = util.SafeCopy(os.Stdout, log)
 	_ = log.Close()
 
 	return err

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -4034,7 +4034,7 @@ func (c *cmdStorageVolumeNBD) Run(cmd *cobra.Command, args []string) error {
 	go func() {
 		defer wg.Done()
 
-		_, _ = io.Copy(conn, nConn)
+		_, _ = util.SafeCopy(conn, nConn)
 		_ = conn.Close()
 		_ = nConn.Close()
 	}()
@@ -4042,7 +4042,7 @@ func (c *cmdStorageVolumeNBD) Run(cmd *cobra.Command, args []string) error {
 	go func() {
 		defer wg.Done()
 
-		_, _ = io.Copy(nConn, conn)
+		_, _ = util.SafeCopy(nConn, conn)
 		_ = conn.Close()
 		_ = nConn.Close()
 	}()

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -2732,17 +2732,10 @@ func (c *cmdStorageVolumeFilePull) pull(parsedPool *u.Parsed, parsedPath *u.Pars
 
 		defer func() { _ = src.Close() }()
 
-		for {
-			// Read 1MB at a time.
-			_, err = io.CopyN(writer, src, 1024*1024)
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
-
-				progress.Done("")
-				return err
-			}
+		_, err = util.SafeCopy(writer, src)
+		if err != nil {
+			progress.Done("")
+			return err
 		}
 	}
 

--- a/cmd/incus/utils.go
+++ b/cmd/incus/utils.go
@@ -27,6 +27,7 @@ import (
 	config "github.com/lxc/incus/v6/shared/cliconfig"
 	"github.com/lxc/incus/v6/shared/termios"
 	localtls "github.com/lxc/incus/v6/shared/tls"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // Date layout to be used throughout the client.
@@ -568,13 +569,13 @@ func sshfsMount(ctx context.Context, sftpConn net.Conn, entity string, relPath s
 		case <-ctx.Done():
 		}
 
-		cancel()                                  // Prevents error output when the io.Copy functions finish.
+		cancel()                                  // Prevents error output when the util.SafeCopy functions finish.
 		_ = sshfsCmd.Process.Signal(os.Interrupt) // This will cause sshfs to unmount.
 		_ = stdin.Close()
 	}()
 
 	go func() {
-		_, err := io.Copy(stdin, sftpConn)
+		_, err := util.SafeCopy(stdin, sftpConn)
 		if ctx.Err() == nil {
 			if err != nil {
 				fmt.Fprintf(os.Stderr, i18n.G("I/O copy from instance to sshfs failed: %v")+"\n", err)
@@ -585,7 +586,7 @@ func sshfsMount(ctx context.Context, sftpConn net.Conn, entity string, relPath s
 		cancel() // Ask sshfs to end.
 	}()
 
-	_, err = io.Copy(sftpConn, stdout)
+	_, err = util.SafeCopy(sftpConn, stdout)
 	if err != nil && ctx.Err() == nil {
 		fmt.Fprintf(os.Stderr, i18n.G("I/O copy from sshfs to instance failed: %v")+"\n", err)
 	}
@@ -742,7 +743,7 @@ func sshSFTPServer(ctx context.Context, sftpConn func() (net.Conn, error), authN
 					// Copy SFTP data between client and remote instance.
 					ctx, cancel := context.WithCancel(ctx)
 					go func() {
-						_, err := io.Copy(channel, sftpConn)
+						_, err := util.SafeCopy(channel, sftpConn)
 						if ctx.Err() == nil {
 							if err != nil {
 								fmt.Fprintf(os.Stderr, i18n.G("I/O copy from instance to SSH failed: %v")+"\n", err)
@@ -750,16 +751,16 @@ func sshSFTPServer(ctx context.Context, sftpConn func() (net.Conn, error), authN
 								fmt.Printf(i18n.G("Instance disconnected for client %q")+"\n", nConn.RemoteAddr())
 							}
 						}
-						cancel() // Prevents error output when other io.Copy finishes.
+						cancel() // Prevents error output when other util.SafeCopy finishes.
 						_ = channel.Close()
 					}()
 
-					_, err = io.Copy(sftpConn, channel)
+					_, err = util.SafeCopy(sftpConn, channel)
 					if err != nil && ctx.Err() == nil {
 						fmt.Fprintf(os.Stderr, i18n.G("I/O copy from SSH to instance failed: %v")+"\n", err)
 					}
 
-					cancel() // Prevents error output when other io.Copy finishes.
+					cancel() // Prevents error output when other util.SafeCopy finishes.
 					_ = sftpConn.Close()
 				}()
 			}

--- a/cmd/incus/utils_sftp.go
+++ b/cmd/incus/utils_sftp.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lxc/incus/v6/shared/ioprogress"
 	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/units"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 func sftpSetOwnerMode(sftpConn *sftp.Client, targetPath string, args incus.InstanceFileArgs) error {
@@ -76,16 +77,9 @@ func sftpCreateFile(sftpConn *sftp.Client, targetPath string, args incus.Instanc
 		defer func() { _ = file.Close() }()
 
 		if push {
-			for {
-				// Read 1MB at a time.
-				_, err = io.CopyN(file, args.Content, 1024*1024)
-				if err != nil {
-					if err == io.EOF {
-						break
-					}
-
-					return err
-				}
+			_, err = util.SafeCopy(file, args.Content)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -212,17 +206,10 @@ func sftpRecursivePullFile(sftpConn *sftp.Client, fInfo os.FileInfo, p string, t
 			},
 		}
 
-		for {
-			// Read 1MB at a time.
-			_, err = io.CopyN(writer, src, 1024*1024)
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
-
-				progress.Done("")
-				return err
-			}
+		_, err = util.SafeCopy(writer, src)
+		if err != nil {
+			progress.Done("")
+			return err
 		}
 
 		err = src.Close()

--- a/cmd/incusd/backup.go
+++ b/cmd/incusd/backup.go
@@ -183,7 +183,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 			}
 		} else {
 			backupProgressWriter.WriteCloser = tarFileWriter
-			_, err = io.Copy(backupProgressWriter, tarPipeReader)
+			_, err = util.SafeCopy(backupProgressWriter, tarPipeReader)
 		}
 
 		resCh <- err
@@ -532,7 +532,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 					_ = tarPipeWriter.Close()
 				}
 			} else {
-				_, err = io.Copy(fileWriter, tarPipeReader)
+				_, err = util.SafeCopy(fileWriter, tarPipeReader)
 			}
 
 			resCh <- err
@@ -791,7 +791,7 @@ func bucketBackupCreate(s *state.State, args db.StoragePoolBucketBackup, project
 				_ = tarPipeWriter.Close()
 			}
 		} else {
-			_, err = io.Copy(tarFileWriter, tarPipeReader)
+			_, err = util.SafeCopy(tarFileWriter, tarPipeReader)
 		}
 
 		resCh <- err

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -729,7 +729,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			newBody := &bytes.Buffer{}
 			captured := &bytes.Buffer{}
 			multiW := io.MultiWriter(newBody, captured)
-			_, err := io.Copy(multiW, r.Body)
+			_, err := util.SafeCopy(multiW, r.Body)
 			if err != nil {
 				_ = response.InternalError(err).Render(w)
 				return

--- a/cmd/incusd/daemon_images.go
+++ b/cmd/incusd/daemon_images.go
@@ -520,7 +520,7 @@ func imageDownload(ctx context.Context, r *http.Request, s *state.State, op *ope
 
 		// Download the image
 		writer := internalIO.NewQuotaWriter(io.MultiWriter(f, hash256), args.Budget)
-		size, err := io.Copy(writer, body)
+		size, err := util.SafeCopy(writer, body)
 		if err != nil {
 			return nil, false, err
 		}

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -172,7 +172,7 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 			return err
 		}
 
-		_, err = io.Copy(outfile, tempfile)
+		_, err = util.SafeCopy(outfile, tempfile)
 		if err != nil {
 			return err
 		}
@@ -740,7 +740,7 @@ func getImgPostInfo(ctx context.Context, s *state.State, r *http.Request, buildd
 			return nil, errors.New("Invalid multipart image")
 		}
 
-		size, err = io.Copy(io.MultiWriter(imageTarf, hash256), part)
+		size, err = util.SafeCopy(io.MultiWriter(imageTarf, hash256), part)
 		info.Size += size
 
 		_ = imageTarf.Close()
@@ -773,7 +773,7 @@ func getImgPostInfo(ctx context.Context, s *state.State, r *http.Request, buildd
 
 		defer func() { _ = os.Remove(rootfsTarf.Name()) }()
 
-		size, err = io.Copy(io.MultiWriter(rootfsTarf, hash256), part)
+		size, err = util.SafeCopy(io.MultiWriter(rootfsTarf, hash256), part)
 		info.Size += size
 
 		_ = rootfsTarf.Close()
@@ -824,7 +824,7 @@ func getImgPostInfo(ctx context.Context, s *state.State, r *http.Request, buildd
 			return nil, err
 		}
 
-		size, err = io.Copy(hash256, post)
+		size, err = util.SafeCopy(hash256, post)
 		if err != nil {
 			l.Error("Failed to copy the tarfile", logger.Ctx{"err": err})
 			return nil, err
@@ -1179,7 +1179,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	_, err = io.Copy(internalIO.NewQuotaWriter(post, budget), r.Body)
+	_, err = util.SafeCopy(internalIO.NewQuotaWriter(post, budget), r.Body)
 	if err != nil {
 		logger.Errorf("Store image POST data to disk: %v", err)
 		cleanup(builddir, post)

--- a/cmd/incusd/instance_debug.go
+++ b/cmd/incusd/instance_debug.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,6 +23,7 @@ import (
 	storageDrivers "github.com/lxc/incus/v6/internal/server/storage/drivers"
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/subprocess"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // swagger:operation GET /1.0/instances/{name}/debug/memory instances instance_debug_memory_get
@@ -123,7 +123,7 @@ func instanceDebugMemoryGet(d *Daemon, r *http.Request) response.Response {
 		chCopy := make(chan error)
 
 		go func() {
-			_, err := io.Copy(w, reader)
+			_, err := util.SafeCopy(w, reader)
 			chCopy <- err
 		}()
 

--- a/cmd/incusd/instance_file.go
+++ b/cmd/incusd/instance_file.go
@@ -549,7 +549,7 @@ func fileSFTPPost(client *sftp.Client, path string, r *http.Request, onSuccess f
 		}
 
 		// Transfer the file into the instance.
-		_, err = io.Copy(file, r.Body)
+		_, err = util.SafeCopy(file, r.Body)
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/cmd/incusd/instance_metadata.go
+++ b/cmd/incusd/instance_metadata.go
@@ -498,7 +498,7 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 		return response.SmartError(err)
 	}
 
-	_, err = io.Copy(tempfile, template)
+	_, err = util.SafeCopy(tempfile, template)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -622,7 +622,7 @@ func instanceMetadataTemplatesPost(d *Daemon, r *http.Request) response.Response
 		return response.SmartError(err)
 	}
 
-	_, err = io.Copy(template, r.Body)
+	_, err = util.SafeCopy(template, r.Body)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -660,7 +660,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 	reverter.Add(func() { _ = backupFile.Close() })
 
 	// Stream uploaded backup data into temporary file.
-	_, err = io.Copy(backupFile, data)
+	_, err = util.SafeCopy(backupFile, data)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/cmd/incusd/main_netcat.go
+++ b/cmd/incusd/main_netcat.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"sync"
@@ -87,7 +86,7 @@ func (c *cmdNetcat) run(cmd *cobra.Command, args []string) error {
 	wg.Add(1)
 
 	go func() {
-		_, err := io.Copy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
+		_, err := util.SafeCopy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
 		if err != nil && logErr == nil {
 			_, _ = logFile.WriteString(fmt.Sprintf("Error while copying from stdout to unix domain socket \"%s\": %s\n", args[0], err))
 		}
@@ -97,7 +96,7 @@ func (c *cmdNetcat) run(cmd *cobra.Command, args []string) error {
 	}()
 
 	go func() {
-		_, err := io.Copy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
+		_, err := util.SafeCopy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
 		if err != nil && logErr == nil {
 			_, _ = logFile.WriteString(fmt.Sprintf("Error while copying from unix domain socket \"%s\" to stdin: %s\n", args[0], err))
 		}

--- a/cmd/incusd/storage_buckets.go
+++ b/cmd/incusd/storage_buckets.go
@@ -1416,7 +1416,7 @@ func createStoragePoolBucketFromBackup(s *state.State, r *http.Request, requestP
 	reverter.Add(func() { _ = backupFile.Close() })
 
 	// Stream uploaded backup data into temporary file.
-	_, err = io.Copy(backupFile, data)
+	_, err = util.SafeCopy(backupFile, data)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/cmd/incusd/storage_volumes.go
+++ b/cmd/incusd/storage_volumes.go
@@ -2553,7 +2553,7 @@ func createStoragePoolVolumeFromISO(s *state.State, r *http.Request, requestProj
 	reverter.Add(func() { _ = isoFile.Close() })
 
 	// Stream uploaded ISO data into temporary file.
-	size, err := io.Copy(isoFile, data)
+	size, err := util.SafeCopy(isoFile, data)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -2606,7 +2606,7 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 	reverter.Add(func() { _ = backupFile.Close() })
 
 	// Stream uploaded backup data into temporary file.
-	_, err = io.Copy(backupFile, data)
+	_, err = util.SafeCopy(backupFile, data)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/cmd/lxc-to-incus/main_netcat.go
+++ b/cmd/lxc-to-incus/main_netcat.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"io"
 	"net"
 	"os"
 	"sync"
@@ -10,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/incus/v6/internal/eagain"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 type cmdNetcat struct {
@@ -59,11 +59,11 @@ func (c *cmdNetcat) run(cmd *cobra.Command, args []string) error {
 		defer func() { _ = conn.Close() }()
 		defer wg.Done()
 
-		_, _ = io.Copy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
+		_, _ = util.SafeCopy(eagain.Writer{Writer: os.Stdout}, eagain.Reader{Reader: conn})
 	}()
 
 	go func() {
-		_, _ = io.Copy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
+		_, _ = util.SafeCopy(eagain.Writer{Writer: conn}, eagain.Reader{Reader: os.Stdin})
 	}()
 
 	// Wait

--- a/cmd/lxd-to-incus/db.go
+++ b/cmd/lxd-to-incus/db.go
@@ -11,6 +11,7 @@ import (
 
 	internalIO "github.com/lxc/incus/v6/internal/io"
 	internalUtil "github.com/lxc/incus/v6/internal/util"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // Uncompress the raft snapshot files in the given database directory.
@@ -108,7 +109,7 @@ func lz4Uncompress(zfilename string) error {
 
 	zr.Reset(zfile)
 
-	_, err = io.Copy(file, zr)
+	_, err = util.SafeCopy(file, zr)
 	if err != nil {
 		return fmt.Errorf("Failed to uncompress %q into %q: %w", zfilename, filename, err)
 	}

--- a/internal/instancewriter/instance_tar_writer.go
+++ b/internal/instancewriter/instance_tar_writer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lxc/incus/v6/internal/linux"
 	"github.com/lxc/incus/v6/shared/idmap"
 	"github.com/lxc/incus/v6/shared/logger"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // InstanceTarWriter provides an InstanceWriter implementation that handles ID shifting and hardlink tracking.
@@ -172,7 +173,7 @@ func (ctw *InstanceTarWriter) WriteFile(name string, srcPath string, fi os.FileI
 			r = io.LimitReader(r, fi.Size())
 		}
 
-		_, err = io.Copy(ctw.tarWriter, r)
+		_, err = util.SafeCopy(ctw.tarWriter, r)
 		if err != nil {
 			return fmt.Errorf("Failed to copy file content %q: %w", srcPath, err)
 		}
@@ -199,7 +200,7 @@ func (ctw *InstanceTarWriter) WriteFileFromReader(src io.Reader, fi os.FileInfo)
 		return fmt.Errorf("Failed to write tar header: %w", err)
 	}
 
-	_, err = io.Copy(ctw.tarWriter, src)
+	_, err = util.SafeCopy(ctw.tarWriter, src)
 	return err
 }
 

--- a/internal/io/writer.go
+++ b/internal/io/writer.go
@@ -3,6 +3,8 @@ package io
 import (
 	"bytes"
 	"io"
+
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // WriteAll copies content of data to specified writer.
@@ -11,7 +13,7 @@ func WriteAll(w io.Writer, data []byte) error {
 
 	toWrite := int64(buf.Len())
 	for {
-		n, err := io.Copy(w, buf)
+		n, err := util.SafeCopy(w, buf)
 		if err != nil {
 			return err
 		}

--- a/internal/rsync/rsync.go
+++ b/internal/rsync/rsync.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lxc/incus/v6/shared/ioprogress"
 	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/subprocess"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // Debug controls additional debugging in rsync output.
@@ -260,7 +261,7 @@ func Send(name string, path string, conn io.ReadWriteCloser, tracker *ioprogress
 	// Forward from netcat to target.
 	chCopyNetcat := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(conn, readNetcatPipe)
+		_, err := util.SafeCopy(conn, readNetcatPipe)
 		chCopyNetcat <- err
 		_ = readNetcatPipe.Close()
 		_ = netcatConn.Close()
@@ -271,7 +272,7 @@ func Send(name string, path string, conn io.ReadWriteCloser, tracker *ioprogress
 	writeNetcatPipe := io.WriteCloser(netcatConn)
 	chCopyTarget := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(writeNetcatPipe, conn)
+		_, err := util.SafeCopy(writeNetcatPipe, conn)
 		chCopyTarget <- err
 		_ = writeNetcatPipe.Close()
 	}()
@@ -350,7 +351,7 @@ func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTrac
 
 	chCopyRsync := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(conn, stdout)
+		_, err := util.SafeCopy(conn, stdout)
 		_ = stdout.Close()
 		_ = conn.Close() // sends barrier message.
 		chCopyRsync <- err
@@ -372,7 +373,7 @@ func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTrac
 
 	chCopySource := make(chan error, 1)
 	go func() {
-		_, err := io.Copy(stdin, readSourcePipe)
+		_, err := util.SafeCopy(stdin, readSourcePipe)
 		_ = stdin.Close()
 		chCopySource <- err
 	}()

--- a/internal/server/cluster/gateway.go
+++ b/internal/server/cluster/gateway.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -1165,12 +1164,12 @@ func dqliteProxy(name string, stopCh chan struct{}, remote net.Conn, local net.C
 	// Start copying data back and forth until either the client or the
 	// server get closed or hit an error.
 	go func() {
-		_, err := io.Copy(local, remote)
+		_, err := util.SafeCopy(local, remote)
 		remoteToLocal <- err
 	}()
 
 	go func() {
-		_, err := io.Copy(remote, local)
+		_, err := util.SafeCopy(remote, local)
 		localToRemote <- err
 	}()
 

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1013,9 +1013,9 @@ func (d *qemu) receiveMigrationSnapshot(monitor *qmp.Monitor, blockExport string
 
 	d.logger.Debug("Migration storage NBD export starting")
 
-	go func() { _, _ = io.Copy(filesystemConn, nbdConn) }()
+	go func() { _, _ = util.SafeCopy(filesystemConn, nbdConn) }()
 
-	_, _ = io.Copy(nbdConn, filesystemConn)
+	_, _ = util.SafeCopy(nbdConn, filesystemConn)
 
 	filesystemConn.Close()
 	d.logger.Debug("Migration storage NBD export finished")
@@ -1094,7 +1094,7 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 		}
 
 		go func() {
-			_, _ = io.Copy(pipeWrite, stateConn)
+			_, _ = util.SafeCopy(pipeWrite, stateConn)
 
 			_ = pipeRead.Close()
 			_ = pipeWrite.Close()
@@ -1131,7 +1131,7 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 		}
 
 		go func() {
-			_, err := io.Copy(pipeWrite, uncompressedState)
+			_, err := util.SafeCopy(pipeWrite, uncompressedState)
 			if err != nil {
 				d.logger.Warn("Failed reading from state file", logger.Ctx{"path": statePath, "err": err})
 			}
@@ -1203,7 +1203,7 @@ func (d *qemu) saveState(monitor *qmp.Monitor) error {
 		_ = pipeWrite.Close()
 	}()
 
-	go func() { _, _ = io.Copy(compressedState, pipeRead) }()
+	go func() { _, _ = util.SafeCopy(compressedState, pipeRead) }()
 
 	err = d.saveStateHandle(monitor, pipeWrite)
 	if err != nil {
@@ -7474,7 +7474,7 @@ func (d *qemu) Export(metaWriter io.Writer, rootfsWriter io.Writer, properties m
 		}
 
 		r := io.Reader(f)
-		_, err = io.Copy(rootfsWriter, r)
+		_, err = util.SafeCopy(rootfsWriter, r)
 		if err != nil {
 			return nil, err
 		}
@@ -7941,9 +7941,9 @@ func (d *qemu) sendMigrationSnapshot(diskName string, filesystemConn io.ReadWrit
 		defer func() { _ = nbdConn.Close() }()
 
 		d.logger.Debug("NBD connection on source started")
-		go func() { _, _ = io.Copy(filesystemConn, nbdConn) }()
+		go func() { _, _ = util.SafeCopy(filesystemConn, nbdConn) }()
 
-		_, _ = io.Copy(nbdConn, filesystemConn)
+		_, _ = util.SafeCopy(nbdConn, filesystemConn)
 		d.logger.Debug("NBD connection on source finished")
 
 		return nil
@@ -8236,7 +8236,7 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 		_ = pipeWrite.Close()
 	}()
 
-	go func() { _, _ = io.Copy(stateConn, pipeRead) }()
+	go func() { _, _ = util.SafeCopy(stateConn, pipeRead) }()
 
 	err = d.saveStateHandle(monitor, pipeWrite)
 	if err != nil {

--- a/internal/server/response/response.go
+++ b/internal/server/response/response.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/tcp"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 var debug bool
@@ -495,7 +496,7 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 			return err
 		}
 
-		_, err = io.Copy(fw, rd)
+		_, err = util.SafeCopy(fw, rd)
 		if err != nil {
 			return err
 		}
@@ -567,7 +568,7 @@ func (r *forwardedResponse) Render(w http.ResponseWriter) error {
 		w.WriteHeader(response.StatusCode)
 	}
 
-	_, err = io.Copy(w, response.Body)
+	_, err = util.SafeCopy(w, response.Body)
 	return err
 }
 
@@ -688,7 +689,7 @@ func (r *upgradeResponse) Render(w http.ResponseWriter) error {
 	go func() {
 		defer wg.Done()
 
-		_, err := io.Copy(remoteConn, r.conn)
+		_, err := util.SafeCopy(remoteConn, r.conn)
 		if err != nil {
 			if ctx.Err() == nil {
 				l.Warn("Failed copying data from local to remote connection", logger.Ctx{"err": err})
@@ -696,10 +697,10 @@ func (r *upgradeResponse) Render(w http.ResponseWriter) error {
 		}
 
 		cancel()               // Cancel context first so when remoteConn is closed it doesn't cause a warning.
-		_ = remoteConn.Close() // Trigger the cancellation of the io.Copy reading from remoteConn.
+		_ = remoteConn.Close() // Trigger the cancellation of the util.SafeCopy reading from remoteConn.
 	}()
 
-	_, err = io.Copy(r.conn, remoteConn)
+	_, err = util.SafeCopy(r.conn, remoteConn)
 	if err != nil {
 		if ctx.Err() == nil {
 			l.Warn("Failed copying data from remote to local connection", logger.Ctx{"err": err})
@@ -708,7 +709,7 @@ func (r *upgradeResponse) Render(w http.ResponseWriter) error {
 
 	cancel() // Cancel context first so when conn is closed it doesn't cause a warning.
 
-	err = r.conn.Close() // Trigger the cancellation of the io.Copy reading from conn.
+	err = r.conn.Close() // Trigger the cancellation of the util.SafeCopy reading from conn.
 	if err != nil {
 		return fmt.Errorf("Failed closing connection to remote server: %w", err)
 	}
@@ -746,7 +747,7 @@ func (r *pipeResponse) Render(w http.ResponseWriter) error {
 		flusher.Flush()
 	}
 
-	_, err := io.Copy(w, r.reader)
+	_, err := util.SafeCopy(w, r.reader)
 	return err
 }
 

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -8848,15 +8848,9 @@ func (b *backend) qcow2CreateVolumeFromMigration(vol drivers.Volume, projectName
 			toPipe = drivers.NewSparseFileWrapper(to)
 		}
 
-		for {
-			_, err = io.CopyN(toPipe, fromPipe, 4*1024*1024)
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-
-				return fmt.Errorf("Error copying from migration connection to %q: %w", path, err)
-			}
+		_, err = util.SafeCopy(toPipe, fromPipe)
+		if err != nil {
+			return fmt.Errorf("Error copying from migration connection to %q: %w", path, err)
 		}
 
 		return to.Close()

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -1756,7 +1756,7 @@ func (b *backend) isoFiller(data io.Reader) func(vol drivers.Volume, rootBlockPa
 
 		defer func() { _ = f.Close() }()
 
-		return io.Copy(f, data)
+		return util.SafeCopy(f, data)
 	}
 }
 
@@ -8692,7 +8692,7 @@ func (b *backend) qcow2MigrateVolume(s *state.State, vol drivers.Volume, project
 		}
 
 		b.logger.Debug("Sending block volume", logger.Ctx{"volName": vol.Name(), "path": nbdPath})
-		_, err = io.Copy(conn, fromPipe)
+		_, err = util.SafeCopy(conn, fromPipe)
 		if err != nil {
 			return fmt.Errorf("Error copying %q to migration connection: %w", nbdPath, err)
 		}

--- a/internal/server/storage/drivers/driver_ceph_utils.go
+++ b/internal/server/storage/drivers/driver_ceph_utils.go
@@ -1278,7 +1278,7 @@ func (d *ceph) receiveVolume(volumeName string, conn io.ReadWriteCloser, writeWr
 	// Forward input through stdin.
 	chCopyConn := make(chan error, 1)
 	go func() {
-		_, err = io.Copy(stdin, conn)
+		_, err = util.SafeCopy(stdin, conn)
 		_ = stdin.Close()
 		chCopyConn <- err
 	}()

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -365,15 +365,9 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 			toPipe = NewSparseFileWrapper(to)
 		}
 
-		for {
-			_, err = io.CopyN(toPipe, fromPipe, 4*1024*1024)
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-
-				return fmt.Errorf("Error copying from migration connection to %q: %w", path, err)
-			}
+		_, err = util.SafeCopy(toPipe, fromPipe)
+		if err != nil {
+			return fmt.Errorf("Error copying from migration connection to %q: %w", path, err)
 		}
 
 		return to.Close()
@@ -860,15 +854,9 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 
 					d.Logger().Debug(logMsg, logger.Ctx{"source": srcFile, "target": targetPath})
 
-					for {
-						_, err = io.CopyN(toPipe, tr, 4*1024*1024)
-						if err != nil {
-							if errors.Is(err, io.EOF) {
-								break
-							}
-
-							return err
-						}
+					_, err = util.SafeCopy(toPipe, tr)
+					if err != nil {
+						return err
 					}
 
 					cancelFunc()

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -229,7 +229,7 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol Volume, conn io.ReadW
 		}
 
 		d.Logger().Debug("Sending block volume", logger.Ctx{"volName": vol.name, "path": path})
-		_, err = io.Copy(conn, fromPipe)
+		_, err = util.SafeCopy(conn, fromPipe)
 		if err != nil {
 			return fmt.Errorf("Error copying %q to migration connection: %w", path, err)
 		}

--- a/internal/server/storage/utils.go
+++ b/internal/server/storage/utils.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -734,7 +733,7 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, sys
 
 			defer to.Close()
 
-			_, err = io.Copy(to, from)
+			_, err = util.SafeCopy(to, from)
 			if err != nil {
 				return -1, err
 			}

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -83,7 +83,7 @@ func FileCopy(source string, dest string) error {
 		}
 	}
 
-	_, err = io.Copy(d, s)
+	_, err = util.SafeCopy(d, s)
 	if err != nil {
 		return err
 	}

--- a/shared/cliconfig/cert.go
+++ b/shared/cliconfig/cert.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 
 	"golang.org/x/crypto/ssh"
@@ -203,7 +202,7 @@ func (c *Config) CopyGlobalCert(src string, dst string) error {
 		}
 
 		// Copy the content.
-		_, err = io.Copy(newFile, sourceFile)
+		_, err = util.SafeCopy(newFile, sourceFile)
 		if err != nil {
 			return err
 		}

--- a/shared/util/io.go
+++ b/shared/util/io.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"io"
+)
+
+// SafeCopy behaves like io.Copy but performs the copy through a loop of
+// io.CopyN calls using a fixed 4MiB chunk size.
+func SafeCopy(dst io.Writer, src io.Reader) (int64, error) {
+	const chunkSize = 4 * 1024 * 1024
+
+	var written int64
+	for {
+		n, err := io.CopyN(dst, src, chunkSize)
+		written += n
+		if err != nil {
+			if err == io.EOF {
+				return written, nil
+			}
+
+			return written, err
+		}
+	}
+}

--- a/shared/util/net.go
+++ b/shared/util/net.go
@@ -78,7 +78,7 @@ func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent st
 	var size int64
 
 	if hashFunc != nil {
-		size, err = io.Copy(io.MultiWriter(target, hashFunc), body)
+		size, err = SafeCopy(io.MultiWriter(target, hashFunc), body)
 		if err != nil {
 			return -1, err
 		}
@@ -88,7 +88,7 @@ func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent st
 			return -1, fmt.Errorf("Hash mismatch for %s: %s != %s", url, result, fileHash)
 		}
 	} else {
-		size, err = io.Copy(target, body)
+		size, err = SafeCopy(target, body)
 		if err != nil {
 			return -1, err
 		}

--- a/shared/ws/mirror.go
+++ b/shared/ws/mirror.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/incus/v6/shared/logger"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // Mirror takes a websocket and replicates all read/write to a ReadWriteCloser.
@@ -30,7 +31,7 @@ func MirrorRead(conn *websocket.Conn, rc io.Reader) chan error {
 	connRWC := NewWrapper(conn)
 
 	go func() {
-		_, err := io.Copy(connRWC, rc)
+		_, err := util.SafeCopy(connRWC, rc)
 
 		logger.Debug("Websocket: Stopped read mirror", logger.Ctx{"address": conn.RemoteAddr().String(), "err": err})
 
@@ -57,7 +58,7 @@ func MirrorWrite(conn *websocket.Conn, wc io.Writer) chan error {
 	connRWC := NewWrapper(conn)
 
 	go func() {
-		_, err := io.Copy(wc, connRWC)
+		_, err := util.SafeCopy(wc, connRWC)
 
 		logger.Debug("Websocket: Stopped write mirror", logger.Ctx{"address": conn.RemoteAddr().String(), "err": err})
 		chDone <- err

--- a/shared/ws/proxy.go
+++ b/shared/ws/proxy.go
@@ -1,11 +1,10 @@
 package ws
 
 import (
-	"io"
-
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/incus/v6/shared/logger"
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // Proxy mirrors the traffic between two websockets.
@@ -25,7 +24,7 @@ func Proxy(source *websocket.Conn, target *websocket.Conn) chan struct{} {
 				break
 			}
 
-			_, err = io.Copy(w, r)
+			_, err = util.SafeCopy(w, r)
 			w.Close()
 			if err != nil {
 				break


### PR DESCRIPTION
This prevents us from ever holding more than 4MiB of data in memory when relaying data between network connections or between network and files. That should help stabilize the memory footprint of incusd when running on busy systems.