### PR TITLE
Improve compatibility with `cp` for pull/push operations

### DIFF
--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -534,20 +534,20 @@ func (c *cmdFilePull) pull(parsedFiles []*u.Parsed, target string) error {
 				sftpClients[instanceID] = sftpConn
 			}
 
-			srcInfo, path, err := c.puller.statFile(sftpConn, path)
+			srcInfo, normalizedPath, err := c.puller.statFile(sftpConn, path)
 			if err != nil {
 				return err
 			}
 
 			// Recursively copy directories.
 			if srcInfo.IsDir() {
-				return sftpRecursivePullFile(sftpConn, srcInfo, path, target, c.global.flagQuiet, c.puller.flagDereference, len(parsedFiles) > 1 || util.PathExists(target))
+				return sftpRecursivePullFile(sftpConn, srcInfo, path, normalizedPath, target, c.global.flagQuiet, c.puller.flagDereference, len(parsedFiles) > 1 || util.PathExists(target))
 			}
 
 			// Determine the target path.
 			var targetPath string
 			if targetIsDir {
-				targetPath = filepath.Join(target, filepath.Base(path))
+				targetPath = filepath.Join(target, filepath.Base(normalizedPath))
 			} else {
 				targetPath = target
 			}
@@ -560,7 +560,7 @@ func (c *cmdFilePull) pull(parsedFiles []*u.Parsed, target string) error {
 			if isStdout(targetPath) {
 				f = os.Stdout
 			} else if targetIsLink {
-				linkName, err = sftpConn.ReadLink(path)
+				linkName, err = sftpConn.ReadLink(normalizedPath)
 				if err != nil {
 					return err
 				}
@@ -579,7 +579,7 @@ func (c *cmdFilePull) pull(parsedFiles []*u.Parsed, target string) error {
 			}
 
 			progress := cli.ProgressRenderer{
-				Format: fmt.Sprintf(i18n.G("Pulling %s from %s: %%s"), targetPath, path),
+				Format: fmt.Sprintf(i18n.G("Pulling %s from %s: %%s"), targetPath, normalizedPath),
 				Quiet:  c.global.flagQuiet,
 			}
 
@@ -607,7 +607,7 @@ func (c *cmdFilePull) pull(parsedFiles []*u.Parsed, target string) error {
 					return err
 				}
 			} else {
-				src, err := sftpConn.Open(path)
+				src, err := sftpConn.Open(normalizedPath)
 				if err != nil {
 					return err
 				}

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -2654,19 +2654,19 @@ func (c *cmdStorageVolumeFilePull) pull(parsedPool *u.Parsed, parsedPath *u.Pars
 
 	defer func() { _ = sftpConn.Close() }()
 
-	srcInfo, fPath, err := c.puller.statFile(sftpConn, fPath)
+	srcInfo, normalizedPath, err := c.puller.statFile(sftpConn, fPath)
 	if err != nil {
 		return err
 	}
 
 	// Recursively copy directories.
 	if srcInfo.IsDir() {
-		return sftpRecursivePullFile(sftpConn, srcInfo, fPath, target, c.global.flagQuiet, c.puller.flagDereference, util.PathExists(target))
+		return sftpRecursivePullFile(sftpConn, srcInfo, fPath, normalizedPath, target, c.global.flagQuiet, c.puller.flagDereference, util.PathExists(target))
 	}
 
 	var targetPath string
 	if targetIsDir {
-		targetPath = filepath.Join(target, filepath.Base(fPath))
+		targetPath = filepath.Join(target, filepath.Base(normalizedPath))
 	} else {
 		targetPath = target
 	}
@@ -2679,7 +2679,7 @@ func (c *cmdStorageVolumeFilePull) pull(parsedPool *u.Parsed, parsedPath *u.Pars
 	if isStdout(targetPath) {
 		f = os.Stdout
 	} else if targetIsLink {
-		linkName, err = sftpConn.ReadLink(fPath)
+		linkName, err = sftpConn.ReadLink(normalizedPath)
 		if err != nil {
 			return err
 		}
@@ -2698,7 +2698,7 @@ func (c *cmdStorageVolumeFilePull) pull(parsedPool *u.Parsed, parsedPath *u.Pars
 	}
 
 	progress := cli.ProgressRenderer{
-		Format: fmt.Sprintf(i18n.G("Pulling %s from %s: %%s"), targetPath, fPath),
+		Format: fmt.Sprintf(i18n.G("Pulling %s from %s: %%s"), targetPath, normalizedPath),
 		Quiet:  c.global.flagQuiet,
 	}
 
@@ -2726,7 +2726,7 @@ func (c *cmdStorageVolumeFilePull) pull(parsedPool *u.Parsed, parsedPath *u.Pars
 			return err
 		}
 	} else {
-		src, err := sftpConn.Open(fPath)
+		src, err := sftpConn.Open(normalizedPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/incus/utils_sftp.go
+++ b/cmd/incus/utils_sftp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -122,7 +123,7 @@ func sftpCreateFile(sftpConn *sftp.Client, targetPath string, args incus.Instanc
 	return nil
 }
 
-func sftpRecursivePullFile(sftpConn *sftp.Client, fInfo os.FileInfo, p string, targetDir string, quiet bool, dereference bool, createRoot bool) error {
+func sftpRecursivePullFile(sftpConn *sftp.Client, fInfo os.FileInfo, source string, normalizedSource string, targetDir string, quiet bool, dereference bool, createRoot bool) error {
 	var fileType string
 	if fInfo.IsDir() {
 		fileType = "directory"
@@ -134,24 +135,42 @@ func sftpRecursivePullFile(sftpConn *sftp.Client, fInfo os.FileInfo, p string, t
 
 	target := targetDir
 	if createRoot {
-		target = filepath.Join(targetDir, filepath.Base(p))
+		root := filepath.Base(source)
+		// `cp` has a special behavior with the following paths.
+		if root == "." || root == ".." {
+			root = ""
+		}
+
+		target = filepath.Join(targetDir, root)
 	}
 
-	logger.Infof("Pulling %s from %s (%s)", target, p, fileType)
+	logger.Infof("Pulling %s from %s (%s)", target, normalizedSource, fileType)
 
 	if fileType == "directory" {
 		err := os.Mkdir(target, fInfo.Mode())
 		if err != nil {
-			return err
+			// If the error isn’t that the path already exists, there’s nothing we can do about it.
+			if !errors.Is(err, os.ErrExist) {
+				return err
+			}
+
+			// The error is pretty wide, so we must check whether the existing path it a directory (in
+			// which case we can continue) or not (in which case we must fail).
+			stat, statErr := os.Stat(target)
+			if statErr != nil || !stat.IsDir() {
+				// Even if the stat error can contain interesting data, the actual error that led us here in
+				// the first place is `err`.
+				return err
+			}
 		}
 
-		entries, err := sftpConn.ReadDir(p)
+		entries, err := sftpConn.ReadDir(normalizedSource)
 		if err != nil {
 			return err
 		}
 
 		for _, ent := range entries {
-			nextP := filepath.Join(p, ent.Name())
+			nextP := filepath.Join(normalizedSource, ent.Name())
 			stat := sftpConn.Lstat
 			if dereference {
 				stat = sftpConn.Stat
@@ -162,13 +181,13 @@ func sftpRecursivePullFile(sftpConn *sftp.Client, fInfo os.FileInfo, p string, t
 				return err
 			}
 
-			err = sftpRecursivePullFile(sftpConn, nextInfo, nextP, target, quiet, dereference, true)
+			err = sftpRecursivePullFile(sftpConn, nextInfo, nextP, nextP, target, quiet, dereference, true)
 			if err != nil {
 				return err
 			}
 		}
 	} else if fileType == "file" {
-		src, err := sftpConn.Open(p)
+		src, err := sftpConn.Open(normalizedSource)
 		if err != nil {
 			return err
 		}
@@ -188,7 +207,7 @@ func sftpRecursivePullFile(sftpConn *sftp.Client, fInfo os.FileInfo, p string, t
 		}
 
 		progress := cli.ProgressRenderer{
-			Format: fmt.Sprintf(i18n.G("Pulling %s from %s: %%s"), p, target),
+			Format: fmt.Sprintf(i18n.G("Pulling %s from %s: %%s"), normalizedSource, target),
 			Quiet:  quiet,
 		}
 
@@ -225,7 +244,7 @@ func sftpRecursivePullFile(sftpConn *sftp.Client, fInfo os.FileInfo, p string, t
 
 		progress.Done("")
 	} else if fileType == "symlink" {
-		linkTarget, err := sftpConn.ReadLink(p)
+		linkTarget, err := sftpConn.ReadLink(normalizedSource)
 		if err != nil {
 			return err
 		}

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -314,6 +314,121 @@ test_filemanip() {
     # ... and so does adding a trailing `/`.
     file_check_push_deref_dir -rL /tmp/qux/ baz barqux
 
+
+    # Test consecutive pulls.
+
+    rm -rf "${TEST_DIR}/tmp/foo"
+    mkdir "${TEST_DIR}/tmp/foo"
+    incus file delete -f filemanip/tmp/bar --project=test
+    incus file create --type=directory filemanip/tmp/bar --project=test
+    incus file create --type=directory filemanip/tmp/baz --project=test
+    incus file create filemanip/tmp/bar/one --project=test
+    incus file create filemanip/tmp/bar/two --project=test
+    echo xxx | incus file push - filemanip/tmp/baz/one --project=test
+
+    # One dotted, one non-dotted, no overlap.
+    incus file pull -r filemanip/tmp/bar/. filemanip/tmp/baz/ "${TEST_DIR}/tmp/foo" --project=test
+    [ -f "${TEST_DIR}/tmp/foo/one" ]
+    [ -f "${TEST_DIR}/tmp/foo/two" ]
+    [ -f "${TEST_DIR}/tmp/foo/baz/one" ]
+
+    # Two dotted, overlapping.
+    rm -rf "${TEST_DIR}/tmp/foo"
+    mkdir "${TEST_DIR}/tmp/foo"
+    incus file pull -r filemanip/tmp/bar/. filemanip/tmp/baz/. "${TEST_DIR}/tmp/foo" --project=test
+    [ -f "${TEST_DIR}/tmp/foo/one" ]
+    [ -f "${TEST_DIR}/tmp/foo/two" ]
+    [ "$(cat "${TEST_DIR}/tmp/foo/one")" = xxx ]
+
+    # File/directory overlap.
+    rm -rf "${TEST_DIR}/tmp/foo"
+    mkdir "${TEST_DIR}/tmp/foo"
+    incus file delete -f filemanip/tmp/bar --project=test
+    incus file create -p --type=directory filemanip/tmp/bar/one --project=test
+    ! incus file pull -r filemanip/tmp/baz/. filemanip/tmp/bar/. "${TEST_DIR}/tmp/foo" --project=test || false
+    # To mimic cp, the operation must have a leftover file.
+    [ -f "${TEST_DIR}/tmp/foo/one" ]
+
+    # Directory merging.
+    rm -rf "${TEST_DIR}/tmp/foo"
+    mkdir "${TEST_DIR}/tmp/foo"
+    incus file delete -f filemanip/tmp/baz --project=test
+    incus file create -p --type=directory filemanip/tmp/baz/one --project=test
+    incus file create filemanip/tmp/bar/one/foo --project=test
+    incus file create filemanip/tmp/bar/one/bar --project=test
+    echo xxx | incus file push - filemanip/tmp/baz/one/foo --project=test
+    incus file pull -r filemanip/tmp/bar/. filemanip/tmp/baz/. "${TEST_DIR}/tmp/foo" --project=test
+    [ -f "${TEST_DIR}/tmp/foo/one/foo" ]
+    [ -f "${TEST_DIR}/tmp/foo/one/bar" ]
+    [ "$(cat "${TEST_DIR}/tmp/foo/one/foo")" = xxx ]
+
+    # Directory stacking.
+    rm -rf "${TEST_DIR}/tmp/foo"
+    mkdir "${TEST_DIR}/tmp/foo"
+    incus file delete -f filemanip/tmp/baz --project=test
+    incus file pull -r filemanip/tmp/bar/one "${TEST_DIR}/tmp/foo/one" --project=test
+    incus file pull -r filemanip/tmp/bar/one "${TEST_DIR}/tmp/foo/one" --project=test
+    [ -f "${TEST_DIR}/tmp/foo/one/foo" ]
+    [ -f "${TEST_DIR}/tmp/foo/one/bar" ]
+    [ -f "${TEST_DIR}/tmp/foo/one/one/foo" ]
+    [ -f "${TEST_DIR}/tmp/foo/one/one/bar" ]
+
+
+    # Test consecutive pushes.
+
+    incus file delete filemanip/tmp/foo --project=test
+    rm -rf "${TEST_DIR}/tmp/bar"
+    incus file create --type=directory filemanip/tmp/foo --project=test
+    mkdir "${TEST_DIR}/tmp/bar" "${TEST_DIR}/tmp/baz"
+    touch "${TEST_DIR}/tmp/bar/one" "${TEST_DIR}/tmp/bar/two"
+    echo xxx > "${TEST_DIR}/tmp/baz/one"
+
+    # One dotted, one non-dotted, no overlap.
+    incus file push -r "${TEST_DIR}/tmp/bar/." "${TEST_DIR}/tmp/baz/" filemanip/tmp/foo --project=test
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one ]
+    incus exec filemanip --project=test -- [ -f /tmp/foo/two ]
+    incus exec filemanip --project=test -- [ -f /tmp/foo/baz/one ]
+
+    # Two dotted, overlapping.
+    incus file delete -f filemanip/tmp/foo --project=test
+    incus file create --type=directory filemanip/tmp/foo --project=test
+    incus file push -r "${TEST_DIR}/tmp/bar/." "${TEST_DIR}/tmp/baz/." filemanip/tmp/foo --project=test
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one ]
+    incus exec filemanip --project=test -- [ -f /tmp/foo/two ]
+    [ "$(incus file pull filemanip/tmp/foo/one - --project=test)" = xxx ]
+
+    # File/directory overlap.
+    incus file delete -f filemanip/tmp/foo --project=test
+    incus file create --type=directory filemanip/tmp/foo --project=test
+    rm -rf "${TEST_DIR}/tmp/bar"
+    mkdir -p "${TEST_DIR}/tmp/bar/one"
+    ! incus file push -r "${TEST_DIR}/tmp/baz/." "${TEST_DIR}/tmp/bar/." filemanip/tmp/foo --project=test || false
+    # To mimic cp, the operation must have a leftover file.
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one ]
+
+    # Directory merging.
+    incus file delete -f filemanip/tmp/foo --project=test
+    incus file create --type=directory filemanip/tmp/foo --project=test
+    rm -rf "${TEST_DIR}/tmp/baz"
+    mkdir -p "${TEST_DIR}/tmp/baz/one"
+    touch "${TEST_DIR}/tmp/bar/one/foo" "${TEST_DIR}/tmp/bar/one/bar"
+    echo xxx > "${TEST_DIR}/tmp/baz/one/foo"
+    incus file push -r "${TEST_DIR}/tmp/bar/." "${TEST_DIR}/tmp/baz/." filemanip/tmp/foo --project=test
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one/foo ]
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one/bar ]
+    [ "$(incus file pull filemanip/tmp/foo/one/foo - --project=test)" = xxx ]
+
+    # Directory stacking.
+    incus file delete -f filemanip/tmp/foo --project=test
+    incus file create --type=directory filemanip/tmp/foo --project=test
+    rm -rf "${TEST_DIR}/tmp/baz"
+    incus file push -r "${TEST_DIR}/tmp/bar/one" filemanip/tmp/foo/one --project=test
+    incus file push -r "${TEST_DIR}/tmp/bar/one" filemanip/tmp/foo/one --project=test
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one/foo ]
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one/bar ]
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one/one/foo ]
+    incus exec filemanip --project=test -- [ -f /tmp/foo/one/one/bar ]
+
     # Test SFTP functionality.
     cmd=$(
         unset -f incus


### PR DESCRIPTION
This makes `sftpRecursivePullFile` take way too many arguments; I may refactor that at some point, but… good enough.

Closes: #3167
Related-to: #3086
Related-to: #3209