### PR TITLE
Check whether an instance snapshot can be restored

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -4013,6 +4013,19 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool, diskOnly
 
 	defer op.Done(nil)
 
+	// Initialize storage interface for the container.
+	pool, err := storagePools.LoadByInstance(d.state, d)
+	if err != nil {
+		op.Done(err)
+		return err
+	}
+
+	err = pool.CanRestoreInstanceSnapshot(d, sourceContainer)
+	if err != nil {
+		op.Done(err)
+		return err
+	}
+
 	// Stop the container.
 	wasRunning := d.IsRunning()
 	if wasRunning {
@@ -4072,13 +4085,6 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool, diskOnly
 	// Wait for any file operations to complete.
 	// This is required so we can actually unmount the container and restore its rootfs.
 	d.stopForkfile(false)
-
-	// Initialize storage interface for the container and mount the rootfs for criu state check.
-	pool, err := storagePools.LoadByInstance(d.state, d)
-	if err != nil {
-		op.Done(err)
-		return err
-	}
 
 	d.logger.Debug("Mounting instance to check for CRIU state path existence")
 

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -5845,6 +5845,19 @@ func (d *qemu) Restore(source instance.Instance, stateful bool, diskOnly bool) e
 
 	var ctxMap logger.Ctx
 
+	// Load the storage driver.
+	pool, err := storagePools.LoadByInstance(d.state, d)
+	if err != nil {
+		op.Done(err)
+		return err
+	}
+
+	err = pool.CanRestoreInstanceSnapshot(d, source)
+	if err != nil {
+		op.Done(err)
+		return err
+	}
+
 	// Stop the instance.
 	wasRunning := false
 	if d.IsRunning() {
@@ -5902,13 +5915,6 @@ func (d *qemu) Restore(source instance.Instance, stateful bool, diskOnly bool) e
 	}
 
 	d.logger.Info("Restoring instance", ctxMap)
-
-	// Load the storage driver.
-	pool, err := storagePools.LoadByInstance(d.state, d)
-	if err != nil {
-		op.Done(err)
-		return err
-	}
 
 	// Restore the rootfs.
 	err = pool.RestoreInstanceSnapshot(d, source, nil)

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -3513,6 +3513,93 @@ func (b *backend) DeleteInstanceSnapshot(inst instance.Instance, op *operations.
 	return nil
 }
 
+// CanRestoreInstanceSnapshot checks whether an instance snapshot can be restored.
+func (b *backend) CanRestoreInstanceSnapshot(inst instance.Instance, src instance.Instance) error {
+	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})
+	l.Debug("CanRestoreInstanceSnapshot started")
+	defer l.Debug("CanRestoreInstanceSnapshot finished")
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	if inst.Type() != src.Type() {
+		return errors.New("Instance types must match")
+	}
+
+	if inst.IsSnapshot() {
+		return errors.New("Instance must not be snapshot")
+	}
+
+	if !src.IsSnapshot() {
+		return errors.New("Source instance must be a snapshot")
+	}
+
+	snaps, err := inst.Snapshots()
+	if err != nil {
+		return err
+	}
+
+	if len(snaps) > 0 && snaps[len(snaps)-1].Name() != src.Name() && inst.HasDependentDisk() {
+		return fmt.Errorf("Snapshot %q cannot be restored due to subsequent snapshot(s).", src.Name())
+	}
+
+	// Check we can convert the instance to the volume type needed.
+	volType, err := InstanceTypeToVolumeType(inst.Type())
+	if err != nil {
+		return err
+	}
+
+	contentType := InstanceContentType(inst)
+
+	// Load storage volume from database.
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	if err != nil {
+		return err
+	}
+
+	// Generate the effective root device volume for instance.
+	volStorageName := project.Instance(inst.Project().Name, inst.Name())
+	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
+
+	_, snapshotName, isSnap := api.GetParentAndSnapshotName(src.Name())
+	if !isSnap {
+		return errors.New("Volume name must be a snapshot")
+	}
+
+	srcDBVol, err := VolumeDBGet(b, src.Project().Name, src.Name(), volType)
+	if err != nil {
+		return err
+	}
+
+	if dbVol.Config["block.type"] == drivers.BlockVolumeTypeQcow2 {
+		snapVol := b.GetVolume(volType, contentType, project.Instance(inst.Project().Name, src.Name()), srcDBVol.Config)
+		err = b.qcow2CanRestoreSnapshot(vol, snapVol, inst.Project().Name)
+		if err != nil {
+			var snapErr drivers.ErrDeleteSnapshots
+			if errors.As(err, &snapErr) {
+				return nil
+			}
+
+			return err
+		}
+
+		return nil
+	}
+
+	err = b.driver.CanRestoreVolume(vol, snapshotName)
+	if err != nil {
+		var snapErr drivers.ErrDeleteSnapshots
+		if errors.As(err, &snapErr) {
+			return nil
+		}
+
+		return err
+	}
+
+	reverter.Success()
+	return nil
+}
+
 // RestoreInstanceSnapshot restores an instance snapshot.
 func (b *backend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "src": src.Name()})
@@ -8196,11 +8283,10 @@ func (b *backend) qcow2CreateSnapshot(vol drivers.Volume, snapVol drivers.Volume
 	return nil
 }
 
-// qcow2RestoreSnapshot restores the QCOW2 volume snapshot.
-func (b *backend) qcow2RestoreSnapshot(vol drivers.Volume, snapVol drivers.Volume, projectName string, op *operations.Operation) error {
-	// Return if this is not a qcow2 image.
+// qcow2CanRestoreSnapshot checks if a qcow2 snapshot can be restored.
+func (b *backend) qcow2CanRestoreSnapshot(vol drivers.Volume, snapVol drivers.Volume, projectName string) error {
 	if vol.Config()["block.type"] != drivers.BlockVolumeTypeQcow2 {
-		return nil
+		return fmt.Errorf("Not a QCOW2 volume type")
 	}
 
 	snapVolDevPath, err := b.driver.GetQcow2BackingFilePath(snapVol)
@@ -8260,6 +8346,38 @@ func (b *backend) qcow2RestoreSnapshot(vol drivers.Volume, snapVol drivers.Volum
 			// Setup custom error to tell the backend what to delete.
 			err := drivers.ErrDeleteSnapshots{}
 			err.Snapshots = snapshots
+			return err
+		}
+
+		return nil
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// qcow2RestoreSnapshot restores the QCOW2 volume snapshot.
+func (b *backend) qcow2RestoreSnapshot(vol drivers.Volume, snapVol drivers.Volume, projectName string, op *operations.Operation) error {
+	// Return if this is not a qcow2 image.
+	if vol.Config()["block.type"] != drivers.BlockVolumeTypeQcow2 {
+		return nil
+	}
+
+	err := b.qcow2CanRestoreSnapshot(vol, snapVol, projectName)
+	if err != nil {
+		return err
+	}
+
+	snapVolDevPath, err := b.driver.GetQcow2BackingFilePath(snapVol)
+	if err != nil {
+		return err
+	}
+
+	err = vol.MountWithSnapshotsTask(func(_ string, _ map[string]string, op *operations.Operation) error {
+		parentDiskPath, err := b.driver.GetVolumeDiskPath(vol)
+		if err != nil {
 			return err
 		}
 

--- a/internal/server/storage/backend_mock.go
+++ b/internal/server/storage/backend_mock.go
@@ -213,6 +213,11 @@ func (b *mockBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operati
 	return nil
 }
 
+// CanRestoreInstanceSnapshot checks if an instance snapshot can be restored.
+func (b *mockBackend) CanRestoreInstanceSnapshot(inst instance.Instance, src instance.Instance) error {
+	return nil
+}
+
 func (b *mockBackend) RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error {
 	return nil
 }

--- a/internal/server/storage/drivers/driver_common.go
+++ b/internal/server/storage/drivers/driver_common.go
@@ -453,6 +453,11 @@ func (d *common) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string
 	return nil, ErrNotSupported
 }
 
+// CanRestoreVolume checks whether a volume snapshot can be restored.
+func (d *common) CanRestoreVolume(vol Volume, snapshotName string) error {
+	return nil
+}
+
 // RestoreVolume resets a volume to its snapshotted state.
 func (d *common) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
 	return ErrNotSupported

--- a/internal/server/storage/drivers/driver_linstor_volumes.go
+++ b/internal/server/storage/drivers/driver_linstor_volumes.go
@@ -899,22 +899,8 @@ func (d *linstor) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation)
 	return nil
 }
 
-// RestoreVolume restores a volume from a snapshot.
-func (d *linstor) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
-	ourUnmount, err := d.UnmountVolume(vol, false, op)
-	if err != nil {
-		return err
-	}
-
-	if ourUnmount {
-		defer func() { _ = d.MountVolume(vol, op) }()
-	}
-
-	snapVol, err := vol.NewSnapshot(snapshotName)
-	if err != nil {
-		return err
-	}
-
+// CanRestoreVolume checks whether a volume snapshot can be restored.
+func (d *linstor) CanRestoreVolume(vol Volume, snapshotName string) error {
 	resourceDefinition, err := d.getResourceDefinition(vol, false)
 	if err != nil {
 		return err
@@ -961,6 +947,30 @@ func (d *linstor) RestoreVolume(vol Volume, snapshotName string, op *operations.
 		// Setup custom error to tell the backend what to delete.
 		err := ErrDeleteSnapshots{}
 		err.Snapshots = snapshots
+		return err
+	}
+
+	return nil
+}
+
+// RestoreVolume restores a volume from a snapshot.
+func (d *linstor) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+	ourUnmount, err := d.UnmountVolume(vol, false, op)
+	if err != nil {
+		return err
+	}
+
+	if ourUnmount {
+		defer func() { _ = d.MountVolume(vol, op) }()
+	}
+
+	snapVol, err := vol.NewSnapshot(snapshotName)
+	if err != nil {
+		return err
+	}
+
+	err = d.CanRestoreVolume(vol, snapshotName)
+	if err != nil {
 		return err
 	}
 

--- a/internal/server/storage/drivers/driver_mock.go
+++ b/internal/server/storage/drivers/driver_mock.go
@@ -206,6 +206,11 @@ func (d *mock) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, 
 	return nil, nil
 }
 
+// CanRestoreVolume checks whether a volume snapshot can be restored.
+func (d *mock) CanRestoreVolume(vol Volume, snapshotName string) error {
+	return nil
+}
+
 // RestoreVolume restores a volume from a snapshot.
 func (d *mock) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
 	return nil

--- a/internal/server/storage/drivers/driver_truenas_volumes.go
+++ b/internal/server/storage/drivers/driver_truenas_volumes.go
@@ -1953,12 +1953,8 @@ func (d *truenas) VolumeSnapshots(vol Volume, op *operations.Operation) ([]strin
 	return snapshots, nil
 }
 
-// RestoreVolume restores a volume from a snapshot.
-func (d *truenas) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
-	return d.restoreVolume(vol, snapshotName, false, op)
-}
-
-func (d *truenas) restoreVolume(vol Volume, snapshotName string, isMigration bool, op *operations.Operation) error {
+// CanRestoreVolume checks whether a volume snapshot can be restored.
+func (d *truenas) CanRestoreVolume(vol Volume, snapshotName string) error {
 	// Get the list of snapshots.
 	dataset := d.dataset(vol, false)
 	entries, err := d.getDatasets(dataset, "snapshot")
@@ -2001,6 +1997,22 @@ func (d *truenas) restoreVolume(vol Volume, snapshotName string, isMigration boo
 		// Setup custom error to tell the backend what to delete.
 		err := ErrDeleteSnapshots{}
 		err.Snapshots = snapshots
+		return err
+	}
+
+	return nil
+}
+
+// RestoreVolume restores a volume from a snapshot.
+func (d *truenas) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+	return d.restoreVolume(vol, snapshotName, false, op)
+}
+
+func (d *truenas) restoreVolume(vol Volume, snapshotName string, isMigration bool, op *operations.Operation) error {
+	dataset := d.dataset(vol, false)
+
+	err := d.CanRestoreVolume(vol, snapshotName)
+	if err != nil {
 		return err
 	}
 

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -3507,12 +3507,8 @@ func (d *zfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 	return snapshots, nil
 }
 
-// RestoreVolume restores a volume from a snapshot.
-func (d *zfs) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
-	return d.restoreVolume(vol, snapshotName, false, op)
-}
-
-func (d *zfs) restoreVolume(vol Volume, snapshotName string, migration bool, op *operations.Operation) error {
+// CanRestoreVolume restores a volume from a snapshot.
+func (d *zfs) CanRestoreVolume(vol Volume, snapshotName string) error {
 	// Get the list of snapshots.
 	entries, err := d.getDatasets(d.dataset(vol, false), "snapshot")
 	if err != nil {
@@ -3554,6 +3550,20 @@ func (d *zfs) restoreVolume(vol Volume, snapshotName string, migration bool, op 
 		// Setup custom error to tell the backend what to delete.
 		err := ErrDeleteSnapshots{}
 		err.Snapshots = snapshots
+		return err
+	}
+
+	return nil
+}
+
+// RestoreVolume restores a volume from a snapshot.
+func (d *zfs) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+	return d.restoreVolume(vol, snapshotName, false, op)
+}
+
+func (d *zfs) restoreVolume(vol Volume, snapshotName string, migration bool, op *operations.Operation) error {
+	err := d.CanRestoreVolume(vol, snapshotName)
+	if err != nil {
 		return err
 	}
 

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -3561,7 +3561,7 @@ func (d *zfs) RestoreVolume(vol Volume, snapshotName string, op *operations.Oper
 	return d.restoreVolume(vol, snapshotName, false, op)
 }
 
-func (d *zfs) restoreVolume(vol Volume, snapshotName string, migration bool, op *operations.Operation) error {
+func (d *zfs) restoreVolume(vol Volume, snapshotName string, isMigration bool, op *operations.Operation) error {
 	err := d.CanRestoreVolume(vol, snapshotName)
 	if err != nil {
 		return err
@@ -3605,9 +3605,9 @@ func (d *zfs) restoreVolume(vol Volume, snapshotName string, migration bool, op 
 	}
 
 	// For VM images, restore the associated filesystem dataset too.
-	if !migration && vol.IsVMBlock() {
+	if !isMigration && vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.restoreVolume(fsVol, snapshotName, migration, op)
+		err := d.restoreVolume(fsVol, snapshotName, isMigration, op)
 		if err != nil {
 			return err
 		}

--- a/internal/server/storage/drivers/interface.go
+++ b/internal/server/storage/drivers/interface.go
@@ -98,6 +98,7 @@ type Driver interface {
 	// not mounted.
 	UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error)
 
+	CanRestoreVolume(vol Volume, snapshotName string) error
 	CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error
 	GetQcow2BackingFilePath(vol Volume) (string, error)
 	DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error

--- a/internal/server/storage/drivers/utils_qcow2.go
+++ b/internal/server/storage/drivers/utils_qcow2.go
@@ -116,7 +116,7 @@ func Qcow2Commit(path string) error {
 
 // Qcow2Info returns information about a qcow2 image.
 func Qcow2Info(path string) (*ImageInfo, error) {
-	imgJSON, err := subprocess.RunCommand("qemu-img", "info", "--output=json", path)
+	imgJSON, err := subprocess.RunCommand("qemu-img", "info", "-U", "--output=json", path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/storage/pool_interface.go
+++ b/internal/server/storage/pool_interface.go
@@ -87,6 +87,7 @@ type Pool interface {
 	UnmountInstance(inst instance.Instance, op *operations.Operation) error
 
 	// Instance snapshots.
+	CanRestoreInstanceSnapshot(inst instance.Instance, src instance.Instance) error
 	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
 	RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error
 	DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error


### PR DESCRIPTION
This adds a pre-check to verify whether an instance snapshot can be safely restored before the instance is stopped.