### PR TITLE
Add support for `block.create_options`

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -5552,6 +5552,14 @@ Note that the claim must be contained in the access token.
 
 <!-- config group server-openfga end -->
 <!-- config group storage_btrfs-common start -->
+```{config:option} btrfs.create_options storage_btrfs-common
+:default: "-"
+:scope: "global"
+:shortdesc: "Additional options to pass to `mkfs.btrfs` when creating the pool"
+:type: "string"
+
+```
+
 ```{config:option} btrfs.mount_options storage_btrfs-common
 :default: "`user_subvol_rm_allowed`"
 :scope: "global"
@@ -6200,6 +6208,14 @@ Note that the claim must be contained in the access token.
 
 <!-- config group storage_volume_btrfs-common end -->
 <!-- config group storage_volume_ceph-common start -->
+```{config:option} block.create_options storage_volume_ceph-common
+:condition: "block-based volume with content type `filesystem`"
+:default: "same as `volume.block.create_options`"
+:shortdesc: "Additional options to pass to the file system creation tool when formatting the volume"
+:type: "string"
+
+```
+
 ```{config:option} block.filesystem storage_volume_ceph-common
 :condition: "block-based volume with content type `filesystem`"
 :default: "same as `volume.block.filesystem`"
@@ -6486,6 +6502,14 @@ Note that the claim must be contained in the access token.
 
 <!-- config group storage_volume_dir-common end -->
 <!-- config group storage_volume_linstor-common start -->
+```{config:option} block.create_options storage_volume_linstor-common
+:condition: "block-based volume with content type `filesystem`"
+:default: "same as `volume.block.create_options`"
+:shortdesc: "Additional options to pass to the file system creation tool when formatting the volume"
+:type: "string"
+
+```
+
 ```{config:option} block.filesystem storage_volume_linstor-common
 :condition: "block-based volume with content type `filesystem`"
 :default: "same as `volume.block.filesystem`"
@@ -6624,6 +6648,14 @@ Note that the claim must be contained in the access token.
 
 <!-- config group storage_volume_linstor-common end -->
 <!-- config group storage_volume_lvm-common start -->
+```{config:option} block.create_options storage_volume_lvm-common
+:condition: "block-based volume with content type `filesystem`"
+:default: "same as `volume.block.create_options`"
+:shortdesc: "Additional options to pass to the file system creation tool when formatting the volume"
+:type: "string"
+
+```
+
 ```{config:option} block.filesystem storage_volume_lvm-common
 :condition: "block-based volume with content type `filesystem`"
 :default: "same as `volume.block.filesystem`"
@@ -6753,6 +6785,14 @@ Note that the claim must be contained in the access token.
 
 <!-- config group storage_volume_lvm-common end -->
 <!-- config group storage_volume_truenas-common start -->
+```{config:option} block.create_options storage_volume_truenas-common
+:condition: "-"
+:default: "same as `volume.block.create_options`"
+:shortdesc: "Additional options to pass to the file system creation tool when formatting the volume"
+:type: "string"
+
+```
+
 ```{config:option} block.filesystem storage_volume_truenas-common
 :condition: "-"
 :default: "same as `volume.block.filesystem`"
@@ -6883,6 +6923,14 @@ Note that the claim must be contained in the access token.
 
 <!-- config group storage_volume_truenas-common end -->
 <!-- config group storage_volume_zfs-common start -->
+```{config:option} block.create_options storage_volume_zfs-common
+:condition: "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)"
+:default: "same as `volume.block.create_options`"
+:shortdesc: "Additional options to pass to the file system creation tool when formatting the volume"
+:type: "string"
+
+```
+
 ```{config:option} block.filesystem storage_volume_zfs-common
 :condition: "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)"
 :default: "same as `volume.block.filesystem`"

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -6253,6 +6253,15 @@
 			"common": {
 				"keys": [
 					{
+						"btrfs.create_options": {
+							"default": "-",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Additional options to pass to `mkfs.btrfs` when creating the pool",
+							"type": "string"
+						}
+					},
+					{
 						"btrfs.mount_options": {
 							"default": "`user_subvol_rm_allowed`",
 							"longdesc": "",
@@ -7031,6 +7040,15 @@
 			"common": {
 				"keys": [
 					{
+						"block.create_options": {
+							"condition": "block-based volume with content type `filesystem`",
+							"default": "same as `volume.block.create_options`",
+							"longdesc": "",
+							"shortdesc": "Additional options to pass to the file system creation tool when formatting the volume",
+							"type": "string"
+						}
+					},
+					{
 						"block.filesystem": {
 							"condition": "block-based volume with content type `filesystem`",
 							"default": "same as `volume.block.filesystem`",
@@ -7364,6 +7382,15 @@
 			"common": {
 				"keys": [
 					{
+						"block.create_options": {
+							"condition": "block-based volume with content type `filesystem`",
+							"default": "same as `volume.block.create_options`",
+							"longdesc": "",
+							"shortdesc": "Additional options to pass to the file system creation tool when formatting the volume",
+							"type": "string"
+						}
+					},
+					{
 						"block.filesystem": {
 							"condition": "block-based volume with content type `filesystem`",
 							"default": "same as `volume.block.filesystem`",
@@ -7523,6 +7550,15 @@
 			"common": {
 				"keys": [
 					{
+						"block.create_options": {
+							"condition": "block-based volume with content type `filesystem`",
+							"default": "same as `volume.block.create_options`",
+							"longdesc": "",
+							"shortdesc": "Additional options to pass to the file system creation tool when formatting the volume",
+							"type": "string"
+						}
+					},
+					{
 						"block.filesystem": {
 							"condition": "block-based volume with content type `filesystem`",
 							"default": "same as `volume.block.filesystem`",
@@ -7671,6 +7707,15 @@
 		"storage_volume_truenas": {
 			"common": {
 				"keys": [
+					{
+						"block.create_options": {
+							"condition": "-",
+							"default": "same as `volume.block.create_options`",
+							"longdesc": "",
+							"shortdesc": "Additional options to pass to the file system creation tool when formatting the volume",
+							"type": "string"
+						}
+					},
 					{
 						"block.filesystem": {
 							"condition": "-",
@@ -7821,6 +7866,15 @@
 		"storage_volume_zfs": {
 			"common": {
 				"keys": [
+					{
+						"block.create_options": {
+							"condition": "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)",
+							"default": "same as `volume.block.create_options`",
+							"longdesc": "",
+							"shortdesc": "Additional options to pass to the file system creation tool when formatting the volume",
+							"type": "string"
+						}
+					},
 					{
 						"block.filesystem": {
 							"condition": "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)",

--- a/internal/server/storage/drivers/driver_btrfs.go
+++ b/internal/server/storage/drivers/driver_btrfs.go
@@ -156,7 +156,7 @@ func (d *btrfs) Create() error {
 		reverter.Add(func() { _ = os.Remove(d.config["source"]) })
 
 		// Format the file.
-		_, err = makeFSType(d.config["source"], "btrfs", &mkfsOptions{Label: d.name})
+		_, err = makeFSType(d.config["source"], "btrfs", &mkfsOptions{Label: d.name, ExtraArgs: d.config["btrfs.create_options"]})
 		if err != nil {
 			return fmt.Errorf("Failed to format sparse file: %w", err)
 		}
@@ -172,7 +172,7 @@ func (d *btrfs) Create() error {
 		}
 
 		// Format the block device.
-		_, err := makeFSType(d.config["source"], "btrfs", &mkfsOptions{Label: d.name})
+		_, err := makeFSType(d.config["source"], "btrfs", &mkfsOptions{Label: d.name, ExtraArgs: d.config["btrfs.create_options"]})
 		if err != nil {
 			return fmt.Errorf("Failed to format block device: %w", err)
 		}
@@ -345,6 +345,15 @@ func (d *btrfs) Validate(config map[string]string) error {
 		//  default: `user_subvol_rm_allowed`
 		//  shortdesc: Mount options for block devices
 		"btrfs.mount_options": validate.IsAny,
+
+		// gendoc:generate(entity=storage_btrfs, group=common, key=btrfs.create_options)
+		//
+		// ---
+		//  type: string
+		//  scope: global
+		//  default: -
+		//  shortdesc: Additional options to pass to `mkfs.btrfs` when creating the pool
+		"btrfs.create_options": validate.IsAny,
 	}
 
 	return d.validatePool(config, rules, nil)

--- a/internal/server/storage/drivers/driver_ceph_volumes.go
+++ b/internal/server/storage/drivers/driver_ceph_volumes.go
@@ -160,7 +160,8 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 	RBDFilesystem := vol.ConfigBlockFilesystem()
 
 	if vol.contentType == ContentTypeFS {
-		_, err = makeFSType(devPath, RBDFilesystem, nil)
+		volCreateOptions := vol.ExpandedConfig("block.create_options")
+		_, err = makeFSType(devPath, RBDFilesystem, &mkfsOptions{ExtraArgs: volCreateOptions})
 		if err != nil {
 			return err
 		}
@@ -798,9 +799,9 @@ func (d *ceph) HasVolume(vol Volume) (bool, error) {
 // FillVolumeConfig populate volume with default config.
 func (d *ceph) FillVolumeConfig(vol Volume) error {
 	// Copy volume.* configuration options from pool.
-	// Exclude 'block.filesystem' and 'block.mount_options'
-	// as this ones are handled below in this function and depends from volume type
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
+	// Exclude 'block.filesystem', 'block.mount_options', and 'block.create_options'
+	// as these are handled below in this function and depend on the volume type
+	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options", "block.create_options")
 	if err != nil {
 		return err
 	}
@@ -829,6 +830,11 @@ func (d *ceph) FillVolumeConfig(vol Volume) error {
 			// Unchangeable volume property: Set unconditionally.
 			vol.config["block.mount_options"] = "discard"
 		}
+
+		// Inherit filesystem creation options from pool if not set.
+		if vol.config["block.create_options"] == "" {
+			vol.config["block.create_options"] = d.config["volume.block.create_options"]
+		}
 	}
 
 	return nil
@@ -854,6 +860,15 @@ func (d *ceph) commonVolumeRules() map[string]func(value string) error {
 		//  default: same as `volume.block.mount_options`
 		//  shortdesc: Mount options for block-backed file system volumes
 		"block.mount_options": validate.IsAny,
+
+		// gendoc:generate(entity=storage_volume_ceph, group=common, key=block.create_options)
+		//
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  default: same as `volume.block.create_options`
+		//  shortdesc: Additional options to pass to the file system creation tool when formatting the volume
+		"block.create_options": validate.IsAny,
 	}
 }
 

--- a/internal/server/storage/drivers/driver_linstor_volumes.go
+++ b/internal/server/storage/drivers/driver_linstor_volumes.go
@@ -31,9 +31,9 @@ import (
 // FillVolumeConfig populate volume with default config.
 func (d *linstor) FillVolumeConfig(vol Volume) error {
 	// Copy volume.* configuration options from pool.
-	// Exclude 'block.filesystem' and 'block.mount_options'
-	// as this ones are handled below in this function and depends from volume type.
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
+	// Exclude 'block.filesystem', 'block.mount_options', and 'block.create_options'
+	// as these are handled below in this function and depend on the volume type.
+	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options", "block.create_options")
 	if err != nil {
 		return err
 	}
@@ -62,6 +62,11 @@ func (d *linstor) FillVolumeConfig(vol Volume) error {
 			// Unchangeable volume property: Set unconditionally.
 			vol.config["block.mount_options"] = "discard"
 		}
+
+		// Inherit filesystem creation options from pool if not set.
+		if vol.config["block.create_options"] == "" {
+			vol.config["block.create_options"] = d.config["volume.block.create_options"]
+		}
 	}
 
 	return nil
@@ -87,6 +92,15 @@ func (d *linstor) commonVolumeRules() map[string]func(value string) error {
 		//  default: same as `volume.block.mount_options`
 		//  shortdesc: Mount options for block-backed file system volumes
 		"block.mount_options": validate.IsAny,
+
+		// gendoc:generate(entity=storage_volume_linstor, group=common, key=block.create_options)
+		//
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  default: same as `volume.block.create_options`
+		//  shortdesc: Additional options to pass to the file system creation tool when formatting the volume
+		"block.create_options": validate.IsAny,
 
 		// gendoc:generate(entity=storage_volume_linstor, group=common, key=drbd.on_no_quorum)
 		//
@@ -303,8 +317,9 @@ func (d *linstor) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 		}
 
 		volFilesystem := vol.ConfigBlockFilesystem()
+		volCreateOptions := vol.ExpandedConfig("block.create_options")
 
-		_, err = makeFSType(devPath, volFilesystem, nil)
+		_, err = makeFSType(devPath, volFilesystem, &mkfsOptions{ExtraArgs: volCreateOptions})
 		if err != nil {
 			return err
 		}
@@ -321,7 +336,8 @@ func (d *linstor) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 		}
 
 		fsVolFilesystem := fsVol.ConfigBlockFilesystem()
-		_, err = makeFSType(fsVolDevPath, fsVolFilesystem, nil)
+		fsVolCreateOptions := fsVol.ExpandedConfig("block.create_options")
+		_, err = makeFSType(fsVolDevPath, fsVolFilesystem, &mkfsOptions{ExtraArgs: fsVolCreateOptions})
 
 		l.Debug("Created filesystem on the associated filesystem volume", logger.Ctx{"fsVolDevPath": fsVolDevPath, "fsVolFilesystem": fsVolFilesystem})
 		if err != nil {

--- a/internal/server/storage/drivers/driver_lvm_utils.go
+++ b/internal/server/storage/drivers/driver_lvm_utils.go
@@ -452,7 +452,9 @@ func (d *lvm) createLogicalVolume(vgName, thinPoolName string, vol Volume, makeT
 	}
 
 	if vol.contentType == ContentTypeFS {
-		_, err = makeFSType(volDevPath, vol.ConfigBlockFilesystem(), nil)
+		volFilesystem := vol.ConfigBlockFilesystem()
+		volCreateOptions := vol.ExpandedConfig("block.create_options")
+		_, err = makeFSType(volDevPath, volFilesystem, &mkfsOptions{ExtraArgs: volCreateOptions})
 		if err != nil {
 			return fmt.Errorf("Error making filesystem on LVM logical volume: %w", err)
 		}

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -299,9 +299,9 @@ func (d *lvm) HasVolume(vol Volume) (bool, error) {
 // FillVolumeConfig populate volume with default config.
 func (d *lvm) FillVolumeConfig(vol Volume) error {
 	// Copy volume.* configuration options from pool.
-	// Exclude "block.filesystem" and "block.mount_options" as they depend on volume type (handled below).
+	// Exclude "block.filesystem", "block.mount_options", and "block.create_options" as they depend on volume type (handled below).
 	// Exclude "lvm.stripes", "lvm.stripes.size" as they only work on non-thin storage pools (handled below).
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options", "lvm.stripes", "lvm.stripes.size")
+	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options", "block.create_options", "lvm.stripes", "lvm.stripes.size")
 	if err != nil {
 		return err
 	}
@@ -329,6 +329,11 @@ func (d *lvm) FillVolumeConfig(vol Volume) error {
 		if vol.config["block.mount_options"] == "" {
 			// Unchangeable volume property: Set unconditionally.
 			vol.config["block.mount_options"] = "discard"
+		}
+
+		// Inherit filesystem creation options from pool if not set.
+		if vol.config["block.create_options"] == "" {
+			vol.config["block.create_options"] = d.config["volume.block.create_options"]
 		}
 	}
 
@@ -369,6 +374,15 @@ func (d *lvm) commonVolumeRules() map[string]func(value string) error {
 		//  default: same as `volume.block.mount_options`
 		//  shortdesc: Mount options for block-backed file system volumes
 		"block.mount_options": validate.IsAny,
+
+		// gendoc:generate(entity=storage_volume_lvm, group=common, key=block.create_options)
+		//
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  default: same as `volume.block.create_options`
+		//  shortdesc: Additional options to pass to the file system creation tool when formatting the volume
+		"block.create_options": validate.IsAny,
 
 		// gendoc:generate(entity=storage_volume_lvm, group=common, key=block.filesystem)
 		//

--- a/internal/server/storage/drivers/driver_truenas_volumes.go
+++ b/internal/server/storage/drivers/driver_truenas_volumes.go
@@ -196,8 +196,9 @@ func (d *truenas) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.
 		}
 
 		fsVolFilesystem := vol.ConfigBlockFilesystem()
+		volCreateOptions := vol.ExpandedConfig("block.create_options")
 
-		_, err = makeFSType(devPath, fsVolFilesystem, nil)
+		_, err = makeFSType(devPath, fsVolFilesystem, &mkfsOptions{ExtraArgs: volCreateOptions})
 
 		// de-activate even if there is an err
 		err2 := d.deactivateIscsiDataset(dataset)
@@ -796,6 +797,15 @@ func (d *truenas) commonVolumeRules() map[string]func(value string) error {
 		//  default: same as `volume.block.mount_options`
 		//  shortdesc: Mount options for block-backed file system volumes
 		"block.mount_options": validate.IsAny,
+
+		// gendoc:generate(entity=storage_volume_truenas, group=common, key=block.create_options)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: same as `volume.block.create_options`
+		//  shortdesc: Additional options to pass to the file system creation tool when formatting the volume
+		"block.create_options": validate.IsAny,
 
 		// gendoc:generate(entity=storage_volume_truenas, group=common, key=truenas.blocksize)
 		//
@@ -2115,7 +2125,7 @@ func (d *truenas) FillVolumeConfig(vol Volume) error {
 	// Copy volume.* configuration options from pool.
 	// If vol has a source, ignore the block mode related config keys from the pool.
 	if vol.hasSource || vol.IsVMBlock() || vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
-		excludedKeys = []string{"block.filesystem", "block.mount_options"}
+		excludedKeys = []string{"block.filesystem", "block.mount_options", "block.create_options"}
 	}
 
 	// Copy volume.* configuration options from pool.
@@ -2150,6 +2160,11 @@ func (d *truenas) FillVolumeConfig(vol Volume) error {
 		if vol.config["block.mount_options"] == "" {
 			// Unchangeable volume property: Set unconditionally.
 			vol.config["block.mount_options"] = "discard"
+		}
+
+		// Inherit filesystem creation options from pool if not set.
+		if vol.config["block.create_options"] == "" {
+			vol.config["block.create_options"] = d.config["volume.block.create_options"]
 		}
 	}
 

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -248,8 +248,9 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			}
 
 			zfsFilesystem := vol.ConfigBlockFilesystem()
+			volCreateOptions := vol.ExpandedConfig("block.create_options")
 
-			_, err = makeFSType(devPath, zfsFilesystem, nil)
+			_, err = makeFSType(devPath, zfsFilesystem, &mkfsOptions{ExtraArgs: volCreateOptions})
 			if err != nil {
 				return err
 			}
@@ -1584,6 +1585,15 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  default: same as `volume.block.mount_options`
 		//  shortdesc: Mount options for block-backed file system volumes
 		"block.mount_options": validate.IsAny,
+
+		// gendoc:generate(entity=storage_volume_zfs, group=common, key=block.create_options)
+		//
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem` (`zfs.block_mode` enabled)
+		//  default: same as `volume.block.create_options`
+		//  shortdesc: Additional options to pass to the file system creation tool when formatting the volume
+		"block.create_options": validate.IsAny,
 
 		// gendoc:generate(entity=storage_volume_zfs, group=common, key=zfs.blocksize)
 		//
@@ -3653,9 +3663,9 @@ func (d *zfs) FillVolumeConfig(vol Volume) error {
 	// Copy volume.* configuration options from pool.
 	// If vol has a source, ignore the block mode related config keys from the pool.
 	if vol.hasSource || vol.IsVMBlock() || vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
-		excludedKeys = []string{"zfs.block_mode", "block.filesystem", "block.mount_options"}
+		excludedKeys = []string{"zfs.block_mode", "block.filesystem", "block.mount_options", "block.create_options"}
 	} else if vol.volType == VolumeTypeCustom && !vol.IsBlockBacked() {
-		excludedKeys = []string{"block.filesystem", "block.mount_options"}
+		excludedKeys = []string{"block.filesystem", "block.mount_options", "block.create_options"}
 	}
 
 	err := d.fillVolumeConfig(&vol, excludedKeys...)
@@ -3690,6 +3700,11 @@ func (d *zfs) FillVolumeConfig(vol Volume) error {
 		if vol.config["block.mount_options"] == "" {
 			// Unchangeable volume property: Set unconditionally.
 			vol.config["block.mount_options"] = "discard"
+		}
+
+		// Inherit filesystem creation options from pool if not set.
+		if vol.config["block.create_options"] == "" {
+			vol.config["block.create_options"] = d.config["volume.block.create_options"]
 		}
 	}
 

--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -420,7 +420,8 @@ func enlargeVolumeBlockFile(path string, volSize int64) error {
 
 // mkfsOptions represents options for filesystem creation.
 type mkfsOptions struct {
-	Label string
+	Label     string
+	ExtraArgs string // Additional arguments passed verbatim to mkfs.
 }
 
 // makeFSType creates the provided filesystem.
@@ -440,6 +441,10 @@ func makeFSType(path string, fsType string, options *mkfsOptions) (string, error
 
 	if fsType == "ext4" {
 		cmd = append(cmd, "-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0")
+	}
+
+	if fsOptions.ExtraArgs != "" {
+		cmd = append(cmd, strings.Fields(fsOptions.ExtraArgs)...)
 	}
 
 	// Always add the path to the device as the last argument for wider compatibility with versions of mkfs.

--- a/internal/server/storage/drivers/utils_test.go
+++ b/internal/server/storage/drivers/utils_test.go
@@ -35,3 +35,20 @@ func TestGetVolumeMountPath(t *testing.T) {
 	expected = GetPoolMountPath(poolName) + "/virtual-machines/testvol"
 	assert.Equal(t, expected, path)
 }
+
+// Test mkfsOptions struct fields and defaults.
+func TestMkfsOptions(t *testing.T) {
+	// Default zero value should have empty ExtraArgs.
+	opts := mkfsOptions{}
+	assert.Empty(t, opts.ExtraArgs)
+	assert.Empty(t, opts.Label)
+
+	// Setting ExtraArgs as a space-separated string should work.
+	opts = mkfsOptions{ExtraArgs: "-b 4096"}
+	assert.Equal(t, "-b 4096", opts.ExtraArgs)
+
+	// Setting Label should work alongside ExtraArgs.
+	opts = mkfsOptions{Label: "myvolume", ExtraArgs: "-E nodiscard"}
+	assert.Equal(t, "myvolume", opts.Label)
+	assert.Equal(t, "-E nodiscard", opts.ExtraArgs)
+}

--- a/test/includes/storage.sh
+++ b/test/includes/storage.sh
@@ -139,3 +139,59 @@ umount_loops() {
         done < "${test_dir}/loops"
     fi
 }
+
+# Check if block.create_options are applied.
+storage_check_create_options_applied() {
+    # shellcheck disable=SC2039,3043
+    local pool filesystem instance mode volume_name mount_path dev_path create_options
+
+    pool="$1"
+    filesystem="$2"
+    instance="$3"
+    mode="$4"
+
+    case "${filesystem}" in
+        ext4)
+            create_options="-I 512"
+            ;;
+        xfs)
+            create_options="-i size=512"
+            ;;
+        *)
+            echo "Unsupported filesystem '${filesystem}' for create_options test"
+            return 0
+            ;;
+    esac
+
+    volume_name="vol-createopts-${filesystem}-${mode}"
+
+    if [ "${mode}" = "volume" ]; then
+        incus storage volume create "${pool}" "${volume_name}" block.filesystem="${filesystem}" block.create_options="${create_options}" size=512MiB
+    elif [ "${mode}" = "pool" ]; then
+        incus storage set "${pool}" volume.block.create_options="${create_options}"
+        incus storage volume create "${pool}" "${volume_name}" block.filesystem="${filesystem}" size=512MiB
+    else
+        echo "Unsupported mode '${mode}' for create_options test"
+        return 1
+    fi
+
+    incus storage volume attach "${pool}" "${volume_name}" "${instance}" createOptsDevice /mnt/createopts
+
+    mount_path="${INCUS_DIR}/storage-pools/${pool}/custom/default_${volume_name}"
+    timeout 10 sh -c "until findmnt -n -o SOURCE '${mount_path}' >/dev/null 2>&1; do sleep 0.1; done"
+    dev_path=$(findmnt -n -o SOURCE "${mount_path}")
+
+    if [ "${filesystem}" = "ext4" ]; then
+        tune2fs -l "${dev_path}" | grep -qE "Inode size:[[:space:]]+512"
+    elif [ "${filesystem}" = "xfs" ]; then
+        xfs_info "${dev_path}" | grep -q "isize=512"
+    fi
+
+    incus storage volume detach "${pool}" "${volume_name}" "${instance}" createOptsDevice
+    incus storage volume delete "${pool}" "${volume_name}"
+
+    if [ "${mode}" = "pool" ]; then
+        incus storage unset "${pool}" volume.block.create_options
+    fi
+}
+

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -249,6 +249,17 @@ test_storage() {
             incus storage create "incustest-$(basename "${INCUS_DIR}")-valid-lvm-pool-config-pool25" lvm volume.block.mount_options="rw,strictatime,discard"
             incus storage set "incustest-$(basename "${INCUS_DIR}")-valid-lvm-pool-config-pool25" volume.block.mount_options "rw,lazytime"
             incus storage create "incustest-$(basename "${INCUS_DIR}")-valid-lvm-pool-config-pool26" lvm volume.block.filesystem=btrfs
+
+            # Functional test: verify that block.create_options are actually applied to ext4 volumes.
+            incus storage create "incustest-$(basename "${INCUS_DIR}")-lvm-createopts" lvm
+            ensure_import_testimage
+            incus launch testimage c-lvm-createopts -s "incustest-$(basename "${INCUS_DIR}")-lvm-createopts"
+            storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-lvm-createopts" ext4 c-lvm-createopts volume
+            storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-lvm-createopts" xfs c-lvm-createopts volume
+            storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-lvm-createopts" ext4 c-lvm-createopts pool
+            storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-lvm-createopts" xfs c-lvm-createopts pool
+            incus rm -f c-lvm-createopts
+            incus storage delete "incustest-$(basename "${INCUS_DIR}")-lvm-createopts"
         fi
 
         # Set default storage pool for image import.

--- a/test/suites/storage_driver_btrfs.sh
+++ b/test/suites/storage_driver_btrfs.sh
@@ -158,6 +158,11 @@ test_storage_driver_btrfs() {
         incus storage delete "incustest-$(basename "${INCUS_DIR}")-pool1"
         incus storage delete "incustest-$(basename "${INCUS_DIR}")-pool2"
 
+        # Functional test: verify that btrfs.create_options are applied when creating the pool filesystem.
+        incus storage create "incustest-$(basename "${INCUS_DIR}")-btrfs-createopts" btrfs btrfs.create_options="--nodesize 8192"
+        btrfs inspect-internal dump-super "$(findmnt -n -o SOURCE "${INCUS_DIR}/storage-pools/incustest-$(basename "${INCUS_DIR}")-btrfs-createopts")" | grep -qE "^nodesize[[:space:]]+8192"
+        incus storage delete "incustest-$(basename "${INCUS_DIR}")-btrfs-createopts"
+
         # Test creating storage pool from exiting btrfs subvolume
         truncate -s 200M testpool.img
         mkfs.btrfs -f testpool.img

--- a/test/suites/storage_driver_ceph.sh
+++ b/test/suites/storage_driver_ceph.sh
@@ -121,6 +121,15 @@ test_storage_driver_ceph() {
         incus storage volume set "incustest-$(basename "${INCUS_DIR}")-pool1" c1pool1 size 500MiB
         incus storage volume unset "incustest-$(basename "${INCUS_DIR}")-pool1" c1pool1 size
 
+        # Functional test: verify that block.create_options are applied to the volume's filesystem.
+        incus launch testimage c6pool1 -s "incustest-$(basename "${INCUS_DIR}")-pool1"
+        incus list -c b c6pool1 | grep "incustest-$(basename "${INCUS_DIR}")-pool1"
+        storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-pool1" ext4 c6pool1 volume
+        storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-pool1" ext4 c6pool1 pool
+        storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-pool1" xfs c6pool1 volume
+        storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-pool1" xfs c6pool1 pool
+        incus delete -f c6pool1
+
         incus storage volume delete "incustest-$(basename "${INCUS_DIR}")-pool1" c1pool1
         incus storage volume delete "incustest-$(basename "${INCUS_DIR}")-pool1" c2pool2
         incus storage volume delete "incustest-$(basename "${INCUS_DIR}")-pool2" c3pool1

--- a/test/suites/storage_driver_linstor.sh
+++ b/test/suites/storage_driver_linstor.sh
@@ -100,6 +100,15 @@ test_storage_driver_linstor() {
         incus storage volume snapshot list "incustest-$(basename "${INCUS_DIR}")-pool1" c3 | grep snap0
         ! incus storage volume snapshot list "incustest-$(basename "${INCUS_DIR}")-pool1" c3 | grep snap1 || false
 
+        # Functional test: verify that block.create_options are applied to the volume's filesystem.
+        incus launch testimage c4 -s "incustest-$(basename "${INCUS_DIR}")-pool1"
+        incus list -c b c4 | grep "incustest-$(basename "${INCUS_DIR}")-pool1"
+        storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-pool1" ext4 c4 volume
+        storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-pool1" ext4 c4 pool
+        storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-pool1" xfs  c4 volume
+        storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")-pool1" xfs  c4 pool
+        incus delete -f c4
+
         # Cleanup
         incus storage volume delete "incustest-$(basename "${INCUS_DIR}")-pool1" c1
         incus storage volume delete "incustest-$(basename "${INCUS_DIR}")-pool1" c2

--- a/test/suites/storage_driver_truenas.sh
+++ b/test/suites/storage_driver_truenas.sh
@@ -186,6 +186,10 @@ do_storage_driver_truenas() {
     # restore default back to ext4, otherwise it can affect future tests.
     incus storage unset incustest-"$(basename "${INCUS_DIR}")" volume.block.filesystem
 
+    # Functional test: verify that block.create_options are applied to the volume's filesystem.
+    storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")" "${filesystem}" c5 volume
+    storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")" "${filesystem}" c5 pool
+
     # Clean up. TrueNAS create/delete can be very slow, this can cause the default 120s command timeout to be exceeded when doing mass instance deletes.
     # FIXME: when deletes aren't so slow, just use `incus rm -f c1 c3 c11 c21 c4 c5`
     instances="c1 c3 c11 c21 c4 c5"

--- a/test/suites/storage_driver_zfs.sh
+++ b/test/suites/storage_driver_zfs.sh
@@ -354,6 +354,10 @@ do_storage_driver_zfs() {
     incus launch testimage c5
     incus storage unset incustest-"$(basename "${INCUS_DIR}")" volume.size
 
+    # Functional test: verify that block.create_options are applied to the volume's filesystem.
+    storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")" "${filesystem}" c5 volume
+    storage_check_create_options_applied "incustest-$(basename "${INCUS_DIR}")" "${filesystem}" c5 pool
+
     # Clean up
     incus rm -f c1 c3 c11 c21 c4 c5 c6 c7
     incus storage volume rm incustest-"$(basename "${INCUS_DIR}")" vol1


### PR DESCRIPTION

This PR close #3308

## incusd

- **`block.create_options`** — added to block-based volumes on LVM, ZFS, Ceph, Linstor, and TrueNAS drivers (alongside the existing `block.mount_options`)
- **`btrfs.create_options`** — added to the BTRFS pool driver (alongside the existing `btrfs.mount_options`)


## test

Added a shared helper `storage_check_create_options_applied()`, which creates a volume with driver-specific options, attaches it to a running instance (to obtain the device path), then inspects the formatted filesystem with `tune2fs` or `xfs_info` to confirm the options were actually applied.
