### PR TITLE
incus: Close web UI probe response body

### DIFF
--- a/cmd/incus/webui_unix.go
+++ b/cmd/incus/webui_unix.go
@@ -53,6 +53,10 @@ func (c *cmdWebui) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+
 	if resp.StatusCode == http.StatusNotFound {
 		return errors.New(i18n.G("The server doesn't have a web UI installed"))
 	}


### PR DESCRIPTION
The web UI command only checks the status code returned by the UI endpoint probe before starting the local proxy. Close the response body once the status code has been checked so the probe does not leave the HTTP response open while the command keeps running.

Testing:
- go test ./cmd/incus