### PR TITLE
Restore config volume as part of VM block restoration (LVM storage)

### DIFF
--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -1770,6 +1770,15 @@ func (d *lvm) RestoreVolume(vol Volume, snapshotName string, op *operations.Oper
 			return fmt.Errorf("Error removing original LVM logical volume: %w", err)
 		}
 
+		// For VMs, also restore the filesystem volume.
+		if vol.IsVMBlock() {
+			fsVol := vol.NewVMBlockFilesystemVolume()
+			err := d.RestoreVolume(fsVol, snapshotName, op)
+			if err != nil {
+				return err
+			}
+		}
+
 		reverter.Success()
 		return nil
 	}


### PR DESCRIPTION
Fix snapshot restoration for LVM when using a thin pool. The restore path was missing logic responsible for restoring the config volume, which caused snapshot restoration to be incomplete.