### PR TITLE
Wait for BLOCK_JOB_COMPLETED event after block-job-complete

### DIFF
--- a/cmd/incusd/migrate.go
+++ b/cmd/incusd/migrate.go
@@ -61,6 +61,7 @@ func (c *migrationFields) send(m proto.Message) error {
 	}
 
 	_ = conn.SetWriteDeadline(time.Now().Add(30 * time.Second))
+
 	err = migration.ProtoSend(conn, m)
 	if err != nil {
 		return err
@@ -69,13 +70,24 @@ func (c *migrationFields) send(m proto.Message) error {
 	return nil
 }
 
-func (c *migrationFields) recv(m proto.Message) error {
+func (c *migrationFields) recv(m proto.Message, handshake bool) error {
 	conn, err := c.conns[api.SecretNameControl].WebSocket(context.TODO())
 	if err != nil {
 		return fmt.Errorf("Control connection not initialized: %w", err)
 	}
 
-	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	// If dealing with the initial handshake, use a short timeout to
+	// prevent lingering create operations on communication failure.
+	//
+	// Later calls are done during migration as migration barrier and
+	// can potentially take multiple hours.
+	if handshake {
+		_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
+		// Remove the deadline after the request.
+		defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+	}
+
 	return migration.ProtoRecv(conn, m)
 }
 
@@ -135,7 +147,7 @@ func (c *migrationFields) controlChannel() <-chan *localMigration.ControlRespons
 	ch := make(chan *localMigration.ControlResponse)
 	go func() {
 		resp := localMigration.ControlResponse{}
-		err := c.recv(&resp.MigrationControl)
+		err := c.recv(&resp.MigrationControl, false)
 		if err != nil {
 			resp.Err = err
 			ch <- &resp

--- a/cmd/incusd/migrate_storage_volumes.go
+++ b/cmd/incusd/migrate_storage_volumes.go
@@ -180,7 +180,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 
 	// Receive response from target.
 	respHeader := &migration.MigrationHeader{}
-	err = s.recv(respHeader)
+	err = s.recv(respHeader, true)
 	if err != nil {
 		logger.Errorf("Failed to receive storage volume migration header")
 		s.sendControl(err)
@@ -232,7 +232,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 	}
 
 	msg := migration.MigrationControl{}
-	err = s.recv(&msg)
+	err = s.recv(&msg, false)
 	if err != nil {
 		logger.Errorf("Failed to receive storage volume migration control message")
 		return err
@@ -309,7 +309,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 	}
 
 	offerHeader := &migration.MigrationHeader{}
-	err := c.recv(offerHeader)
+	err := c.recv(offerHeader, true)
 	if err != nil {
 		logger.Errorf("Failed to receive storage volume migration header")
 		c.sendControl(err)

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -6023,7 +6023,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 	// Receive response from target.
 	d.logger.Debug("Waiting for migration offer response from target")
 	respHeader := &migration.MigrationHeader{}
-	err = args.ControlReceive(respHeader)
+	err = args.ControlReceive(respHeader, true)
 	if err != nil {
 		err := fmt.Errorf("Failed receiving migration offer response: %w", err)
 		op.Done(err)
@@ -6104,7 +6104,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 		// This will read the result message from the target side and detect disconnections.
 		go func() {
 			resp := migration.MigrationControl{}
-			err := args.ControlReceive(&resp)
+			err := args.ControlReceive(&resp, false)
 			if err != nil {
 				err = fmt.Errorf("Error reading migration control target: %w", err)
 			} else if !resp.GetSuccess() {
@@ -6559,7 +6559,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 	// Receive offer from source.
 	d.logger.Debug("Waiting for migration offer from source")
 	offerHeader := &migration.MigrationHeader{}
-	err = args.ControlReceive(offerHeader)
+	err = args.ControlReceive(offerHeader, true)
 	if err != nil {
 		return fmt.Errorf("Failed receiving migration offer from source: %w", err)
 	}
@@ -6740,7 +6740,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		// This will read the result message from the source side and detect disconnections.
 		go func() {
 			resp := migration.MigrationControl{}
-			err := args.ControlReceive(&resp)
+			err := args.ControlReceive(&resp, false)
 			if err != nil {
 				err = fmt.Errorf("Error reading migration control source: %w", err)
 			} else if !resp.GetSuccess() {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -7641,7 +7641,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 	// Receive response from target.
 	d.logger.Debug("Waiting for migration offer response from target")
 	respHeader := &migration.MigrationHeader{}
-	err = args.ControlReceive(respHeader)
+	err = args.ControlReceive(respHeader, true)
 	if err != nil {
 		err := fmt.Errorf("Failed receiving migration offer response: %w", err)
 		op.Done(err)
@@ -7722,7 +7722,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 		// This will read the result message from the target side and detect disconnections.
 		go func() {
 			resp := migration.MigrationControl{}
-			err := args.ControlReceive(&resp)
+			err := args.ControlReceive(&resp, false)
 			if err != nil {
 				err = fmt.Errorf("Error reading migration control target: %w", err)
 			} else if !resp.GetSuccess() {
@@ -8382,7 +8382,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 	// Receive offer from source.
 	d.logger.Debug("Waiting for migration offer from source")
 	offerHeader := &migration.MigrationHeader{}
-	err = args.ControlReceive(offerHeader)
+	err = args.ControlReceive(offerHeader, true)
 	if err != nil {
 		return fmt.Errorf("Failed receiving migration offer from source: %w", err)
 	}
@@ -8554,7 +8554,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		// This will read the result message from the source side and detect disconnections.
 		go func() {
 			resp := migration.MigrationControl{}
-			err := args.ControlReceive(&resp)
+			err := args.ControlReceive(&resp, false)
 			if err != nil {
 				err = fmt.Errorf("Error reading migration control source: %w", err)
 			} else if !resp.GetSuccess() {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -478,7 +478,7 @@ func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) 
 	state := d.state
 
 	return func(event string, data map[string]any) {
-		if !slices.Contains([]string{qmp.EventVMShutdown, qmp.EventVMReset, qmp.EventAgentStarted, qmp.EventAgentStopped, qmp.EventRTCChange}, event) {
+		if !slices.Contains([]string{qmp.EventVMShutdown, qmp.EventVMReset, qmp.EventAgentStarted, qmp.EventAgentStopped, qmp.EventRTCChange, qmp.EventBlockJobCompleted, qmp.EventBlockJobError}, event) {
 			return // Don't bother loading the instance from DB if we aren't going to handle the event.
 		}
 
@@ -566,6 +566,11 @@ func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) 
 			if err != nil {
 				d.logger.Error("Failed to apply rtc change", logger.Ctx{"offset": val, "err": err})
 			}
+
+		case qmp.EventBlockJobCompleted, qmp.EventBlockJobError:
+			monitor, _ := d.qmpConnect()
+			monitor.PushEvent(event, data)
+			monitor.CleanupEventChannel(data["device"].(string))
 		}
 	}
 }

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -1488,12 +1488,26 @@ func (m *Monitor) BlockJobComplete(deviceNodeName string) error {
 
 	args.Device = deviceNodeName
 
-	err := m.Run("block-job-complete", args, nil)
+	ch, err := m.CreateEventChannel(args.Device)
 	if err != nil {
 		return err
 	}
 
-	return nil
+	err = m.Run("block-job-complete", args, nil)
+	if err != nil {
+		return err
+	}
+
+	event := <-ch
+
+	switch event.Name {
+	case EventBlockJobCompleted:
+		return nil
+	case EventBlockJobError:
+		return fmt.Errorf("Error during block-job-complete")
+	default:
+		return fmt.Errorf("Not supported event: %q", event.Name)
+	}
 }
 
 // UpdateBlockSize updates the size of a disk.

--- a/internal/server/instance/drivers/qmp/monitor.go
+++ b/internal/server/instance/drivers/qmp/monitor.go
@@ -45,8 +45,20 @@ var EventDiskEjected = "DEVICE_TRAY_MOVED"
 // EventRTCChange is used to get RTC adjustment.
 var EventRTCChange = "RTC_CHANGE"
 
+// EventBlockJobCompleted is emitted when a block job has completed.
+var EventBlockJobCompleted = "BLOCK_JOB_COMPLETED"
+
+// EventBlockJobError is emitted when a block job has errored.
+var EventBlockJobError = "BLOCK_JOB_ERROR"
+
 // ExcludedCommands is used to filter verbose commands from the QMP logs.
 var ExcludedCommands = []string{"ringbuf-read"}
+
+// Event represents a QMP event.
+type Event struct {
+	Name string
+	Data map[string]any
+}
 
 // Monitor represents a QMP monitor.
 type Monitor struct {
@@ -61,6 +73,8 @@ type Monitor struct {
 	serialCharDev  string
 	initialized    bool
 	detachDisk     func(name string) error
+	eventMap       map[string]chan Event
+	eventMapLock   sync.Mutex
 }
 
 // TransactionAction represents a single action within a QMP transaction.
@@ -366,6 +380,7 @@ func Connect(path string, serialCharDev string, eventHandler func(name string, d
 	monitor.eventHandler = eventHandler
 	monitor.serialCharDev = serialCharDev
 	monitor.detachDisk = detachDisk
+	monitor.eventMap = make(map[string]chan Event)
 
 	// Default to generating a shutdown event when the monitor disconnects so that devices can be
 	// cleaned up. This will be disabled after a shutdown event is received from QEMU itself to avoid
@@ -426,4 +441,45 @@ func (m *Monitor) SetInitialized(enable bool) {
 // IsInitialized reports whether the monitor believes the VM has been fully initialized.
 func (m *Monitor) IsInitialized() bool {
 	return m.initialized
+}
+
+// CreateEventChannel creates and registers a new event channel for the given device.
+func (m *Monitor) CreateEventChannel(deviceName string) (chan Event, error) {
+	m.eventMapLock.Lock()
+	defer m.eventMapLock.Unlock()
+
+	_, ok := m.eventMap[deviceName]
+	if ok {
+		return nil, fmt.Errorf("Event channel already exists for %s", deviceName)
+	}
+
+	ch := make(chan Event)
+	m.eventMap[deviceName] = ch
+	return ch, nil
+}
+
+// CleanupEventChannel removes the event channel associated with the given device.
+func (m *Monitor) CleanupEventChannel(deviceName string) {
+	m.eventMapLock.Lock()
+	defer m.eventMapLock.Unlock()
+
+	ch, ok := m.eventMap[deviceName]
+	if ok {
+		delete(m.eventMap, deviceName)
+	}
+
+	if ok {
+		close(ch)
+	}
+}
+
+// PushEvent publishes an event to the registered channel for the given device.
+func (m *Monitor) PushEvent(event string, data map[string]any) {
+	m.eventMapLock.Lock()
+	defer m.eventMapLock.Unlock()
+
+	ch, ok := m.eventMap[data["device"].(string)]
+	if ok {
+		ch <- Event{Name: event, Data: data}
+	}
 }

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -241,7 +241,7 @@ type Info struct {
 // MigrateArgs represent arguments for instance migration send and receive.
 type MigrateArgs struct {
 	ControlSend           func(m proto.Message) error
-	ControlReceive        func(m proto.Message) error
+	ControlReceive        func(m proto.Message, handshake bool) error
 	StateConn             func(ctx context.Context) (io.ReadWriteCloser, error)
 	FilesystemConn        func(ctx context.Context) (io.ReadWriteCloser, error)
 	Snapshots             bool


### PR DESCRIPTION
This change ensures we wait for the `BLOCK_JOB_COMPLETED` event after issuing `block-job-complete`. In QEMU, the return from the command does not guarantee that the job has fully finished. The completion event is the only reliable signal that the block job is fully finalized. This avoids race conditions where follow-up logic runs too early.

Closes: #3188