### PR TITLE
Remove temporary snapshot block device after migration

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -8033,6 +8033,11 @@ func (d *qemu) sendMigrationSnapshot(diskName string, filesystemConn io.ReadWrit
 			return fmt.Errorf("Failed merging migration storage snapshot: %w", err)
 		}
 
+		err = monitor.RemoveBlockDevice(snapshotDiskName)
+		if err != nil {
+			return fmt.Errorf("Failed removing temporary snapshot disk device: %w", err)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Missing cleanup of the temporary snapshot block device causes subsequent migration attempts to fail, as the snapshot block already exists. This is not noticeable during move operations since the source instance is removed, but can be easily reproduced during copy.

```
root@server01:~# incus cp v1 v2 --storage local
root@server01:~# incus cp v1 v3 --storage local
Error: Error transferring instance data: Failed migration on target: Error from migration control source: Failed migration on source: Failed creating migration snapshot: Failed adding migration storage snapshot block device: Failed adding block device: GenericError: Duplicate nodes with node-name='incus_root_snap'
```