### PR TITLE
doc/authorization: Fix reference to old "manager" relation

### DIFF
--- a/doc/authorization.md
+++ b/doc/authorization.md
@@ -62,7 +62,7 @@ Users that you do not trust with root access to the host should not be granted t
 - `server -> can_create_certificates`
 - `certificate -> can_edit`
 - `storage_pool -> can_edit`
-- `project -> manager`
+- `project -> admin`
 
 The remaining relations may be granted.
 However, you must apply appropriate {ref}`project-restrictions`.


### PR DESCRIPTION
There is no such thing as a "manager" in the current model. The relation that needs to be avoided is "admin".

Closes #3301