### PR TITLE
incusd/device/disk: Use virtiofsd --posix-acl=auto if supported

### DIFF
--- a/internal/server/device/device_utils_disk.go
+++ b/internal/server/device/device_utils_disk.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -291,6 +292,24 @@ func diskCephfsOptions(clusterName string, userName string, fsName string, fsPat
 	return srcPath, fsOptions, nil
 }
 
+func virtiofsdHasFeature(cmd string, feature string) bool {
+	output, err := subprocess.RunCommand(cmd, "--print-capabilities")
+	if err != nil {
+		return false
+	}
+
+	var caps struct {
+		Features []string `json:"features"`
+	}
+
+	err = json.Unmarshal([]byte(output), &caps)
+	if err != nil {
+		return false
+	}
+
+	return slices.Contains(caps.Features, feature)
+}
+
 // DiskVMVirtiofsdStart starts a new virtiofsd process.
 // If the idmaps slice is supplied then the proxy process is run inside a user namespace using the supplied maps.
 // Returns UnsupportedError error if the host system or instance does not support virtiosfd, returns normal error
@@ -406,7 +425,11 @@ func DiskVMVirtiofsdStart(execPath string, inst instance.Instance, socketPath st
 			args = append(args, fmt.Sprintf("--translate-gid=forbid-guest:%d:%d", lastGID, 4294967295-lastGID))
 		}
 	} else if inst.GuestOS() != "windows" {
-		args = append(args, "--posix-acl")
+		if virtiofsdHasFeature(cmd, "posix-acl-negotiation-mode") {
+			args = append(args, "--posix-acl=auto")
+		} else {
+			args = append(args, "--posix-acl")
+		}
 	}
 
 	proc, err := subprocess.NewProcess(cmd, args, logPath, logPath)


### PR DESCRIPTION
Detect virtiofsd negotiation mode support via `--print-capabilities` and use `--posix-acl=auto` if possible, so virtiofsd doesn't fail if the guest doesn't support posix ACLs.

A note for reviewers: calling `--print-capabilities` on older virtiofsd is safe (even the old C version) since it is mandatory for vhost-user backends[0] 

Fixes #2947 

[0] https://qemu-project.gitlab.io/qemu/interop/vhost-user.html#backend-program-conventions