### PR TITLE
incusd/instance/qemu: Remove deprecated QEMU flag

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -8106,9 +8106,6 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 			// migration and blockdev-mirror. This requires that the migration be continued after it
 			// has reached the "pre-switchover" status.
 			"pause-before-switchover": true,
-
-			// During storage migration encode blocks of zeroes efficiently.
-			"zero-blocks": true,
 		}
 
 		err = monitor.MigrateSetCapabilities(capabilities)


### PR DESCRIPTION
zero-blocks has been deprecated since 9.1 and fully removed now.

Closes #3316 