### PR TITLE
Adjust instance-agent events

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -3111,6 +3111,12 @@ The cluster member that the instance lived on before evacuation.
 
 ```
 
+```{config:option} volatile.last_state.agent instance-volatile
+:shortdesc: "Instance agent state as of last host shutdown"
+:type: "string"
+
+```
+
 ```{config:option} volatile.rebalance.last_move instance-volatile
 :shortdesc: "Timestamp of last move by automatic live-migration"
 :type: "integer"

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -3093,6 +3093,12 @@ The cluster member that the instance lived on before evacuation.
 
 ```
 
+```{config:option} volatile.last_state.agent instance-volatile
+:shortdesc: "Instance agent state as of last host shutdown"
+:type: "string"
+
+```
+
 ```{config:option} volatile.last_state.idmap instance-volatile
 :shortdesc: "Serialized instance UID/GID map"
 :type: "string"
@@ -3107,12 +3113,6 @@ The cluster member that the instance lived on before evacuation.
 
 ```{config:option} volatile.last_state.ready instance-volatile
 :shortdesc: "Instance marked itself as ready"
-:type: "string"
-
-```
-
-```{config:option} volatile.last_state.agent instance-volatile
-:shortdesc: "Instance agent state as of last host shutdown"
 :type: "string"
 
 ```

--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -437,6 +437,13 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	//  shortdesc: Instance marked itself as ready
 	"volatile.last_state.ready": validate.IsBool,
 
+	// gendoc:generate(entity=instance, group=volatile, key=volatile.last_state.agent)
+	//
+	// ---
+	//  type: string
+	//  shortdesc: Instance agent state as of last host shutdown
+	"volatile.last_state.agent": validate.IsAny,
+
 	// gendoc:generate(entity=instance, group=volatile, key=volatile.rebalance.last_move)
 	//
 	// ---

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -514,10 +514,23 @@ func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) 
 				return
 			}
 
+			if err = d.VolatileSet(map[string]string{
+				"volatile.last_state.agent": instance.AgentStateStarted,
+			}); err != nil {
+				d.logger.Error("Failed recording last agent state", logger.Ctx{"err": err})
+			}
+
 			state.Events.SendLifecycle(instProject.Name, lifecycle.InstanceAgentStarted.Event(d, nil))
 
 		case qmp.EventAgentStopped:
 			d.logger.Debug("Instance agent stopped")
+
+			if err = d.VolatileSet(map[string]string{
+				"volatile.last_state.agent": instance.AgentStateStopped,
+			}); err != nil {
+				d.logger.Error("Failed recording last agent state", logger.Ctx{"err": err})
+			}
+
 			state.Events.SendLifecycle(instProject.Name, lifecycle.InstanceAgentStopped.Event(d, nil))
 
 		case qmp.EventVMReset:
@@ -812,8 +825,17 @@ func (d *qemu) onStop(target string, reason string) error {
 		} else {
 			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceStopped.Event(d, nil))
 		}
-		// agent stopped when shutdown
-		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceAgentStopped.Event(d, nil))
+
+		// only trigger if agent state not stopped and update accordingly
+		if d.LocalConfig()["volatile.last_state.agent"] == instance.AgentStateStarted {
+			if err = d.VolatileSet(map[string]string{
+				"volatile.last_state.agent": instance.AgentStateStopped,
+			}); err != nil {
+				d.logger.Error("Failed recording last ready state", logger.Ctx{"err": err})
+			}
+
+			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceAgentStopped.Event(d, nil))
+		}
 	}
 
 	// Reboot the instance.

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -58,6 +58,12 @@ const PowerStateRunning = "RUNNING"
 // PowerStateStopped represents the power state stored when an instance is stopped.
 const PowerStateStopped = "STOPPED"
 
+// AgentStateStarted represents the agent state stored when an instance agent is running.
+const AgentStateStarted = "STARTED"
+
+// AgentStateStopped represents the agent state stored when an instance agent is stopped.
+const AgentStateStopped = "STOPPED"
+
 // ConfigReader is used to read instance config.
 type ConfigReader interface {
 	Project() api.Project

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -3428,6 +3428,13 @@
 						}
 					},
 					{
+						"volatile.last_state.agent": {
+							"longdesc": "",
+							"shortdesc": "Instance agent state as of last host shutdown",
+							"type": "string"
+						}
+					},
+					{
 						"volatile.last_state.idmap": {
 							"longdesc": "",
 							"shortdesc": "Serialized instance UID/GID map",


### PR DESCRIPTION
I previously contributed #3026, which added the firing of events when an instance's agent started/stopped.

During testing, I discovered that in some cases, it was possible to produce a case in which `instance-agent-stopped` was fired twice, because there is currently no check in the `onStop()` hook that checks if the agent event has been fired before.

In the process of fixing this, I thought it would be a cool idea to also expose the agent state in the instance's config, so I added an additional parameter `volatile.last_state.agent` that now tracks it.

The checks before firing the lifecycle events should prevent two events from being fired f.E. if the agent was killed in the instance and is then being killed forcefully `-f`.