### PR TITLE
tests: Use a 5MiB test file for buckets

### DIFF
--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -113,7 +113,7 @@ test_storage_buckets() {
 
     # Test putting a file into a bucket.
     incusTestFile="bucketfile_${bucketPrefix}.txt"
-    head -c 2M /dev/urandom > "${incusTestFile}"
+    head -c 5M /dev/urandom > "${incusTestFile}"
     s3cmdrun "${incus_backend}" "${adAccessKey}" "${adSecretKey}" put "${incusTestFile}" "s3://${bucketPrefix}.foo"
     ! s3cmdrun "${incus_backend}" "${roAccessKey}" "${roSecretKey}" put "${incusTestFile}" "s3://${bucketPrefix}.foo" || false
 


### PR DESCRIPTION
LVM extent size is typically 4MiB so a 1MiB bucket will be rounded up to 4MiB making the 2MiB test file fit and the quota test fail.