### PR TITLE
incus-agent: Work around issue when built with GO111MODULE=off

### DIFF
--- a/cmd/incus-agent/main.go
+++ b/cmd/incus-agent/main.go
@@ -1,3 +1,5 @@
+//go:debug httpmuxgo121=0
+
 package main
 
 import (


### PR DESCRIPTION
In some build setups, such as Debian's packaging of Incus, the environment variable GO111MODULE=off is set. Commit 4e828ca replaced gorilla/mux with net/http, and net/http has a compatibility flag for pre-1.22 behavior which is triggered by setting GO111MODULE=off. This breaks the resulting incus-agent binary.

To work around this, unconditionally set httpmuxgo121=0 in the GODEBUG environment variable when incus-agent starts to force 1.22+ net/http behavior. This shouldn't cause any issues with builds that don't define GO111MODULE=off, as they will be using the modern behavior of net/http.

Closes #2513