### PR TITLE
storage/zfs: avoid raw send for snapshot copies

### DIFF
--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -640,6 +640,86 @@ func (d *zfs) receiveFromZfsSender(vol Volume, sender *exec.Cmd) error {
 	return nil
 }
 
+func (d *zfs) useSnapshotSendChain(srcVol Volume) (bool, error) {
+	srcDataset := d.dataset(srcVol, false)
+
+	if d.needsRecursion(srcDataset) {
+		return false, nil
+	}
+
+	encryptionRoot, err := d.getDatasetProperty(srcDataset, "encryptionroot")
+	if err != nil {
+		// Older ZFS versions may not support encryption properties. Keep the existing
+		// replication stream path in that case.
+		return false, nil
+	}
+
+	if encryptionRoot == "" || encryptionRoot == "-" {
+		return false, nil
+	}
+
+	origin, err := d.getDatasetProperty(srcDataset, "origin")
+	if err != nil {
+		return false, err
+	}
+
+	return origin == "" || origin == "-", nil
+}
+
+func (d *zfs) copyVolumeSnapshotsUsingSend(vol Volume, srcVol Volume, srcSnapshot string, snapshots []string) error {
+	srcDataset := d.dataset(srcVol, false)
+	requested := map[string]struct{}{}
+	for _, snapshot := range snapshots {
+		requested[snapshot] = struct{}{}
+	}
+
+	entries, err := d.getDatasets(srcDataset, "snapshot")
+	if err != nil {
+		return err
+	}
+
+	sourceSnapshots := make([]string, 0, len(snapshots)+1)
+	for _, entry := range entries {
+		snapName, ok := strings.CutPrefix(entry, "@snapshot-")
+		if !ok {
+			continue
+		}
+
+		_, ok = requested[snapName]
+		if !ok {
+			continue
+		}
+
+		sourceSnapshots = append(sourceSnapshots, fmt.Sprintf("%s%s", srcDataset, entry))
+	}
+
+	if len(sourceSnapshots) != len(snapshots) {
+		return fmt.Errorf("Failed locating all ZFS snapshots for copy")
+	}
+
+	sourceSnapshots = append(sourceSnapshots, srcSnapshot)
+
+	var parentSnapshot string
+	for _, sourceSnapshot := range sourceSnapshots {
+		args := []string{"send"}
+		if parentSnapshot != "" {
+			args = append(args, "-i", parentSnapshot)
+		}
+
+		args = append(args, sourceSnapshot)
+
+		sender := exec.Command("zfs", args...)
+		err := d.receiveFromZfsSender(vol, sender)
+		if err != nil {
+			return err
+		}
+
+		parentSnapshot = sourceSnapshot
+	}
+
+	return nil
+}
+
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error {
 	var err error
@@ -745,13 +825,23 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		snapName := strings.SplitN(srcSnapshot, "@", 2)[1]
 
 		// Send/receive the snapshot.
-		var sender *exec.Cmd
-
-		// Handle transferring snapshots.
 		if len(snapshots) > 0 {
-			// Raw send is required to send/receive encrypted volumes (and enables compression).
-			args := []string{"send", "-R", "-w", srcSnapshot}
-			sender = exec.Command("zfs", args...)
+			useSnapshotChain, err := d.useSnapshotSendChain(srcVol)
+			if err != nil {
+				return err
+			}
+
+			if useSnapshotChain {
+				err = d.copyVolumeSnapshotsUsingSend(vol, srcVol, srcSnapshot, snapshots)
+			} else {
+				// Raw send is required to send/receive encrypted volumes (and enables compression).
+				sender := exec.Command("zfs", "send", "-R", "-w", srcSnapshot)
+				err = d.receiveFromZfsSender(vol, sender)
+			}
+
+			if err != nil {
+				return err
+			}
 		} else {
 			args := []string{"send"}
 
@@ -760,6 +850,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 				args = append(args, "-R", "-w")
 			}
 
+			var sender *exec.Cmd
 			if d.config["zfs.clone_copy"] == "rebase" {
 				var err error
 				origin := d.dataset(srcVol, false)
@@ -794,11 +885,11 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 				args = append(args, srcSnapshot)
 				sender = exec.Command("zfs", args...)
 			}
-		}
 
-		err := d.receiveFromZfsSender(vol, sender)
-		if err != nil {
-			return err
+			err := d.receiveFromZfsSender(vol, sender)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Delete the snapshot.

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -576,6 +576,70 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 	return postHook, cleanup, nil
 }
 
+func (d *zfs) receiveFromZfsSender(vol Volume, sender *exec.Cmd) error {
+	var receiver *exec.Cmd
+	if vol.ContentType() == ContentTypeBlock || d.isBlockBacked(vol) {
+		receiver = exec.Command("zfs", "receive", d.dataset(vol, false))
+	} else {
+		receiver = exec.Command("zfs", "receive", "-x", "mountpoint", d.dataset(vol, false))
+	}
+
+	// Configure the pipes.
+	receiver.Stdin, _ = sender.StdoutPipe()
+	receiver.Stdout = os.Stdout
+
+	var recvStderr bytes.Buffer
+	receiver.Stderr = &recvStderr
+
+	var sendStderr bytes.Buffer
+	sender.Stderr = &sendStderr
+
+	// Run the transfer.
+	err := receiver.Start()
+	if err != nil {
+		return fmt.Errorf("Failed starting ZFS receive: %w", err)
+	}
+
+	err = sender.Start()
+	if err != nil {
+		_ = receiver.Process.Kill()
+		return fmt.Errorf("Failed starting ZFS send: %w", err)
+	}
+
+	senderErr := make(chan error)
+	go func() {
+		err := sender.Wait()
+		if err != nil {
+			_ = receiver.Process.Kill()
+
+			// This removes any newlines in the error message.
+			msg := strings.ReplaceAll(strings.TrimSpace(sendStderr.String()), "\n", " ")
+
+			senderErr <- fmt.Errorf("Failed ZFS send: %w (%s)", err, msg)
+			return
+		}
+
+		senderErr <- nil
+	}()
+
+	err = receiver.Wait()
+	if err != nil {
+		_ = sender.Process.Kill()
+
+		// This removes any newlines in the error message.
+		msg := strings.ReplaceAll(strings.TrimSpace(recvStderr.String()), "\n", " ")
+
+		return fmt.Errorf("Failed ZFS receive: %w (%s)", err, msg)
+	}
+
+	err = <-senderErr
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error {
 	var err error
@@ -682,12 +746,6 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 
 		// Send/receive the snapshot.
 		var sender *exec.Cmd
-		var receiver *exec.Cmd
-		if vol.ContentType() == ContentTypeBlock || d.isBlockBacked(vol) {
-			receiver = exec.Command("zfs", "receive", d.dataset(vol, false))
-		} else {
-			receiver = exec.Command("zfs", "receive", "-x", "mountpoint", d.dataset(vol, false))
-		}
 
 		// Handle transferring snapshots.
 		if len(snapshots) > 0 {
@@ -738,55 +796,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			}
 		}
 
-		// Configure the pipes.
-		receiver.Stdin, _ = sender.StdoutPipe()
-		receiver.Stdout = os.Stdout
-
-		var recvStderr bytes.Buffer
-		receiver.Stderr = &recvStderr
-
-		var sendStderr bytes.Buffer
-		sender.Stderr = &sendStderr
-
-		// Run the transfer.
-		err := receiver.Start()
-		if err != nil {
-			return fmt.Errorf("Failed starting ZFS receive: %w", err)
-		}
-
-		err = sender.Start()
-		if err != nil {
-			_ = receiver.Process.Kill()
-			return fmt.Errorf("Failed starting ZFS send: %w", err)
-		}
-
-		senderErr := make(chan error)
-		go func() {
-			err := sender.Wait()
-			if err != nil {
-				_ = receiver.Process.Kill()
-
-				// This removes any newlines in the error message.
-				msg := strings.ReplaceAll(strings.TrimSpace(sendStderr.String()), "\n", " ")
-
-				senderErr <- fmt.Errorf("Failed ZFS send: %w (%s)", err, msg)
-				return
-			}
-
-			senderErr <- nil
-		}()
-
-		err = receiver.Wait()
-		if err != nil {
-			_ = sender.Process.Kill()
-
-			// This removes any newlines in the error message.
-			msg := strings.ReplaceAll(strings.TrimSpace(recvStderr.String()), "\n", " ")
-
-			return fmt.Errorf("Failed ZFS receive: %w (%s)", err, msg)
-		}
-
-		err = <-senderErr
+		err := d.receiveFromZfsSender(vol, sender)
 		if err != nil {
 			return err
 		}

--- a/test/suites/storage_driver_zfs.sh
+++ b/test/suites/storage_driver_zfs.sh
@@ -88,6 +88,20 @@ do_zfs_encryption() {
     zfs get -H -o name,property,value keystatus "$zpool_name" | grep -Eq "$zpool_name\s+keystatus\s+available"
     INCUS_DIR="${INCUS_STORAGE_DIR}" incus storage list -f csv -c nDs | grep -q "zpool_encrypted,zfs,CREATED"
 
+    # Regression test for copying non-clone datasets with snapshots inside an
+    # encrypted ZFS pool. This used to receive a raw replication stream, creating
+    # a new encryption root with an unavailable key and making the final mount fail.
+    INCUS_DIR="${INCUS_STORAGE_DIR}" ensure_import_testimage
+    INCUS_DIR="${INCUS_STORAGE_DIR}" incus storage create zfs-encryption-dir dir
+    INCUS_DIR="${INCUS_STORAGE_DIR}" incus init testimage zfs-encryption-dir-source -s zfs-encryption-dir
+    INCUS_DIR="${INCUS_STORAGE_DIR}" incus copy zfs-encryption-dir-source zfs-encryption-copy-source -s zpool_encrypted
+    [ "$(zfs get -H -o value origin "$zpool_name/containers/zfs-encryption-copy-source")" = "-" ]
+    INCUS_DIR="${INCUS_STORAGE_DIR}" incus snapshot create zfs-encryption-copy-source snap0
+    INCUS_DIR="${INCUS_STORAGE_DIR}" incus copy zfs-encryption-copy-source zfs-encryption-copy-target
+    INCUS_DIR="${INCUS_STORAGE_DIR}" incus info zfs-encryption-copy-target | grep -q "snap0"
+    INCUS_DIR="${INCUS_STORAGE_DIR}" incus delete -f zfs-encryption-dir-source zfs-encryption-copy-source zfs-encryption-copy-target
+    INCUS_DIR="${INCUS_STORAGE_DIR}" incus storage delete zfs-encryption-dir
+
     # Shut down Incus to force the pool to get exported.
     shutdown_incus "${INCUS_STORAGE_DIR}"
 


### PR DESCRIPTION
## Summary
- avoid raw ZFS replication sends for same-pool snapshot copies unless recursive send is needed
- add a ZFS encryption regression test for copying a non-clone volume with snapshots

Fixes #3046

## Tests
- `go test ./internal/server/storage/drivers`
- `shellcheck -s bash test/suites/storage_driver_zfs.sh`
- `bash -n test/suites/storage_driver_zfs.sh`

