### PR TITLE
Fix forward duplicate ip check

### DIFF
--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -6002,6 +6002,48 @@ func (n *ovn) ForwardCreate(forward api.NetworkForwardsPost, clientType request.
 			return api.StatusErrorf(http.StatusConflict, "A forward for that listen address already exists")
 		}
 
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			listenIP := net.ParseIP(forward.ListenAddress)
+
+			if listenIP == nil {
+				return fmt.Errorf("Invalid forward listen address %s", forward.ListenAddress)
+			}
+
+			allAllocatedIPv4, allAllocatedIPv6, err := n.uplinkAllAllocatedIPs(ctx, tx, n.config["network"])
+			if err != nil {
+				return err
+			}
+
+			networkIPv4 := net.ParseIP(n.config[ovnVolatileUplinkIPv4])
+			networkIPv6 := net.ParseIP(n.config[ovnVolatileUplinkIPv6])
+
+			for _, usedIP := range allAllocatedIPv4 {
+				// Skip our own network because its a valid overlap.
+				if usedIP.Equal(networkIPv4) {
+					continue
+				}
+
+				if usedIP.Equal(listenIP) {
+					return fmt.Errorf("Forward listen address %q overlaps with another network or NIC", forward.ListenAddress)
+				}
+			}
+
+			for _, usedIP := range allAllocatedIPv6 {
+				// Skip our own network because its a valid overlap.
+				if usedIP.Equal(networkIPv6) {
+					continue
+				}
+
+				if usedIP.Equal(listenIP) {
+					return fmt.Errorf("Forward listen address %q overlaps with another network or NIC", forward.ListenAddress)
+				}
+			}
+			return err
+		})
+		if err != nil {
+			return err
+		}
+
 		// Convert listen address to subnet so we can check its valid and can be used.
 		listenAddressNet, err := ParseIPToNet(forward.ListenAddress)
 		if err != nil {

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -6494,6 +6494,48 @@ func (n *ovn) LoadBalancerCreate(loadBalancer api.NetworkLoadBalancersPost, clie
 			return api.StatusErrorf(http.StatusConflict, "A load balancer for that listen address already exists")
 		}
 
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			listenIP := net.ParseIP(loadBalancer.ListenAddress)
+
+			if listenIP == nil {
+				return fmt.Errorf("Invalid load balancer listen address %s", loadBalancer.ListenAddress)
+			}
+
+			allAllocatedIPv4, allAllocatedIPv6, err := n.uplinkAllAllocatedIPs(ctx, tx, n.config["network"])
+			if err != nil {
+				return err
+			}
+
+			networkIPv4 := net.ParseIP(n.config[ovnVolatileUplinkIPv4])
+			networkIPv6 := net.ParseIP(n.config[ovnVolatileUplinkIPv6])
+
+			for _, usedIP := range allAllocatedIPv4 {
+				// Skip our own network because its a valid overlap.
+				if usedIP.Equal(networkIPv4) {
+					continue
+				}
+
+				if usedIP.Equal(listenIP) {
+					return fmt.Errorf("Load balancer listen address %q overlaps with another network or NIC", loadBalancer.ListenAddress)
+				}
+			}
+
+			for _, usedIP := range allAllocatedIPv6 {
+				// Skip our own network because its a valid overlap.
+				if usedIP.Equal(networkIPv6) {
+					continue
+				}
+
+				if usedIP.Equal(listenIP) {
+					return fmt.Errorf("Load balancer listen address %q overlaps with another network or NIC", loadBalancer.ListenAddress)
+				}
+			}
+			return err
+		})
+		if err != nil {
+			return err
+		}
+
 		// Convert listen address to subnet so we can check its valid and can be used.
 		listenAddressNet, err := ParseIPToNet(loadBalancer.ListenAddress)
 		if err != nil {


### PR DESCRIPTION
fixes #3244 

Not the proudest piece of code I've written but it works.

Long term I think the best strategy would be to ensure that the `volatile.network.ipvX.address` keys are correctly backfilled in the config.
If we can rely on that, we only need to check for duplicates in there.
Currently there are three different sources of truth as what the external ip(s) of a network are.
1. `volatile.network.ipvX.address` keys.
2. `ipvX.address` key if `nat` is False
3. `ipvX.nat.address` key if `nat` is True

If we'd want the `volatile.network.ipvX.address` key to be the single source of truth for a network external IP, we'd have to ensure that all current logik is adapted for that and all checks that currently run against 2. or 3. are switched to 1 and everything is migrated correctly.
I think long term this would probably be a benefit for the codebase, as it would be more easy to maintain becuase it should net to less code.

I opted not to implement that here as that would have quite a big blast radius.
Could we maybe open a task issue for this? (I'm not permitted to do that)