### PR TITLE
Update remote.go

### DIFF
--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -500,9 +500,9 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 			}
 
 			if string(line) != digest {
-				if len(line) < 1 || strings.ToLower(string(line[0])) == i18n.G("n") {
+				if len(line) < 1 || strings.ToLower(string(line[0])) == i18n.G("n") || strings.ToLower(string(line[0])) == "n" {
 					return errors.New(i18n.G("Server certificate NACKed by user"))
-				} else if strings.ToLower(string(line[0])) != i18n.G("y") {
+				} else if strings.ToLower(string(line[0])) != i18n.G("y") || strings.ToLower(string(line[0])) == "y" {
 					return errors.New(i18n.G("Please type 'y', 'n' or the fingerprint:"))
 				}
 			}

--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -500,16 +500,16 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 			}
 
 			if string(line) != digest {
-				if len(line) < 1 || strings.ToLower(string(line[0])) == i18n.G("n") || strings.ToLower(string(line[0])) == "n" {
-					return errors.New(i18n.G("Server certificate NACKed by user"))
-				} else if strings.ToLower(string(line[0])) != i18n.G("y") || strings.ToLower(string(line[0])) == "y" {
+				if len(line) < 1 || strings.ToLower(string(line[0])) != i18n.G("y") || strings.ToLower(string(line[0])) == "y" {
 					return errors.New(i18n.G("Please type 'y', 'n' or the fingerprint:"))
+				} else if strings.ToLower(string(line[0])) == i18n.G("n") || strings.ToLower(string(line[0])) == "n" {
+					return errors.New(i18n.G("Server certificate NACKed by user"))
 				}
 			}
 		}
 
 		dnam := conf.ConfigPath("servercerts")
-		err := os.MkdirAll(dnam, 0o750)
+		err := os.MkdirAll(dnam, 0750)
 		if err != nil {
 			return errors.New(i18n.G("Could not create server cert dir"))
 		}


### PR DESCRIPTION
Better usability. 
Accept not only localized y/n, but also native english y/n, so if user answering on wizard questins in english he can also answer in plain english on this question without switching to their native language. Native language answers still supported.
This is standart localization measure used in "apt" software for example.