### PR TITLE
incusd/instance/qemu: add virtio vga feature gating

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3959,6 +3959,7 @@ func (d *qemu) generateQemuConfig(bs *qemuBootState, mountInfo *storagePools.Mou
 	_, spice := info.Features["spice"]
 	_, plan9 := info.Features["plan9"]
 	_, virtioSound := info.Features["virtio-sound"]
+	_, virtioVGA := info.Features["virtio-vga"]
 
 	devBus, devAddr, multi = bus.allocate(busFunctionGroupGeneric)
 	serialOpts := qemuSerialOpts{
@@ -4098,6 +4099,7 @@ func (d *qemu) generateQemuConfig(bs *qemuBootState, mountInfo *storagePools.Mou
 			multifunction: multi,
 		},
 		architecture: d.Architecture(),
+		virtioVGA:    virtioVGA,
 	}
 
 	conf = append(conf, qemuGPU(&gpuOpts)...)
@@ -10169,6 +10171,14 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 		logger.Debug("Failed querying virtio-sound-pci during VM feature check", logger.Ctx{"err": err})
 	} else {
 		features["virtio-sound"] = struct{}{}
+	}
+
+	// Check if virtio-vga is compiled into QEMU.
+	err = monitor.QueryVirtioVGADevice()
+	if err != nil {
+		logger.Debug("Failed querying virtio-vga during VM feature check", logger.Ctx{"err": err})
+	} else {
+		features["virtio-vga"] = struct{}{}
 	}
 
 	// Check if running nested.

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -345,7 +345,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			opts     qemuGpuOpts
 			expected string
 		}{{
-			qemuGpuOpts{dev: qemuDevOpts{"pci", "qemu_pcie3", "00.0", true}, architecture: osarch.ARCH_64BIT_INTEL_X86},
+			qemuGpuOpts{dev: qemuDevOpts{"pci", "qemu_pcie3", "00.0", true}, architecture: osarch.ARCH_64BIT_INTEL_X86, virtioVGA: true},
 			`# GPU
 			[device "qemu_gpu"]
 			addr = "00.0"

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -450,12 +450,13 @@ func qemuVsock(opts *qemuVsockOpts) []cfg.Section {
 type qemuGpuOpts struct {
 	dev          qemuDevOpts
 	architecture int
+	virtioVGA    bool
 }
 
 func qemuGPU(opts *qemuGpuOpts) []cfg.Section {
 	var pciName string
 
-	if opts.architecture == osarch.ARCH_64BIT_INTEL_X86 {
+	if opts.architecture == osarch.ARCH_64BIT_INTEL_X86 && opts.virtioVGA {
 		pciName = "virtio-vga"
 	} else {
 		pciName = "virtio-gpu-pci"

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -1774,6 +1774,11 @@ func (m *Monitor) QueryVirtioSoundDevice() error {
 	return m.Run("device-list-properties", map[string]string{"typename": "virtio-sound-pci"}, nil)
 }
 
+// QueryVirtioVGADevice checks whether virtio-vga support is available in QEMU.
+func (m *Monitor) QueryVirtioVGADevice() error {
+	return m.Run("device-list-properties", map[string]string{"typename": "virtio-vga"}, nil)
+}
+
 // AddDirtyBitmap creates a dirty bitmap for a block device.
 func (m *Monitor) AddDirtyBitmap(deviceNames []string, bitmapName string, granularity int, persistent bool, disabled bool) error {
 	actions := []TransactionAction{}


### PR DESCRIPTION
rhel10 does not have virtio-vga compiled in.
```
[damex@biggie1 ~]$   /usr/bin/qemu-system-x86_64 -device help | grep -iE 'vga|virtio.gpu'
name "secondary-vga", bus PCI
name "VGA", bus PCI
```
here we we feature gate it so rhel10 won't have this vga device added.

that's what we have if vm attempts to start with automatically generated config with virtio-vga on el10
```
[damex@biggie1 ~]$ incus start chr1
Error: Failed to run: forklimits limit=memlock:unlimited:unlimited fd=3 fd=4 -- /usr/bin/qemu-system-x86_64 -S -name chr1 -uuid f5ffee62-de41-4b09-8983-bbd4dfb8b25a -daemonize -cpu host,hv_passthrough,migratable=no,+invtsc -nographic -serial chardev:console -nodefaults -no-user-config -sandbox on,obsolete=deny,elevateprivileges=allow,spawn=allow,resourcecontrol=deny -readconfig /run/incus/chr1/qemu.conf -pidfile /run/incus/chr1/qemu.pid -D /var/log/incus/chr1/qemu.log -smbios type=2,manufacturer=LinuxContainers,product=Incus -run-with user=incus: : exit status 1
Try `incus info --show-log chr1` for more info
[damex@biggie1 ~]$ incus info --show-log chr1
Name: chr1
Description:
Status: STOPPED
Type: virtual-machine
Architecture: x86_64
Location: biggie1.home
Created: 2026/03/14 09:42 UTC
Last Used: 2026/05/02 14:42 UTC

Log (qemu.log):

qemu-system-x86_64:/run/incus/chr1/qemu.conf:175: 'virtio-vga' is not a valid device model name
```