### PR TITLE
doc: Extend description for OCI-compliant remotes

### DIFF
--- a/doc/howto/images_remote.md
+++ b/doc/howto/images_remote.md
@@ -54,6 +54,24 @@ For example, enter the following command to add a remote through an IP address:
 You are prompted to confirm the remote server fingerprint and then asked for the token.
 <!-- Include end add remotes -->
 
+### Add a remote OCI compliant server (i.e. Docker Hub)
+
+To add a OCI compliant server as a remote, enter the following command:
+
+    incus remote add <remote_name> <URL> --protocol=oci
+
+The URL must use HTTPS.
+
+For example, enter the following command to add Docker Hub as a remote:
+
+    incus remote add oci-docker https://docker.io --protocol=oci
+
+To log in, use a token with `--token <token>`.
+
+For example, enter the following command to add your custom container registry with your own token as a remote:
+
+    incus remote add oci-myregistry https://code.example.org --token abcMyToken --protocol=oci
+
 ## Reference an image
 
 To reference an image, specify its remote and its alias or fingerprint, separated with a colon.

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -56,11 +56,10 @@ To launch a system container with a Debian 12 image from the `images` server usi
 
 ### Launch an application container
 
-To launch an application (OCI) container, you first need to add an image registry:
+To launch an application (OCI) container, you first need to add an OCI compliant image registry.
+See {ref}`images-remote` for instructions.
 
-    incus remote add oci-docker https://docker.io --protocol=oci
-
-And then can launch a container from one of its images:
+Then you can launch a container from one of its images:
 
     incus launch oci-docker:hello-world --ephemeral --console
 


### PR DESCRIPTION
Move instructions on how to add a remote from "instance creation" chapter to "remote" chapter. Also extend log in instructions for custom oci compliant remote.