### PR TITLE
doc: Ignore criu.org link checking

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -210,6 +210,7 @@ linkcheck_ignore = [
     'https://web.libera.chat/#lxc',
     'http://localhost:8001',
     'https://www.schlachter.tech/solutions/pongo2-template-engine/',
+    'https://criu.org/',
     r'https://gitlab.alpinelinux.org/.*',
     r'https://developer.hashicorp.com/.*',
     r'https://docutils.sourceforge.io/.*',


### PR DESCRIPTION
The CRIU website has proven quite unreliable in terms of uptime.