### PR TITLE
incus/server/network/ovn/driver: Fix duplicate external network ip check on network creation

### DIFF
--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -978,8 +978,8 @@ func (n *ovn) Validate(config map[string]string, clientType request.ClientType) 
 			continue
 		}
 
-		// Skip if unchanged
-		if config[key] == n.config[key] {
+		// Skip if unchanged and already created
+		if config[key] == n.config[key] && n.status == api.NetworkStatusCreated {
 			continue
 		}
 


### PR DESCRIPTION
I forgot one thing in #3271. I apologize.

This change runs the check upon initial network creation as well.