### PR TITLE
Update list of Ubuntu LTS releases that get pre-built Incus packages

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -237,7 +237,7 @@ There are two options currently available to Ubuntu users.
 
 1. Zabbly package repository
 
-    [Zabbly](https://zabbly.com) provides up to date and supported Incus packages for Ubuntu LTS releases (22.04 and 24.04).
+    [Zabbly](https://zabbly.com) provides up to date and supported Incus packages for Ubuntu LTS releases (22.04, 24.04, and 26.04).
     Those packages contain everything needed to use all Incus features.
 
     Up to date installation instructions may be found here: [`https://github.com/zabbly/incus`](https://github.com/zabbly/incus)


### PR DESCRIPTION
According to Zabbly docs, they now host packages for recent Ubuntu 26.04 LTS ("resolute"). I have not tested any of these packages yet.