### PR TITLE
Use correct host:port format for ClusterAddress

### DIFF
--- a/cmd/incus/cluster.go
+++ b/cmd/incus/cluster.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"slices"
@@ -1769,8 +1770,12 @@ func askClustering(asker ask.Asker, config *api.InitPreseed, cluster incus.Insta
 				return err
 			}
 
-			// Set the token.
-			config.Cluster.ClusterAddress = connectInfo.URL
+			clusterURL, err := url.Parse(connectInfo.URL)
+			if err != nil {
+				return err
+			}
+
+			config.Cluster.ClusterAddress = clusterURL.Host
 			config.Cluster.ClusterCertificate = connectInfo.Certificate
 			config.Cluster.ClusterToken = joinToken.String()
 		}


### PR DESCRIPTION
This PR fixes the issue where cluster joins are failing with:
```
Error: Failed to join cluster: Failed to setup cluster trust: Failed to add server cert to cluster: Post “https://https//10.1.1.12:8443:8443/1.0/certificates”: lookup https on 127.0.0.53:53: server misbehaving
```

This is failing as `config.cluster.ClusterAddress` is expected to be in the format `host:port` and not a full URL.

This was initially logged in the forum here:
https://discuss.linuxcontainers.org/t/unique-situation-i-cant-seem-to-find-anywhere-involving-adding-a-server-to-my-cluster/26666/9

Note, I think there is another issue from the original poster where the IP of the joining server is not being detected correctly:
`“https://https//:8443:8443/1.0/certificates”`