### PR TITLE
incusd/devices: Cleanup leftover forkproxy on startup

### DIFF
--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1497,6 +1497,9 @@ func (d *Daemon) init() error {
 		// This should come after the event handler go routines have been started.
 		devicesRegister(instances)
 
+		// Reap any forkproxy helpers left behind by an out-of-cgroup kill of the previous daemon.
+		cleanupOrphanedProxyHelpers(instances)
+
 		// Setup seccomp handler
 		seccompServer, err := seccomp.NewSeccompServer(d.State(), internalUtil.RunPath("seccomp.socket"), func(pid int32, state *state.State) (seccomp.Instance, error) {
 			return findContainerForPid(pid, state)

--- a/cmd/incusd/devices.go
+++ b/cmd/incusd/devices.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -21,6 +23,7 @@ import (
 	"github.com/lxc/incus/v7/internal/server/state"
 	"github.com/lxc/incus/v7/shared/logger"
 	"github.com/lxc/incus/v7/shared/resources"
+	"github.com/lxc/incus/v7/shared/subprocess"
 	"github.com/lxc/incus/v7/shared/util"
 )
 
@@ -675,6 +678,72 @@ func devicesRegister(instances []instance.Instance) {
 		}
 
 		inst.RegisterDevices()
+	}
+}
+
+// cleanupOrphanedProxyHelpers reaps forkproxy helpers left running for stopped containers.
+func cleanupOrphanedProxyHelpers(instances []instance.Instance) {
+	for _, inst := range instances {
+		// Only containers spawn forkproxy helpers; proxy devices on VMs only support NAT mode.
+		if inst.Type() != instancetype.Container {
+			continue
+		}
+
+		// Running instances still need their helpers; only consider stopped instances.
+		if inst.IsRunning() {
+			continue
+		}
+
+		devicesPath := inst.DevicesPath()
+		if !util.PathExists(devicesPath) {
+			continue
+		}
+
+		for devName, devConfig := range inst.ExpandedDevices() {
+			if devConfig["type"] != "proxy" {
+				continue
+			}
+
+			pidPath := filepath.Join(devicesPath, fmt.Sprintf("proxy.%s", devName))
+			if !util.PathExists(pidPath) {
+				continue
+			}
+
+			p, err := subprocess.ImportProcess(pidPath)
+			if err != nil {
+				logger.Warn("Failed to import orphaned forkproxy helper, removing stale pid file", logger.Ctx{
+					"project":  inst.Project().Name,
+					"instance": inst.Name(),
+					"device":   devName,
+					"err":      err,
+				})
+
+				_ = os.Remove(pidPath)
+				continue
+			}
+
+			// Verify the PID still belongs to a forkproxy helper before
+			// signalling it, otherwise PID reuse could result in killing
+			// an unrelated process.
+			cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", p.PID))
+			if err != nil || !bytes.Contains(cmdline, []byte("forkproxy")) {
+				_ = os.Remove(pidPath)
+				continue
+			}
+
+			err = p.Stop()
+			if err != nil && !errors.Is(err, subprocess.ErrNotRunning) {
+				logger.Warn("Failed to stop orphaned forkproxy helper", logger.Ctx{
+					"project":  inst.Project().Name,
+					"instance": inst.Name(),
+					"device":   devName,
+					"pid":      p.PID,
+					"err":      err,
+				})
+			}
+
+			_ = os.Remove(pidPath)
+		}
 	}
 }
 


### PR DESCRIPTION
If a container shuts down or gets killed while incusd is down, the forkproxy processes get reparented to PID1 and remain there forever. Add logic to detect that and clean them up.

Closes #3415