### PR TITLE
incusd/devices: Set volatileGet on Refresh

### DIFF
--- a/internal/server/device/device_load.go
+++ b/internal/server/device/device_load.go
@@ -162,8 +162,8 @@ func Validate(instConfig instance.ConfigReader, s *state.State, name string, con
 
 // Register performs a lightweight load of the device, bypassing most
 // validation to very quickly register the device on server startup.
-func Register(inst instance.Instance, s *state.State, name string, conf deviceConfig.Device) error {
-	dev, err := load(inst, s, inst.Project().Name, name, conf, nil, nil)
+func Register(inst instance.Instance, s *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter) error {
+	dev, err := load(inst, s, inst.Project().Name, name, conf, volatileGet, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -1333,7 +1333,7 @@ func (d *common) devicesAdd(inst instance.Instance, instanceRunning bool, partia
 // devicesRegister calls the Register() function on all of the instance's devices.
 func (d *common) devicesRegister(inst instance.Instance) {
 	for _, entry := range d.ExpandedDevices().Sorted() {
-		err := device.Register(inst, d.state, entry.Name, entry.Config)
+		err := device.Register(inst, d.state, entry.Name, entry.Config, d.deviceVolatileGetFunc(entry.Name))
 		if err != nil {
 			if errors.Is(err, device.ErrUnsupportedDevType) {
 				continue // Skip unsupported device (allows for mixed instance type profiles).


### PR DESCRIPTION
Fixes startup crash during re-register when volatile keys are needed.