### PR TITLE
incus/server/storage/driver/ceph: Shrink images to minimal size after unpacking

### DIFF
--- a/internal/server/storage/drivers/driver_ceph_volumes.go
+++ b/internal/server/storage/drivers/driver_ceph_volumes.go
@@ -93,10 +93,7 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 				return err
 			}
 
-			// If the cached volume size is different than the pool volume size, then we can't use the
-			// deleted cached image volume and instead we will rename it to a random UUID so it can't
-			// be restored in the future and a new cached image volume will be created instead.
-			if volSizeBytes != poolVolSizeBytes {
+			if volSizeBytes > poolVolSizeBytes {
 				d.logger.Debug("Renaming deleted cached image volume so that regeneration is used", logger.Ctx{"fingerprint": vol.Name()})
 				randomVol := NewVolume(d, d.name, deletedVol.volType, deletedVol.contentType, strings.ReplaceAll(uuid.New().String(), "-", ""), deletedVol.config, deletedVol.poolConfig)
 				err = renameVolume(d.getRBDVolumeName(deletedVol, "", true), d.getRBDVolumeName(randomVol, "", true))
@@ -212,6 +209,20 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 			err = genericRunFiller(d, vol, devPath, filler, allowUnsafeResize)
 			if err != nil {
 				return err
+			}
+
+			if vol.volType == VolumeTypeImage && IsContentBlock(vol.contentType) && filler.Size > 0 {
+				currentSizeBytes, err := BlockDiskSizeBytes(devPath)
+				if err != nil {
+					return err
+				}
+
+				if currentSizeBytes > filler.Size {
+					err = d.resizeVolume(vol, filler.Size, true)
+					if err != nil {
+						return err
+					}
+				}
 			}
 
 			// Move the GPT alt header to end of disk if needed.


### PR DESCRIPTION
Currently all images will have a default block size of `10GiB` if nothing else is configured in the `volume.size` pool option.
This causes VMs with disk smaller than `10GiB` to not be able the get cloned from that image. Instead it will be copied and unpacked again, which means higher storage usage and slower VM creation.

This PR implements a shrinking of the downloaded image, to the smallest possible size ceph allows, after the image has been filled.