### PR TITLE
Add support for export/import qcow2 in raw format

### DIFF
--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -56,6 +56,7 @@ import (
 	localUtil "github.com/lxc/incus/v6/internal/server/util"
 	internalUtil "github.com/lxc/incus/v6/internal/util"
 	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/archive"
 	"github.com/lxc/incus/v6/shared/ioprogress"
 	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/revert"
@@ -791,9 +792,18 @@ func (b *backend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.Rea
 	defer importRevert.Fail()
 
 	// Unpack the backup into the new storage volume(s).
-	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(vol, srcBackup, srcData, backup.DefaultBackupPrefix, op)
-	if err != nil {
-		return nil, nil, err
+	var volPostHook drivers.VolumePostHook
+	var revertHook revert.Hook
+	if srcBackup.Config.Volume.Config["block.type"] == drivers.BlockVolumeTypeQcow2 {
+		volPostHook, revertHook, err = b.qcow2UnpackVolume(vol, srcBackup.Snapshots, srcData, backup.DefaultBackupPrefix, op)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		volPostHook, revertHook, err = b.driver.CreateVolumeFromBackup(vol, srcBackup, srcData, backup.DefaultBackupPrefix, op)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	if revertHook != nil {
@@ -2769,9 +2779,16 @@ func (b *backend) BackupInstance(inst instance.Instance, tarWriter *instancewrit
 		}
 	}
 
-	err = b.driver.BackupVolume(vol, tarWriter, backup.DefaultBackupPrefix, optimized, snapNames, op)
-	if err != nil {
-		return err
+	if dbVol.Config["block.type"] == drivers.BlockVolumeTypeQcow2 {
+		err = b.qcow2BackupVolume(vol, dbVol, inst.Project().Name, tarWriter, backup.DefaultBackupPrefix, snapNames, op)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = b.driver.BackupVolume(vol, tarWriter, backup.DefaultBackupPrefix, optimized, snapNames, op)
+		if err != nil {
+			return err
+		}
 	}
 
 	if dependentVolumes {
@@ -7590,9 +7607,16 @@ func (b *backend) BackupCustomVolume(projectName string, volName string, writer 
 
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
-	err = b.driver.BackupVolume(vol, writer, basePrefix, optimized, snapNames, op)
-	if err != nil {
-		return err
+	if volume.Config["block.type"] == drivers.BlockVolumeTypeQcow2 {
+		err = b.qcow2BackupVolume(vol, volume, projectName, writer, basePrefix, snapNames, op)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = b.driver.BackupVolume(vol, writer, basePrefix, optimized, snapNames, op)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -7764,9 +7788,18 @@ func (b *backend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData io
 	}
 
 	// Unpack the backup into the new storage volume(s).
-	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(vol, srcBackup, srcData, basePrefix, op)
-	if err != nil {
-		return err
+	var volPostHook drivers.VolumePostHook
+	var revertHook revert.Hook
+	if srcBackup.Config.Volume.Config["block.type"] == drivers.BlockVolumeTypeQcow2 {
+		volPostHook, revertHook, err = b.qcow2UnpackVolume(vol, srcBackup.Snapshots, srcData, basePrefix, op)
+		if err != nil {
+			return err
+		}
+	} else {
+		volPostHook, revertHook, err = b.driver.CreateVolumeFromBackup(vol, srcBackup, srcData, basePrefix, op)
+		if err != nil {
+			return err
+		}
 	}
 
 	if revertHook != nil {
@@ -8971,6 +9004,313 @@ func (b *backend) qcow2CreateVolumeFromMigration(vol drivers.Volume, projectName
 
 	reverter.Success()
 	return nil
+}
+
+func (b *backend) qcow2BackupVolume(vol drivers.Volume, dbVol *db.StorageVolume, projectName string, writer instancewriter.InstanceWriter, basePrefix string, snapshots []string, op *operations.Operation) error {
+	if len(snapshots) > 0 {
+		// Check requested snapshot match those in storage.
+		err := vol.SnapshotsMatch(snapshots, op)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Convert the volume type name to our internal integer representation.
+	volumeDBType, err := VolumeTypeNameToDBType(dbVol.Type)
+	if err != nil {
+		return err
+	}
+
+	inst, deviceName, err := InstanceByVolumeName(b.state, b.name, projectName, vol.Name(), volumeDBType)
+	if err != nil {
+		return err
+	}
+
+	getDiskPath := func(v drivers.Volume, blockIndex int) (string, func(), error) {
+		blockPath, err := b.driver.GetVolumeDiskPath(v)
+		if err != nil {
+			errMsg := "Error getting VM block volume disk path"
+			if v.Type() == drivers.VolumeTypeCustom {
+				errMsg = "Error getting custom block volume disk path"
+			}
+
+			return "", nil, fmt.Errorf(errMsg+": %w", err)
+		}
+
+		if inst != nil && inst.IsRunning() {
+			cleanupExport, path, err := inst.ExportQcow2Block(deviceName, blockIndex)
+			if err != nil {
+				return "", nil, err
+			}
+
+			nbdPath, err := drivers.ConnectQemuNbd(path, "", "", true)
+			if err != nil {
+				return "", nil, err
+			}
+
+			cleanup := func() {
+				_ = drivers.DisconnectQemuNbd(nbdPath)
+				cleanupExport()
+			}
+
+			return nbdPath, cleanup, nil
+		}
+
+		nbdPath, err := drivers.ConnectQemuNbd(blockPath, "qcow2", "", true)
+		if err != nil {
+			return "", nil, err
+		}
+
+		cleanup := func() {
+			_ = drivers.DisconnectQemuNbd(nbdPath)
+		}
+
+		return nbdPath, cleanup, nil
+	}
+
+	blockIndex := 0
+	// Handle snapshots.
+	if len(snapshots) > 0 {
+		for _, snapName := range snapshots {
+			prefix := filepath.Join(basePrefix, drivers.BackupSnapshotPrefix(vol), snapName)
+			snapVol, err := vol.NewSnapshot(snapName)
+			if err != nil {
+				return err
+			}
+
+			err = vol.MountWithSnapshotsTask(func(parentMountPath string, snapsMountPath map[string]string, op *operations.Operation) error {
+				mountPath := snapsMountPath[snapVol.Name()]
+				diskPath, cleanup, err := getDiskPath(snapVol, blockIndex)
+				if err != nil {
+					return err
+				}
+
+				err = drivers.BackupVolume(b.driver, snapVol, writer, mountPath, diskPath, prefix)
+				if err != nil {
+					cleanup()
+					return err
+				}
+
+				cleanup()
+
+				return nil
+			}, op)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Copy the main volume itself.
+	err = vol.MountWithSnapshotsTask(func(mountPath string, _ map[string]string, op *operations.Operation) error {
+		diskPath, cleanup, err := getDiskPath(vol, blockIndex)
+		if err != nil {
+			return err
+		}
+
+		err = drivers.BackupVolume(b.driver, vol, writer, mountPath, diskPath, filepath.Join(basePrefix, drivers.BackupPrefix(vol)))
+		if err != nil {
+			cleanup()
+			return err
+		}
+
+		cleanup()
+		return nil
+	}, op)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *backend) qcow2UnpackVolume(vol drivers.Volume, snapshots []string, srcData io.ReadSeeker, basePrefix string, op *operations.Operation) (drivers.VolumePostHook, revert.Hook, error) {
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	// Find the compression algorithm used for backup source data.
+	_, err := srcData.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tarArgs, _, unpacker, err := archive.DetectCompressionFile(srcData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	volExists, err := b.driver.HasVolume(vol)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if volExists {
+		return nil, nil, errors.New("Cannot restore volume, already exists on target")
+	}
+
+	// Create new empty volume.
+	err = b.driver.CreateVolume(vol, nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	reverter.Add(func() { _ = b.driver.DeleteVolume(vol, op) })
+
+	getDiskPath := func(v drivers.Volume) (string, func(), error) {
+		blockPath, err := b.driver.GetVolumeDiskPath(v)
+		if err != nil {
+			errMsg := "Error getting VM block volume disk path"
+			if v.Type() == drivers.VolumeTypeCustom {
+				errMsg = "Error getting custom block volume disk path"
+			}
+
+			return "", nil, fmt.Errorf(errMsg+": %w", err)
+		}
+
+		nbdPath, err := drivers.ConnectQemuNbd(blockPath, "qcow2", "unmap", false)
+		if err != nil {
+			return "", nil, err
+		}
+
+		cleanup := func() {
+			_ = drivers.DisconnectQemuNbd(nbdPath)
+		}
+
+		return nbdPath, cleanup, nil
+	}
+
+	if len(snapshots) > 0 {
+		// Create new snapshots directory.
+		err := drivers.CreateParentSnapshotDirIfMissing(b.driver.Name(), vol.Type(), vol.Name())
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	for _, snapName := range snapshots {
+		err = vol.MountWithSnapshotsTask(func(mountPath string, _ map[string]string, op *operations.Operation) error {
+			backupSnapshotPrefix := filepath.Join(basePrefix, drivers.BackupSnapshotPrefix(vol), snapName)
+			diskPath, cleanup, err := getDiskPath(vol)
+			if err != nil {
+				return err
+			}
+
+			err = drivers.UnpackVolume(b.driver, vol, srcData, tarArgs, unpacker, backupSnapshotPrefix, mountPath, diskPath)
+			if err != nil {
+				cleanup()
+				return err
+			}
+
+			cleanup()
+			return nil
+		}, op)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		snapVol, err := vol.NewSnapshot(snapName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		b.logger.Debug("Creating volume snapshot", logger.Ctx{"snapshotName": snapVol.Name()})
+		err = b.driver.CreateVolumeSnapshot(snapVol, op)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		err = b.qcow2CreateSnapshot(vol, snapVol, "", nil, "", false, op)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		reverter.Add(func() { _ = b.driver.DeleteVolumeSnapshot(snapVol, op) })
+	}
+
+	err = b.driver.MountVolume(vol, op)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	reverter.Add(func() { _, _ = b.driver.UnmountVolume(vol, false, op) })
+
+	for _, snapName := range snapshots {
+		snapVol, err := vol.NewSnapshot(snapName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		err = b.driver.MountVolumeSnapshot(snapVol, op)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	reverter.Add(func() {
+		for _, snapName := range snapshots {
+			snapVol, _ := vol.NewSnapshot(snapName)
+			_, _ = b.driver.UnmountVolumeSnapshot(snapVol, op)
+		}
+	})
+
+	mountPath := vol.MountPath()
+	diskPath, cleanupNBD, err := getDiskPath(vol)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = drivers.UnpackVolume(b.driver, vol, srcData, tarArgs, unpacker, filepath.Join(basePrefix, drivers.BackupPrefix(vol)), mountPath, diskPath)
+	if err != nil {
+		cleanupNBD()
+		return nil, nil, err
+	}
+
+	cleanupNBD()
+
+	// Run EnsureMountPath after mounting and unpacking to ensure the mounted directory has the
+	// correct permissions set.
+	err = vol.EnsureMountPath(false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cleanup := reverter.Clone().Fail // Clone before calling reverter.Success() so we can return the Fail func.
+	reverter.Success()
+
+	var postHook drivers.VolumePostHook
+	if vol.Type() != drivers.VolumeTypeCustom {
+		// Leave volume mounted (as is needed during backup.yaml generation during latter parts of the
+		// backup restoration process). Create a post hook function that will be called at the end of the
+		// backup restore process to unmount the volume if needed.
+		postHook = func(vol drivers.Volume) error {
+			for _, snapName := range snapshots {
+				snapVol, err := vol.NewSnapshot(snapName)
+				if err != nil {
+					return err
+				}
+
+				_, err = b.driver.UnmountVolumeSnapshot(snapVol, op)
+				if err != nil {
+					return err
+				}
+			}
+
+			_, err = b.driver.UnmountVolume(vol, false, op)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	} else {
+		// For custom volumes unmount now, there is no post hook as there is no backup.yaml to generate.
+		_, err = b.driver.UnmountVolume(vol, false, op)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return postHook, cleanup, nil
 }
 
 // volumeUsedByRunningInstance returns the name of the running instance and the

--- a/internal/server/storage/drivers/driver_btrfs_volumes.go
+++ b/internal/server/storage/drivers/driver_btrfs_volumes.go
@@ -324,7 +324,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcDat
 
 	if len(srcBackup.Snapshots) > 0 {
 		// Create new snapshots directory.
-		err := createParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
+		err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -471,7 +471,7 @@ func (d *btrfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bo
 	// Copy any snapshots needed.
 	if len(snapshots) > 0 {
 		// Create the parent directory.
-		err = createParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
+		err = CreateParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
 		if err != nil {
 			return err
 		}
@@ -694,7 +694,7 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 	// Handle btrfs send/receive migration.
 	if !volTargetArgs.VolumeOnly && len(volTargetArgs.Snapshots) > 0 {
 		// Create the parent directory.
-		err := createParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
+		err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
 		if err != nil {
 			return err
 		}
@@ -1884,7 +1884,7 @@ func (d *btrfs) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) e
 	snapPath := snapVol.MountPath()
 
 	// Create the parent directory.
-	err := createParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
+	err := CreateParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/drivers/driver_ceph_volumes.go
+++ b/internal/server/storage/drivers/driver_ceph_volumes.go
@@ -474,7 +474,7 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 	lastSnap := ""
 
 	if len(snapshots) > 0 {
-		err := createParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
+		err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
 		if err != nil {
 			return err
 		}
@@ -579,7 +579,7 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 	// Handle rbd migration.
 	if len(volTargetArgs.Snapshots) > 0 {
 		// Create the parent directory.
-		err := createParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
+		err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
 		if err != nil {
 			return err
 		}
@@ -1599,7 +1599,7 @@ func (d *ceph) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 	}
 
 	// Create the parent directory.
-	err := createParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
+	err := CreateParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/drivers/driver_cephfs_volumes.go
+++ b/internal/server/storage/drivers/driver_cephfs_volumes.go
@@ -471,7 +471,7 @@ func (d *cephfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Ope
 // RenameVolume renames the volume and all related filesystem entries.
 func (d *cephfs) RenameVolume(vol Volume, newVolName string, op *operations.Operation) error {
 	// Create the parent directory.
-	err := createParentSnapshotDirIfMissing(d.name, vol.volType, newVolName)
+	err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, newVolName)
 	if err != nil {
 		return err
 	}
@@ -588,7 +588,7 @@ func (d *cephfs) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) 
 	}
 
 	// Create the parent directory.
-	err = createParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
+	err = CreateParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/drivers/driver_linstor_volumes.go
+++ b/internal/server/storage/drivers/driver_linstor_volumes.go
@@ -831,7 +831,7 @@ func (d *linstor) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation)
 	}
 
 	// Create the parent directory.
-	err := createParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
+	err := CreateParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/drivers/driver_lvm_utils.go
+++ b/internal/server/storage/drivers/driver_lvm_utils.go
@@ -701,7 +701,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 	// If copying snapshots is indicated, check the source isn't itself a snapshot.
 	if len(srcSnapshots) > 0 && !srcVol.IsSnapshot() {
 		// Create the parent snapshot directory.
-		err := createParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
+		err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
 		if err != nil {
 			return err
 		}

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -1334,7 +1334,7 @@ func (d *lvm) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	}
 
 	// Create the parent directory.
-	err := createParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
+	err := CreateParentSnapshotDirIfMissing(d.name, snapVol.volType, parentName)
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/drivers/driver_truenas_volumes.go
+++ b/internal/server/storage/drivers/driver_truenas_volumes.go
@@ -1641,7 +1641,7 @@ func (d *truenas) CreateVolumeSnapshot(vol Volume, op *operations.Operation) err
 	defer reverter.Fail()
 
 	// Create the parent directory.
-	err := createParentSnapshotDirIfMissing(d.name, vol.volType, parentName)
+	err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, parentName)
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -463,7 +463,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 
 		if len(srcBackup.Snapshots) > 0 {
 			// Create new snapshots directory.
-			err := createParentSnapshotDirIfMissing(d.name, v.volType, v.name)
+			err := CreateParentSnapshotDirIfMissing(d.name, v.volType, v.name)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1100,7 +1100,7 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 	// Handle zfs send/receive migration.
 	if len(volTargetArgs.Snapshots) > 0 {
 		// Create the parent directory.
-		err := createParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
+		err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, vol.name)
 		if err != nil {
 			return err
 		}
@@ -3095,7 +3095,7 @@ func (d *zfs) CreateVolumeSnapshot(vol Volume, op *operations.Operation) error {
 	defer reverter.Fail()
 
 	// Create the parent directory.
-	err := createParentSnapshotDirIfMissing(d.name, vol.volType, parentName)
+	err := CreateParentSnapshotDirIfMissing(d.name, vol.volType, parentName)
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -528,6 +528,24 @@ func genericVFSBackupVolume(d Driver, vol Volume, writer instancewriter.Instance
 		}
 	}
 
+	getDiskPath := func(v Volume) (string, error) {
+		if v.contentType != ContentTypeBlock && v.contentType != ContentTypeISO {
+			return "", nil
+		}
+
+		blockPath, err := d.GetVolumeDiskPath(v)
+		if err != nil {
+			errMsg := "Error getting VM block volume disk path"
+			if v.Type() == VolumeTypeCustom {
+				errMsg = "Error getting custom block volume disk path"
+			}
+
+			return "", fmt.Errorf(errMsg+": %w", err)
+		}
+
+		return blockPath, nil
+	}
+
 	// Handle snapshots.
 	if len(snapshots) > 0 {
 		for _, snapName := range snapshots {
@@ -538,7 +556,12 @@ func genericVFSBackupVolume(d Driver, vol Volume, writer instancewriter.Instance
 			}
 
 			err = snapVol.MountTask(func(mountPath string, op *operations.Operation) error {
-				err := BackupVolume(d, snapVol, writer, mountPath, prefix)
+				diskPath, err := getDiskPath(snapVol)
+				if err != nil {
+					return err
+				}
+
+				err = BackupVolume(d, snapVol, writer, mountPath, diskPath, prefix)
 				if err != nil {
 					return err
 				}
@@ -553,7 +576,12 @@ func genericVFSBackupVolume(d Driver, vol Volume, writer instancewriter.Instance
 
 	// Copy the main volume itself.
 	err := vol.MountTask(func(mountPath string, op *operations.Operation) error {
-		err := BackupVolume(d, vol, writer, mountPath, filepath.Join(basePrefix, BackupPrefix(vol)))
+		diskPath, err := getDiskPath(vol)
+		if err != nil {
+			return err
+		}
+
+		err = BackupVolume(d, vol, writer, mountPath, diskPath, filepath.Join(basePrefix, BackupPrefix(vol)))
 		if err != nil {
 			return err
 		}
@@ -604,6 +632,24 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 
 	reverter.Add(func() { _ = d.DeleteVolume(vol, op) })
 
+	getDiskPath := func(v Volume) (string, error) {
+		if v.contentType != ContentTypeBlock && v.contentType != ContentTypeISO {
+			return "", nil
+		}
+
+		blockPath, err := d.GetVolumeDiskPath(v)
+		if err != nil {
+			errMsg := "Error getting VM block volume disk path"
+			if v.Type() == VolumeTypeCustom {
+				errMsg = "Error getting custom block volume disk path"
+			}
+
+			return "", fmt.Errorf(errMsg+": %w", err)
+		}
+
+		return blockPath, nil
+	}
+
 	if len(snapshots) > 0 {
 		// Create new snapshots directory.
 		err := CreateParentSnapshotDirIfMissing(d.Name(), vol.volType, vol.name)
@@ -615,7 +661,12 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 	for _, snapName := range snapshots {
 		err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
 			backupSnapshotPrefix := filepath.Join(basePrefix, BackupSnapshotPrefix(vol), snapName)
-			return UnpackVolume(d, vol, srcData, tarArgs, unpacker, backupSnapshotPrefix, mountPath)
+			diskPath, err := getDiskPath(vol)
+			if err != nil {
+				return err
+			}
+
+			return UnpackVolume(d, vol, srcData, tarArgs, unpacker, backupSnapshotPrefix, mountPath, diskPath)
 		}, op)
 		if err != nil {
 			return nil, nil, err
@@ -652,7 +703,12 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 	reverter.Add(func() { _, _ = d.UnmountVolume(vol, false, op) })
 
 	mountPath := vol.MountPath()
-	err = UnpackVolume(d, vol, srcData, tarArgs, unpacker, filepath.Join(basePrefix, BackupPrefix(vol)), mountPath)
+	diskPath, err := getDiskPath(vol)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = UnpackVolume(d, vol, srcData, tarArgs, unpacker, filepath.Join(basePrefix, BackupPrefix(vol)), mountPath, diskPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -1,16 +1,13 @@
 package drivers
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/lxc/incus/v6/internal/instancewriter"
 	"github.com/lxc/incus/v6/internal/linux"
@@ -531,164 +528,23 @@ func genericVFSBackupVolume(d Driver, vol Volume, writer instancewriter.Instance
 		}
 	}
 
-	// Define a function that can copy a volume into the backup target location.
-	backupVolume := func(v Volume, prefix string) error {
-		return v.MountTask(func(mountPath string, op *operations.Operation) error {
-			// Reset hard link cache as we are copying a new volume (instance or snapshot).
-			writer.ResetHardLinkMap()
-
-			if v.contentType == ContentTypeBlock || v.contentType == ContentTypeISO {
-				blockPath, err := d.GetVolumeDiskPath(v)
-				if err != nil {
-					errMsg := "Error getting VM block volume disk path"
-					if vol.volType == VolumeTypeCustom {
-						errMsg = "Error getting custom block volume disk path"
-					}
-
-					return fmt.Errorf(errMsg+": %w", err)
-				}
-
-				// Get size of disk block device for tarball header.
-				blockDiskSize, err := BlockDiskSizeBytes(blockPath)
-				if err != nil {
-					return fmt.Errorf("Error getting block device size %q: %w", blockPath, err)
-				}
-
-				var exclude []string // Files to exclude from filesystem volume backup.
-				if !linux.IsBlockdevPath(blockPath) {
-					// Exclude the volume root disk file from the filesystem volume backup.
-					// We will read it as a block device later instead.
-					exclude = append(exclude, blockPath)
-				}
-
-				if v.IsVMBlock() {
-					logMsg := "Copying virtual machine config volume"
-
-					d.Logger().Debug(logMsg, logger.Ctx{"sourcePath": mountPath, "prefix": prefix})
-					err = filepath.Walk(mountPath, func(srcPath string, fi os.FileInfo, err error) error {
-						if err != nil {
-							return err
-						}
-
-						// Skip any excluded files.
-						if util.StringHasPrefix(srcPath, exclude...) {
-							return nil
-						}
-
-						name := filepath.Join(prefix, strings.TrimPrefix(srcPath, mountPath))
-						err = writer.WriteFile(name, srcPath, fi, false)
-						if err != nil {
-							return fmt.Errorf("Error adding %q as %q to tarball: %w", srcPath, name, err)
-						}
-
-						return nil
-					})
-					if err != nil {
-						return err
-					}
-				}
-
-				name := fmt.Sprintf("%s.%s", prefix, genericVolumeBlockExtension)
-
-				logMsg := "Copying virtual machine block volume"
-				if vol.volType == VolumeTypeCustom {
-					logMsg = "Copying custom block volume"
-				}
-
-				d.Logger().Debug(logMsg, logger.Ctx{"sourcePath": blockPath, "file": name, "size": blockDiskSize})
-				from, err := os.Open(blockPath)
-				if err != nil {
-					return fmt.Errorf("Error opening file for reading %q: %w", blockPath, err)
-				}
-
-				defer func() { _ = from.Close() }()
-
-				var fileSize int64
-				fileSize, err = strconv.ParseInt(vol.config["size"], 10, 64)
-				if err != nil {
-					fileSize = blockDiskSize
-				}
-
-				fi := instancewriter.FileInfo{
-					FileName:    name,
-					FileSize:    fileSize,
-					FileMode:    0o600,
-					FileModTime: time.Now(),
-				}
-
-				err = writer.WriteFileFromReader(from, &fi)
-				if err != nil {
-					return fmt.Errorf("Error copying %q as %q to tarball: %w", blockPath, name, err)
-				}
-
-				err = from.Close()
-				if err != nil {
-					return fmt.Errorf("Failed to close file %q: %w", blockPath, err)
-				}
-
-				return nil
-			}
-
-			logMsg := "Copying container filesystem volume"
-			if vol.volType == VolumeTypeCustom {
-				logMsg = "Copying custom filesystem volume"
-			}
-
-			d.Logger().Debug(logMsg, logger.Ctx{"sourcePath": mountPath, "prefix": prefix})
-
-			// Follow the target if mountPath is a symlink.
-			// Functions like filepath.Walk() won't list any directory content otherwise.
-			target, err := os.Readlink(mountPath)
-			if err == nil {
-				// Make sure the target is valid before return it.
-				_, err = os.Stat(target)
-				if err == nil {
-					mountPath = target
-				}
-			}
-
-			return filepath.Walk(mountPath, func(srcPath string, fi os.FileInfo, err error) error {
-				if err != nil {
-					if errors.Is(err, fs.ErrNotExist) {
-						logger.Warnf("File vanished during export: %q, skipping", srcPath)
-						return nil
-					}
-
-					return fmt.Errorf("Error walking file during export: %q: %w", srcPath, err)
-				}
-
-				name := filepath.Join(prefix, strings.TrimPrefix(srcPath, mountPath))
-
-				// Write the file to the tarball with ignoreGrowth enabled so that if the
-				// source file grows during copy we only copy up to the original size.
-				// This means that the file in the tarball may be inconsistent.
-				err = writer.WriteFile(name, srcPath, fi, true)
-				if err != nil {
-					return fmt.Errorf("Error adding %q as %q to tarball: %w", srcPath, name, err)
-				}
-
-				return nil
-			})
-		}, op)
-	}
-
 	// Handle snapshots.
 	if len(snapshots) > 0 {
-		snapshotsPrefix := "snapshots"
-		if vol.IsVMBlock() {
-			snapshotsPrefix = "virtual-machine-snapshots"
-		} else if vol.volType == VolumeTypeCustom {
-			snapshotsPrefix = "volume-snapshots"
-		}
-
 		for _, snapName := range snapshots {
-			prefix := filepath.Join(basePrefix, snapshotsPrefix, snapName)
+			prefix := filepath.Join(basePrefix, BackupSnapshotPrefix(vol), snapName)
 			snapVol, err := vol.NewSnapshot(snapName)
 			if err != nil {
 				return err
 			}
 
-			err = backupVolume(snapVol, prefix)
+			err = snapVol.MountTask(func(mountPath string, op *operations.Operation) error {
+				err := BackupVolume(d, snapVol, writer, mountPath, prefix)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}, op)
 			if err != nil {
 				return err
 			}
@@ -696,14 +552,14 @@ func genericVFSBackupVolume(d Driver, vol Volume, writer instancewriter.Instance
 	}
 
 	// Copy the main volume itself.
-	prefix := "container"
-	if vol.IsVMBlock() {
-		prefix = "virtual-machine"
-	} else if vol.volType == VolumeTypeCustom {
-		prefix = "volume"
-	}
+	err := vol.MountTask(func(mountPath string, op *operations.Operation) error {
+		err := BackupVolume(d, vol, writer, mountPath, filepath.Join(basePrefix, BackupPrefix(vol)))
+		if err != nil {
+			return err
+		}
 
-	err := backupVolume(vol, filepath.Join(basePrefix, prefix))
+		return nil
+	}, op)
 	if err != nil {
 		return err
 	}
@@ -717,159 +573,6 @@ func genericVFSBackupVolume(d Driver, vol Volume, writer instancewriter.Instance
 // subsequently fail. For VolumeTypeCustom volumes, a nil post hook is returned as it is expected that the DB
 // record be created before the volume is unpacked due to differences in the archive format that allows this.
 func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []string, srcData io.ReadSeeker, basePrefix string, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	// Define function to unpack a volume from a backup tarball file.
-	unpackVolume := func(r io.ReadSeeker, tarArgs []string, unpacker []string, srcPrefix string, mountPath string) error {
-		volTypeName := "container"
-		if vol.IsVMBlock() {
-			volTypeName = "virtual machine"
-		} else if vol.volType == VolumeTypeCustom {
-			volTypeName = "custom"
-		}
-
-		// Clear the volume ready for unpack.
-		err := wipeDirectory(mountPath)
-		if err != nil {
-			return fmt.Errorf("Error clearing volume before unpack: %w", err)
-		}
-
-		// Unpack the filesystem parts of the volume (for containers and custom filesystem volumes that is
-		// the respective root filesystem data or volume itself, and for VMs that is the config volume).
-		// Custom block volumes do not have a filesystem component to their volumes.
-		if !vol.IsCustomBlock() {
-			// Prepare tar arguments.
-			srcParts := strings.Split(srcPrefix, string(os.PathSeparator))
-			args := append(tarArgs, []string{
-				"-",
-				"--xattrs-include=*",
-				"--restrict",
-				"--force-local",
-				"--numeric-owner",
-				"-C", mountPath,
-			}...)
-
-			if vol.Type() == VolumeTypeCustom {
-				// If the volume type is custom, then we need to ensure that we restore the top level
-				// directory's ownership from the backup. We cannot use --strip-components flag because it
-				// removes the top level directory from the unpack list. Instead we use the --transform
-				// flag to remove the prefix path and transform it into the "." current unpack directory.
-				args = append(args, fmt.Sprintf("--transform=s/^%s/./", strings.ReplaceAll(srcPrefix, "/", `\/`)))
-			} else {
-				// For instance volumes, the user created files are stored in the rootfs sub-directory
-				// and so strip-components flag works fine.
-				args = append(args, fmt.Sprintf("--strip-components=%d", len(srcParts)))
-			}
-
-			// Directory to unpack comes after other options.
-			args = append(args, srcPrefix)
-
-			// Extract filesystem volume.
-			d.Logger().Debug(fmt.Sprintf("Unpacking %s filesystem volume", volTypeName), logger.Ctx{"source": srcPrefix, "target": mountPath, "args": fmt.Sprintf("%+v", args)})
-			_, err := srcData.Seek(0, io.SeekStart)
-			if err != nil {
-				return err
-			}
-
-			f, err := os.OpenFile(mountPath, os.O_RDONLY, 0)
-			if err != nil {
-				return fmt.Errorf("Error opening directory: %w", err)
-			}
-
-			defer func() { _ = f.Close() }()
-
-			allowedCmds := []string{}
-			if len(unpacker) > 0 {
-				allowedCmds = append(allowedCmds, unpacker[0])
-			}
-
-			err = archive.ExtractWithFds("tar", args, allowedCmds, io.NopCloser(r), f)
-			if err != nil {
-				return fmt.Errorf("Error starting unpack: %w", err)
-			}
-		}
-
-		// Extract block file to block volume.
-		if vol.contentType == ContentTypeBlock {
-			targetPath, err := d.GetVolumeDiskPath(vol)
-			if err != nil {
-				return err
-			}
-
-			srcFile := fmt.Sprintf("%s.%s", srcPrefix, genericVolumeBlockExtension)
-
-			tr, cancelFunc, err := archive.CompressedTarReader(context.Background(), r, unpacker, mountPath)
-			if err != nil {
-				return err
-			}
-
-			defer cancelFunc()
-
-			for {
-				hdr, err := tr.Next()
-				if err == io.EOF {
-					break // End of archive.
-				}
-
-				if err != nil {
-					return err
-				}
-
-				if hdr.Name == srcFile {
-					var allowUnsafeResize bool
-
-					// Reset the disk.
-					err = linux.ClearBlock(targetPath, 0)
-					if err != nil {
-						return err
-					}
-
-					// Open block file (use O_CREATE to support drivers that use image files).
-					to, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o644)
-					if err != nil {
-						return fmt.Errorf("Error opening file for writing %q: %w", targetPath, err)
-					}
-
-					defer func() { _ = to.Close() }()
-
-					// Restore original size of volume from raw block backup file size.
-					d.Logger().Debug("Setting volume size from source", logger.Ctx{"source": srcFile, "target": targetPath, "size": hdr.Size})
-
-					// Allow potentially destructive resize of volume as we are going to be
-					// overwriting it entirely anyway. This allows shrinking of block volumes.
-					allowUnsafeResize = true
-					err = d.SetVolumeQuota(vol, fmt.Sprintf("%d", hdr.Size), allowUnsafeResize, op)
-					if err != nil {
-						return err
-					}
-
-					logMsg := "Unpacking virtual machine block volume"
-					if vol.volType == VolumeTypeCustom {
-						logMsg = "Unpacking custom block volume"
-					}
-
-					// Copy the data.
-					toPipe := io.Writer(to)
-					if !d.Info().ZeroUnpack {
-						toPipe = NewSparseFileWrapper(to)
-					}
-
-					d.Logger().Debug(logMsg, logger.Ctx{"source": srcFile, "target": targetPath})
-
-					_, err = util.SafeCopy(toPipe, tr)
-					if err != nil {
-						return err
-					}
-
-					cancelFunc()
-					return to.Close()
-				}
-			}
-
-			return fmt.Errorf("Could not find %q", srcFile)
-		}
-
-		return nil
-	}
-
 	reverter := revert.New()
 	defer reverter.Fail()
 
@@ -909,17 +612,10 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 		}
 	}
 
-	backupSnapshotsPrefix := "snapshots"
-	if vol.IsVMBlock() {
-		backupSnapshotsPrefix = "virtual-machine-snapshots"
-	} else if vol.volType == VolumeTypeCustom {
-		backupSnapshotsPrefix = "volume-snapshots"
-	}
-
 	for _, snapName := range snapshots {
 		err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
-			backupSnapshotPrefix := filepath.Join(basePrefix, backupSnapshotsPrefix, snapName)
-			return unpackVolume(srcData, tarArgs, unpacker, backupSnapshotPrefix, mountPath)
+			backupSnapshotPrefix := filepath.Join(basePrefix, BackupSnapshotPrefix(vol), snapName)
+			return UnpackVolume(d, vol, srcData, tarArgs, unpacker, backupSnapshotPrefix, mountPath)
 		}, op)
 		if err != nil {
 			return nil, nil, err
@@ -955,15 +651,8 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 
 	reverter.Add(func() { _, _ = d.UnmountVolume(vol, false, op) })
 
-	backupPrefix := "container"
-	if vol.IsVMBlock() {
-		backupPrefix = "virtual-machine"
-	} else if vol.volType == VolumeTypeCustom {
-		backupPrefix = "volume"
-	}
-
 	mountPath := vol.MountPath()
-	err = unpackVolume(srcData, tarArgs, unpacker, filepath.Join(basePrefix, backupPrefix), mountPath)
+	err = UnpackVolume(d, vol, srcData, tarArgs, unpacker, filepath.Join(basePrefix, BackupPrefix(vol)), mountPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -606,7 +606,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 
 	if len(snapshots) > 0 {
 		// Create new snapshots directory.
-		err := createParentSnapshotDirIfMissing(d.Name(), vol.volType, vol.name)
+		err := CreateParentSnapshotDirIfMissing(d.Name(), vol.volType, vol.name)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -272,8 +272,8 @@ func GetSnapshotVolumeName(parentName, snapshotName string) string {
 	return fmt.Sprintf("%s%s%s", parentName, internalInstance.SnapshotDelimiter, snapshotName)
 }
 
-// createParentSnapshotDirIfMissing creates the parent directory for volume snapshots.
-func createParentSnapshotDirIfMissing(poolName string, volType VolumeType, volName string) error {
+// CreateParentSnapshotDirIfMissing creates the parent directory for volume snapshots.
+func CreateParentSnapshotDirIfMissing(poolName string, volType VolumeType, volName string) error {
 	snapshotsPath := GetVolumeSnapshotDir(poolName, volType, volName)
 
 	// If it's missing, create it.

--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -1047,21 +1047,11 @@ func BackupSnapshotPrefix(vol Volume) string {
 }
 
 // BackupVolume copy a volume into the backup target location.
-func BackupVolume(d Driver, v Volume, writer instancewriter.InstanceWriter, mountPath string, prefix string) error {
+func BackupVolume(d Driver, v Volume, writer instancewriter.InstanceWriter, mountPath string, blockPath string, prefix string) error {
 	// Reset hard link cache as we are copying a new volume (instance or snapshot).
 	writer.ResetHardLinkMap()
 
 	if v.contentType == ContentTypeBlock || v.contentType == ContentTypeISO {
-		blockPath, err := d.GetVolumeDiskPath(v)
-		if err != nil {
-			errMsg := "Error getting VM block volume disk path"
-			if v.volType == VolumeTypeCustom {
-				errMsg = "Error getting custom block volume disk path"
-			}
-
-			return fmt.Errorf(errMsg+": %w", err)
-		}
-
 		// Get size of disk block device for tarball header.
 		blockDiskSize, err := BlockDiskSizeBytes(blockPath)
 		if err != nil {
@@ -1186,7 +1176,7 @@ func BackupVolume(d Driver, v Volume, writer instancewriter.InstanceWriter, moun
 }
 
 // UnpackVolume unpack a volume from a backup tarball file.
-func UnpackVolume(d Driver, vol Volume, r io.ReadSeeker, tarArgs []string, unpacker []string, srcPrefix string, mountPath string) error {
+func UnpackVolume(d Driver, vol Volume, r io.ReadSeeker, tarArgs []string, unpacker []string, srcPrefix string, mountPath string, targetPath string) error {
 	volTypeName := "container"
 	if vol.IsVMBlock() {
 		volTypeName = "virtual machine"
@@ -1257,11 +1247,6 @@ func UnpackVolume(d Driver, vol Volume, r io.ReadSeeker, tarArgs []string, unpac
 
 	// Extract block file to block volume.
 	if vol.contentType == ContentTypeBlock {
-		targetPath, err := d.GetVolumeDiskPath(vol)
-		if err != nil {
-			return err
-		}
-
 		srcFile := fmt.Sprintf("%s.%s", srcPrefix, genericVolumeBlockExtension)
 
 		tr, cancelFunc, err := archive.CompressedTarReader(context.Background(), r, unpacker, mountPath)

--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -1,6 +1,8 @@
 package drivers
 
 import (
+	"archive/tar"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unsafe"
@@ -17,10 +20,12 @@ import (
 	"golang.org/x/sys/unix"
 
 	internalInstance "github.com/lxc/incus/v6/internal/instance"
+	"github.com/lxc/incus/v6/internal/instancewriter"
 	"github.com/lxc/incus/v6/internal/linux"
 	"github.com/lxc/incus/v6/internal/server/operations"
 	internalUtil "github.com/lxc/incus/v6/internal/util"
 	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/archive"
 	"github.com/lxc/incus/v6/shared/idmap"
 	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/subprocess"
@@ -1012,6 +1017,326 @@ func ValidateDependentConfigKey(cfg map[string]string) error {
 		}
 
 		return fmt.Errorf("Dependent disk may not have a %q config", k)
+	}
+
+	return nil
+}
+
+// BackupPrefix returns backup prefix based on volume type.
+func BackupPrefix(vol Volume) string {
+	backupPrefix := "container"
+	if vol.IsVMBlock() {
+		backupPrefix = "virtual-machine"
+	} else if vol.volType == VolumeTypeCustom {
+		backupPrefix = "volume"
+	}
+
+	return backupPrefix
+}
+
+// BackupSnapshotPrefix returns backup snapshot prefix based on volume type.
+func BackupSnapshotPrefix(vol Volume) string {
+	backupSnapshotsPrefix := "snapshots"
+	if vol.IsVMBlock() {
+		backupSnapshotsPrefix = "virtual-machine-snapshots"
+	} else if vol.volType == VolumeTypeCustom {
+		backupSnapshotsPrefix = "volume-snapshots"
+	}
+
+	return backupSnapshotsPrefix
+}
+
+// BackupVolume copy a volume into the backup target location.
+func BackupVolume(d Driver, v Volume, writer instancewriter.InstanceWriter, mountPath string, prefix string) error {
+	// Reset hard link cache as we are copying a new volume (instance or snapshot).
+	writer.ResetHardLinkMap()
+
+	if v.contentType == ContentTypeBlock || v.contentType == ContentTypeISO {
+		blockPath, err := d.GetVolumeDiskPath(v)
+		if err != nil {
+			errMsg := "Error getting VM block volume disk path"
+			if v.volType == VolumeTypeCustom {
+				errMsg = "Error getting custom block volume disk path"
+			}
+
+			return fmt.Errorf(errMsg+": %w", err)
+		}
+
+		// Get size of disk block device for tarball header.
+		blockDiskSize, err := BlockDiskSizeBytes(blockPath)
+		if err != nil {
+			return fmt.Errorf("Error getting block device size %q: %w", blockPath, err)
+		}
+
+		var exclude []string // Files to exclude from filesystem volume backup.
+		if !linux.IsBlockdevPath(blockPath) {
+			// Exclude the volume root disk file from the filesystem volume backup.
+			// We will read it as a block device later instead.
+			exclude = append(exclude, blockPath)
+		}
+
+		if v.IsVMBlock() {
+			logMsg := "Copying virtual machine config volume"
+
+			d.Logger().Debug(logMsg, logger.Ctx{"sourcePath": mountPath, "prefix": prefix})
+			err = filepath.Walk(mountPath, func(srcPath string, fi os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				// Skip any excluded files.
+				if util.StringHasPrefix(srcPath, exclude...) {
+					return nil
+				}
+
+				name := filepath.Join(prefix, strings.TrimPrefix(srcPath, mountPath))
+				err = writer.WriteFile(name, srcPath, fi, false)
+				if err != nil {
+					return fmt.Errorf("Error adding %q as %q to tarball: %w", srcPath, name, err)
+				}
+
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		name := fmt.Sprintf("%s.%s", prefix, genericVolumeBlockExtension)
+
+		logMsg := "Copying virtual machine block volume"
+		if v.volType == VolumeTypeCustom {
+			logMsg = "Copying custom block volume"
+		}
+
+		d.Logger().Debug(logMsg, logger.Ctx{"sourcePath": blockPath, "file": name, "size": blockDiskSize})
+		from, err := os.Open(blockPath)
+		if err != nil {
+			return fmt.Errorf("Error opening file for reading %q: %w", blockPath, err)
+		}
+
+		defer func() { _ = from.Close() }()
+
+		var fileSize int64
+		fileSize, err = strconv.ParseInt(v.config["size"], 10, 64)
+		if err != nil {
+			fileSize = blockDiskSize
+		}
+
+		fi := instancewriter.FileInfo{
+			FileName:    name,
+			FileSize:    fileSize,
+			FileMode:    0o600,
+			FileModTime: time.Now(),
+		}
+
+		err = writer.WriteFileFromReader(from, &fi)
+		if err != nil {
+			return fmt.Errorf("Error copying %q as %q to tarball: %w", blockPath, name, err)
+		}
+
+		err = from.Close()
+		if err != nil {
+			return fmt.Errorf("Failed to close file %q: %w", blockPath, err)
+		}
+
+		return nil
+	}
+
+	logMsg := "Copying container filesystem volume"
+	if v.volType == VolumeTypeCustom {
+		logMsg = "Copying custom filesystem volume"
+	}
+
+	d.Logger().Debug(logMsg, logger.Ctx{"sourcePath": mountPath, "prefix": prefix})
+
+	// Follow the target if mountPath is a symlink.
+	// Functions like filepath.Walk() won't list any directory content otherwise.
+	target, err := os.Readlink(mountPath)
+	if err == nil {
+		// Make sure the target is valid before return it.
+		_, err = os.Stat(target)
+		if err == nil {
+			mountPath = target
+		}
+	}
+
+	return filepath.Walk(mountPath, func(srcPath string, fi os.FileInfo, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				logger.Warnf("File vanished during export: %q, skipping", srcPath)
+				return nil
+			}
+
+			return fmt.Errorf("Error walking file during export: %q: %w", srcPath, err)
+		}
+
+		name := filepath.Join(prefix, strings.TrimPrefix(srcPath, mountPath))
+
+		// Write the file to the tarball with ignoreGrowth enabled so that if the
+		// source file grows during copy we only copy up to the original size.
+		// This means that the file in the tarball may be inconsistent.
+		err = writer.WriteFile(name, srcPath, fi, true)
+		if err != nil {
+			return fmt.Errorf("Error adding %q as %q to tarball: %w", srcPath, name, err)
+		}
+
+		return nil
+	})
+}
+
+// UnpackVolume unpack a volume from a backup tarball file.
+func UnpackVolume(d Driver, vol Volume, r io.ReadSeeker, tarArgs []string, unpacker []string, srcPrefix string, mountPath string) error {
+	volTypeName := "container"
+	if vol.IsVMBlock() {
+		volTypeName = "virtual machine"
+	} else if vol.volType == VolumeTypeCustom {
+		volTypeName = "custom"
+	}
+
+	// Clear the volume ready for unpack.
+	err := wipeDirectory(mountPath)
+	if err != nil {
+		return fmt.Errorf("Error clearing volume before unpack: %w", err)
+	}
+
+	// Unpack the filesystem parts of the volume (for containers and custom filesystem volumes that is
+	// the respective root filesystem data or volume itself, and for VMs that is the config volume).
+	// Custom block volumes do not have a filesystem component to their volumes.
+	if !vol.IsCustomBlock() {
+		// Prepare tar arguments.
+		srcParts := strings.Split(srcPrefix, string(os.PathSeparator))
+		args := append(tarArgs, []string{
+			"-",
+			"--xattrs-include=*",
+			"--restrict",
+			"--force-local",
+			"--numeric-owner",
+			"-C", mountPath,
+		}...)
+
+		if vol.Type() == VolumeTypeCustom {
+			// If the volume type is custom, then we need to ensure that we restore the top level
+			// directory's ownership from the backup. We cannot use --strip-components flag because it
+			// removes the top level directory from the unpack list. Instead we use the --transform
+			// flag to remove the prefix path and transform it into the "." current unpack directory.
+			args = append(args, fmt.Sprintf("--transform=s/^%s/./", strings.ReplaceAll(srcPrefix, "/", `\/`)))
+		} else {
+			// For instance volumes, the user created files are stored in the rootfs sub-directory
+			// and so strip-components flag works fine.
+			args = append(args, fmt.Sprintf("--strip-components=%d", len(srcParts)))
+		}
+
+		// Directory to unpack comes after other options.
+		args = append(args, srcPrefix)
+
+		// Extract filesystem volume.
+		d.Logger().Debug(fmt.Sprintf("Unpacking %s filesystem volume", volTypeName), logger.Ctx{"source": srcPrefix, "target": mountPath, "args": fmt.Sprintf("%+v", args)})
+		_, err := r.Seek(0, io.SeekStart)
+		if err != nil {
+			return err
+		}
+
+		f, err := os.OpenFile(mountPath, os.O_RDONLY, 0)
+		if err != nil {
+			return fmt.Errorf("Error opening directory: %w", err)
+		}
+
+		defer func() { _ = f.Close() }()
+
+		allowedCmds := []string{}
+		if len(unpacker) > 0 {
+			allowedCmds = append(allowedCmds, unpacker[0])
+		}
+
+		err = archive.ExtractWithFds("tar", args, allowedCmds, io.NopCloser(r), f)
+		if err != nil {
+			return fmt.Errorf("Error starting unpack: %w", err)
+		}
+	}
+
+	// Extract block file to block volume.
+	if vol.contentType == ContentTypeBlock {
+		targetPath, err := d.GetVolumeDiskPath(vol)
+		if err != nil {
+			return err
+		}
+
+		srcFile := fmt.Sprintf("%s.%s", srcPrefix, genericVolumeBlockExtension)
+
+		tr, cancelFunc, err := archive.CompressedTarReader(context.Background(), r, unpacker, mountPath)
+		if err != nil {
+			return err
+		}
+
+		defer cancelFunc()
+
+		unpackBlockVolume := func(hdr *tar.Header) error {
+			var allowUnsafeResize bool
+
+			// Reset the disk.
+			err = linux.ClearBlock(targetPath, 0)
+			if err != nil {
+				return err
+			}
+
+			// Open block file (use O_CREATE to support drivers that use image files).
+			to, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o644)
+			if err != nil {
+				return fmt.Errorf("Error opening file for writing %q: %w", targetPath, err)
+			}
+
+			defer func() { _ = to.Close() }()
+
+			// Restore original size of volume from raw block backup file size.
+			d.Logger().Debug("Setting volume size from source", logger.Ctx{"source": srcFile, "target": targetPath, "size": hdr.Size})
+
+			// Allow potentially destructive resize of volume as we are going to be
+			// overwriting it entirely anyway. This allows shrinking of block volumes.
+			allowUnsafeResize = true
+			err = d.SetVolumeQuota(vol, fmt.Sprintf("%d", hdr.Size), allowUnsafeResize, nil)
+			if err != nil {
+				return err
+			}
+
+			logMsg := "Unpacking virtual machine block volume"
+			if vol.volType == VolumeTypeCustom {
+				logMsg = "Unpacking custom block volume"
+			}
+
+			// Copy the data.
+			toPipe := io.Writer(to)
+			if !d.Info().ZeroUnpack {
+				toPipe = NewSparseFileWrapper(to)
+			}
+
+			d.Logger().Debug(logMsg, logger.Ctx{"source": srcFile, "target": targetPath})
+
+			_, err = util.SafeCopy(toPipe, tr)
+			if err != nil {
+				return err
+			}
+
+			cancelFunc()
+			return to.Close()
+		}
+
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break // End of archive.
+			}
+
+			if err != nil {
+				return err
+			}
+
+			if hdr.Name == srcFile {
+				return unpackBlockVolume(hdr)
+			}
+		}
+
+		return fmt.Errorf("Could not find %q", srcFile)
 	}
 
 	return nil

--- a/internal/server/storage/drivers/volume.go
+++ b/internal/server/storage/drivers/volume.go
@@ -239,7 +239,7 @@ func (v Volume) EnsureMountPath(creation bool) error {
 		if v.IsSnapshot() {
 			// Create the parent directory if needed.
 			parentName, _, _ := api.GetParentAndSnapshotName(v.name)
-			err := createParentSnapshotDirIfMissing(v.pool, v.volType, parentName)
+			err := CreateParentSnapshotDirIfMissing(v.pool, v.volType, parentName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously, qcow2 volumes were exported in their native format, which could result in incomplete data when exporting instances without snapshots due to copy-on-write behavior. This caused only allocated blocks to be included in the export. The export process has been updated to convert qcow2 volumes to raw format, ensuring the entire disk content is exported. This guarantees consistency and completeness regardless of snapshot presence.

Closes: #3164