### PR TITLE
qmp: fix nil-pointer dereference in RunJSON during concurrent disconnect

### DIFF
--- a/internal/server/instance/drivers/qmp/monitor.go
+++ b/internal/server/instance/drivers/qmp/monitor.go
@@ -239,11 +239,15 @@ func (m *Monitor) RunJSON(request []byte, resp any, logCommand bool, id uint32) 
 	}
 
 	var err error
-	if logCommand && m.qmp.log != nil {
+	if logCommand && m.qmp != nil && m.qmp.log != nil {
 		_, err = fmt.Fprintf(m.qmp.log, "[%s] QUERY: %s\n", time.Now().Format(time.RFC3339), request)
 		if err != nil {
 			return err
 		}
+	}
+
+	if m.qmp == nil {
+		return ErrMonitorDisconnect
 	}
 
 	out, err := m.qmp.run(request, id)
@@ -257,7 +261,7 @@ func (m *Monitor) RunJSON(request []byte, resp any, logCommand bool, id uint32) 
 		return err
 	}
 
-	if logCommand && m.qmp.log != nil {
+	if logCommand && m.qmp != nil && m.qmp.log != nil {
 		_, err = fmt.Fprintf(m.qmp.log, "[%s] REPLY: %s\n\n", time.Now().Format(time.RFC3339), out)
 		if err != nil {
 			return err

--- a/internal/server/instance/drivers/qmp/monitor_race_test.go
+++ b/internal/server/instance/drivers/qmp/monitor_race_test.go
@@ -5,50 +5,6 @@ import (
 	"testing"
 )
 
-// TestRunJSONConcurrentDisconnect reproduces a nil-pointer dereference
-// in RunJSON when a concurrent Disconnect nils the QMP socket state
-// while RunJSON is accessing m.qmp.log.
-//
-// The race: Disconnect() calls m.qmp.disconnect() which closes the
-// underlying unix socket. A concurrent RunJSON checks m.disconnected
-// (still false), then dereferences m.qmp.log. If m.qmp's internal
-// state is partially torn down (e.g., log closed/nilled by disconnect),
-// or if the Monitor is reused from the global map in a state where
-// qmp was never fully initialized, the dereference panics.
-//
-// Run with: go test -race -count=100 -run TestRunJSONConcurrentDisconnect
-func TestRunJSONConcurrentDisconnect(t *testing.T) {
-	// Create a minimal Monitor with a nil qmp to simulate the
-	// post-disconnect state. This is the simplest reproduction:
-	// m.qmp is nil but m.disconnected hasn't been set yet.
-	m := &Monitor{
-		qmp:          nil, // simulates torn-down state
-		disconnected: false,
-		chDisconnect: make(chan struct{}, 1),
-		eventMap:     make(map[string]chan Event),
-	}
-
-	// RunJSON should not panic when m.qmp is nil.
-	// It should return ErrMonitorDisconnect or similar.
-	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					t.Errorf("RunJSON panicked with nil m.qmp: %v", r)
-				}
-			}()
-
-			// This will panic on current code because RunJSON
-			// accesses m.qmp.log without checking m.qmp != nil.
-			_ = m.RunJSON([]byte(`{"execute":"quit"}`), nil, true, 1)
-		}()
-	}
-
-	wg.Wait()
-}
 
 // TestRunJSONAfterDisconnect verifies RunJSON is safe to call after
 // Disconnect has been called (m.disconnected = true).

--- a/internal/server/instance/drivers/qmp/monitor_race_test.go
+++ b/internal/server/instance/drivers/qmp/monitor_race_test.go
@@ -1,0 +1,67 @@
+package qmp
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestRunJSONConcurrentDisconnect reproduces a nil-pointer dereference
+// in RunJSON when a concurrent Disconnect nils the QMP socket state
+// while RunJSON is accessing m.qmp.log.
+//
+// The race: Disconnect() calls m.qmp.disconnect() which closes the
+// underlying unix socket. A concurrent RunJSON checks m.disconnected
+// (still false), then dereferences m.qmp.log. If m.qmp's internal
+// state is partially torn down (e.g., log closed/nilled by disconnect),
+// or if the Monitor is reused from the global map in a state where
+// qmp was never fully initialized, the dereference panics.
+//
+// Run with: go test -race -count=100 -run TestRunJSONConcurrentDisconnect
+func TestRunJSONConcurrentDisconnect(t *testing.T) {
+	// Create a minimal Monitor with a nil qmp to simulate the
+	// post-disconnect state. This is the simplest reproduction:
+	// m.qmp is nil but m.disconnected hasn't been set yet.
+	m := &Monitor{
+		qmp:          nil, // simulates torn-down state
+		disconnected: false,
+		chDisconnect: make(chan struct{}, 1),
+		eventMap:     make(map[string]chan Event),
+	}
+
+	// RunJSON should not panic when m.qmp is nil.
+	// It should return ErrMonitorDisconnect or similar.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("RunJSON panicked with nil m.qmp: %v", r)
+				}
+			}()
+
+			// This will panic on current code because RunJSON
+			// accesses m.qmp.log without checking m.qmp != nil.
+			_ = m.RunJSON([]byte(`{"execute":"quit"}`), nil, true, 1)
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestRunJSONAfterDisconnect verifies RunJSON is safe to call after
+// Disconnect has been called (m.disconnected = true).
+func TestRunJSONAfterDisconnect(t *testing.T) {
+	m := &Monitor{
+		qmp:          nil,
+		disconnected: true,
+		chDisconnect: make(chan struct{}, 1),
+		eventMap:     make(map[string]chan Event),
+	}
+
+	err := m.RunJSON([]byte(`{"execute":"quit"}`), nil, true, 1)
+	if err != ErrMonitorDisconnect {
+		t.Errorf("expected ErrMonitorDisconnect, got %v", err)
+	}
+}


### PR DESCRIPTION
When developing on an incus instance, i accidentally provisioned 289 vms on an instance that could only handle about 50. 

I tried to delete these all at once, and i would get errors doing it. my coding agent found a solution to this by checking for a nil pointer at this field, and my bulk delete operation started working again. 

I'm patching this manually for my services, and I felt like it would make sense to contribute this back upstream. 

I had the agent write up a more detailed bug report, i will add this as a supporting comment