### PR TITLE
Support including additional GPU functions on different IOMMU groups

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -334,6 +334,13 @@ With VMs, this option supports mounting file system disk devices and paths withi
 
 <!-- config group devices-gpu_mig end -->
 <!-- config group devices-gpu_physical start -->
+```{config:option} functions devices-gpu_physical
+:required: "no"
+:shortdesc: "Comma-delimited list of additional GPU function numbers (1-7) to include (VM only)"
+:type: "string"
+
+```
+
 ```{config:option} gid devices-gpu_physical
 :default: "0"
 :required: "no"

--- a/internal/server/device/gpu.go
+++ b/internal/server/device/gpu.go
@@ -22,6 +22,7 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 		"mig.ci":    validate.IsUint8,
 		"mig.uuid":  gpuValidMigUUID,
 		"mdev":      validate.IsAny,
+		"functions": validate.IsUniqueListOf(validate.IsInRange(1, 7)), // functions consist of 3 bits.
 	}
 
 	validators := map[string]func(value string) error{}

--- a/internal/server/device/gpu_physical.go
+++ b/internal/server/device/gpu_physical.go
@@ -74,6 +74,16 @@ func (d *gpuPhysical) validateConfig(instConf instance.ConfigReader, partialVali
 		"pci",
 	}
 
+	if instConf.Type() == instancetype.VM || instConf.Type() == instancetype.Any {
+		// gendoc:generate(entity=devices, group=gpu_physical, key=functions)
+		//
+		// ---
+		//  type: string
+		//  required: no
+		//  shortdesc: Comma-delimited list of additional GPU function numbers (1-7) to include (VM only)
+		optionalFields = append(optionalFields, "functions")
+	}
+
 	if instConf.Type() == instancetype.Container || instConf.Type() == instancetype.Any {
 		// gendoc:generate(entity=devices, group=gpu_physical, key=uid)
 		//
@@ -270,6 +280,7 @@ func (d *gpuPhysical) startVM() (*deviceConfig.RunConfig, error) {
 
 	saveData := make(map[string]string)
 	var pciAddress string
+	var includeFunctions string
 
 	for _, gpu := range gpus.Cards {
 		// Skip any cards that are not selected.
@@ -300,6 +311,8 @@ func (d *gpuPhysical) startVM() (*deviceConfig.RunConfig, error) {
 		}
 
 		pciAddress = gpu.PCIAddress
+
+		includeFunctions = d.Config()["functions"]
 	}
 
 	if pciAddress == "" {
@@ -331,6 +344,7 @@ func (d *gpuPhysical) startVM() (*deviceConfig.RunConfig, error) {
 		[]deviceConfig.RunConfigItem{
 			{Key: "devName", Value: d.name},
 			{Key: "pciSlotName", Value: saveData["last_state.pci.slot.name"]},
+			{Key: "requestedFunctions", Value: includeFunctions},
 		}...)
 
 	err = d.volatileSet(saveData)

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -5451,6 +5451,7 @@ func (d *qemu) addPCIDevConfig(conf *[]cfg.Section, bus *qemuBus, pciConfig []de
 // addGPUDevConfig adds the qemu config required for adding a GPU device.
 func (d *qemu) addGPUDevConfig(conf *[]cfg.Section, bus *qemuBus, gpuConfig []deviceConfig.RunConfigItem) error {
 	var devName, pciSlotName, vgpu string
+	var requestedFunctions []string
 	for _, gpuItem := range gpuConfig {
 		switch gpuItem.Key {
 		case "devName":
@@ -5459,6 +5460,8 @@ func (d *qemu) addGPUDevConfig(conf *[]cfg.Section, bus *qemuBus, gpuConfig []de
 			pciSlotName = gpuItem.Value
 		case "vgpu":
 			vgpu = gpuItem.Value
+		case "requestedFunctions":
+			requestedFunctions = strings.Split(gpuItem.Value, ",")
 		}
 	}
 
@@ -5515,8 +5518,14 @@ func (d *qemu) addGPUDevConfig(conf *[]cfg.Section, bus *qemuBus, gpuConfig []de
 	// Extract parent slot name by removing any virtual function ID.
 	parts := strings.SplitN(pciSlotName, ".", 2)
 	pciSlotPrefix := parts[0]
+	var addedFunctions []string
 
 	addFunction := func(iommuSlotName string) {
+		parts := strings.SplitN(iommuSlotName, ".", 2)
+		if len(parts) == 2 {
+			addedFunctions = append(addedFunctions, parts[1])
+		}
+
 		// Add VF device without VGA mode to qemu config.
 		devBus, devAddr, multi := bus.allocate(fmt.Sprintf("incus_%s", devName))
 		gpuDevPhysicalOpts := qemuGPUDevPhysicalOpts{
@@ -5555,6 +5564,22 @@ func (d *qemu) addGPUDevConfig(conf *[]cfg.Section, bus *qemuBus, gpuConfig []de
 		if err != nil {
 			return err
 		}
+	}
+
+	// Handle any explicitly requested functions.
+	for _, f := range requestedFunctions {
+		functionName := pciSlotPrefix + "." + f
+		if f == "" || slices.Contains(addedFunctions, f) || functionName == pciSlotName {
+			continue
+		}
+
+		// Ensure the index maps to an actual consumer, and error out if we can't find one.
+		consumerPath := filepath.Join("/sys/bus/pci/devices", pciSlotName, "consumer:pci:"+functionName)
+		if !util.PathExists(consumerPath) {
+			return fmt.Errorf("Failed to find consumer path for GPU function %q", f)
+		}
+
+		addFunction(functionName)
 	}
 
 	return nil

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -5512,11 +5512,31 @@ func (d *qemu) addGPUDevConfig(conf *[]cfg.Section, bus *qemuBus, gpuConfig []de
 		iommuGroupPath = filepath.Join("/sys/bus/pci/devices", pciSlotName, "iommu_group", "devices")
 	}
 
-	if util.PathExists(iommuGroupPath) {
-		// Extract parent slot name by removing any virtual function ID.
-		parts := strings.SplitN(pciSlotName, ".", 2)
-		prefix := parts[0]
+	// Extract parent slot name by removing any virtual function ID.
+	parts := strings.SplitN(pciSlotName, ".", 2)
+	pciSlotPrefix := parts[0]
 
+	addFunction := func(iommuSlotName string) {
+		// Add VF device without VGA mode to qemu config.
+		devBus, devAddr, multi := bus.allocate(fmt.Sprintf("incus_%s", devName))
+		gpuDevPhysicalOpts := qemuGPUDevPhysicalOpts{
+			dev: qemuDevOpts{
+				busName:       bus.name,
+				devBus:        devBus,
+				devAddr:       devAddr,
+				multifunction: multi,
+			},
+			// Generate associated device name by combining main device name and VF ID.
+			devName:     fmt.Sprintf("%s_%s", devName, devAddr),
+			pciSlotName: iommuSlotName,
+			vga:         false,
+			vgpu:        "",
+		}
+
+		*conf = append(*conf, qemuGPUDevPhysical(&gpuDevPhysicalOpts)...)
+	}
+
+	if util.PathExists(iommuGroupPath) {
 		// Iterate the members of the IOMMU group and override any that match the parent slot name prefix.
 		err := filepath.Walk(iommuGroupPath, func(path string, _ os.FileInfo, err error) error {
 			if err != nil {
@@ -5526,24 +5546,8 @@ func (d *qemu) addGPUDevConfig(conf *[]cfg.Section, bus *qemuBus, gpuConfig []de
 			iommuSlotName := filepath.Base(path) // Virtual function's address is dir name.
 
 			// Match any VFs that are related to the GPU device (but not the GPU device itself).
-			if strings.HasPrefix(iommuSlotName, prefix) && iommuSlotName != pciSlotName {
-				// Add VF device without VGA mode to qemu config.
-				devBus, devAddr, multi := bus.allocate(fmt.Sprintf("incus_%s", devName))
-				gpuDevPhysicalOpts := qemuGPUDevPhysicalOpts{
-					dev: qemuDevOpts{
-						busName:       bus.name,
-						devBus:        devBus,
-						devAddr:       devAddr,
-						multifunction: multi,
-					},
-					// Generate associated device name by combining main device name and VF ID.
-					devName:     fmt.Sprintf("%s_%s", devName, devAddr),
-					pciSlotName: iommuSlotName,
-					vga:         false,
-					vgpu:        "",
-				}
-
-				*conf = append(*conf, qemuGPUDevPhysical(&gpuDevPhysicalOpts)...)
+			if strings.HasPrefix(iommuSlotName, pciSlotPrefix) && iommuSlotName != pciSlotName {
+				addFunction(iommuSlotName)
 			}
 
 			return nil

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -347,6 +347,14 @@
 			"gpu_physical": {
 				"keys": [
 					{
+						"functions": {
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Comma-delimited list of additional GPU function numbers (1-7) to include (VM only)",
+							"type": "string"
+						}
+					},
+					{
 						"gid": {
 							"default": "0",
 							"longdesc": "",

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -205,6 +205,30 @@ func IsListOf(validator func(value string) error) func(value string) error {
 	}
 }
 
+// IsUniqueListOf returns a validator for a comma separated list of values with no duplicates.
+func IsUniqueListOf(validator func(value string) error) func(value string) error {
+	return func(value string) error {
+		list := strings.Split(value, ",")
+		seen := make(map[string]struct{}, len(list))
+		for _, v := range list {
+			v = strings.TrimSpace(v)
+			err := validator(v)
+			if err != nil {
+				return fmt.Errorf("Item %q: %w", v, err)
+			}
+
+			_, ok := seen[v]
+			if ok {
+				return fmt.Errorf("Duplicate item %q", v)
+			}
+
+			seen[v] = struct{}{}
+		}
+
+		return nil
+	}
+}
+
 // IsNotEmpty requires a non-empty string.
 func IsNotEmpty(value string) error {
 	if value == "" {


### PR DESCRIPTION
Incus' current behaviour with the `gpu` device type is to auto-load all additional GPU functions in the same IOMMU group. 

If GPU functions are on different IOMMU groups, then they are not imported, and adding them as explicit `pci` devices causes Incus to import them as discrete PCI devices on separate root ports, which then has to be amended with `raw.qemu.conf` or `raw.qemu.scriptlet`.  

Here, I've added a `functions` config key that accepts comma delimited additional function numbers (1-7) to enforce inclusion as long as the following path exists on the main device:

```
ls /sys/bus/pci/devices/0000:40:00.0/ -l | grep consumer
lrwxrwxrwx 1 root root         0 Jun 10 16:57 consumer:pci:0000:40:00.1 -> ../../../../../virtual/devlink/pci:0000:40:00.0--pci:0000:40:00.1
lrwxrwxrwx 1 root root         0 Jun 10 16:57 consumer:pci:0000:40:00.2 -> ../../../../../virtual/devlink/pci:0000:40:00.0--pci:0000:40:00.2
lrwxrwxrwx 1 root root         0 Jun 10 16:57 consumer:pci:0000:40:00.3 -> ../../../../../virtual/devlink/pci:0000:40:00.0--pci:0000:40:00.3

# But not present in the same IOMMU group:
ls /sys/bus/pci/devices/0000:40:00.0/iommu_group/devices  -l
total 0
lrwxrwxrwx 1 root root 0 Jun 10 17:52 0000:40:00.0 -> ../../../../devices/pci0000:00/0000:00:03.2/0000:3e:00.0/0000:3f:00.0/0000:40:00.0
```

So to include all of these, the devices section would look like this:
```yaml
devices:
  gpu:
    functions: "1,2,3"
    pci: 40:00.0
    type: gpu
```

With the changes here, additional functions are enforced as a fallback to the existing IOMMU group inclusions.

---
Some additional steps are required before this can be considered ready:
* Properly handle "transactional" unplug of the entire slot. This is related to #3422 but with the caveat that IOMMU groups may not be the whole source of truth.
* Potentially use a more generic solution rather than the `functions` key, so it can apply to non-GPU devices too. This could look like explicit `pci` and `gpu` devices, where Incus internally determines if they ought to be treated as the same multifunction device.