### PR TITLE
internal/linux: Add logging to ClearBlock

### DIFF
--- a/internal/linux/discard.go
+++ b/internal/linux/discard.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/subprocess"
 )
 
@@ -15,6 +16,8 @@ import (
 //
 // An offset can be specified to only reset a part of a device.
 func ClearBlock(blockPath string, blockOffset int64) error {
+	logger.Debug("Clearing block device", logger.Ctx{"dev": blockPath, "offset": blockOffset})
+
 	// Open the block device for checking.
 	fd, err := os.OpenFile(blockPath, os.O_RDWR, 0o644)
 	if err != nil {
@@ -51,6 +54,8 @@ func ClearBlock(blockPath string, blockOffset int64) error {
 		if err != nil {
 			return err
 		}
+
+		logger.Debug("Cleared block device", logger.Ctx{"dev": blockPath, "offset": blockOffset, "method": "truncate"})
 
 		return nil
 	}
@@ -170,6 +175,8 @@ func ClearBlock(blockPath string, blockOffset int64) error {
 		}
 
 		if found == 0 {
+			logger.Debug("Cleared block device", logger.Ctx{"dev": blockPath, "offset": blockOffset, "method": "secure-discard"})
+
 			// All markers are gone, secure discard succeeded.
 			return nil
 		}
@@ -195,6 +202,8 @@ func ClearBlock(blockPath string, blockOffset int64) error {
 		}
 
 		if found == 0 {
+			logger.Debug("Cleared block device", logger.Ctx{"dev": blockPath, "offset": blockOffset, "method": "discard"})
+
 			// All markers are gone, regular discard succeeded.
 			return nil
 		}
@@ -220,6 +229,8 @@ func ClearBlock(blockPath string, blockOffset int64) error {
 		}
 
 		if found == 0 {
+			logger.Debug("Cleared block device", logger.Ctx{"dev": blockPath, "offset": blockOffset, "method": "zero-discard"})
+
 			// All markers are gone, device zero-ing succeeded.
 			return nil
 		}
@@ -256,6 +267,8 @@ func ClearBlock(blockPath string, blockOffset int64) error {
 	if n != (size - blockOffset) {
 		return fmt.Errorf("Only managed to reset %d bytes out of %d", n, size)
 	}
+
+	logger.Debug("Cleared block device", logger.Ctx{"dev": blockPath, "offset": blockOffset, "method": "zero-overwrite"})
 
 	return nil
 }


### PR DESCRIPTION
It can be pretty useful to know what block clearing method was used for a particular device as not all storage arrays/backends behave the same.