### PR TITLE
Fix allow cached shared image to grow

### DIFF
--- a/internal/server/storage/drivers/volume.go
+++ b/internal/server/storage/drivers/volume.go
@@ -690,9 +690,19 @@ func (v Volume) ConfigSizeFromSource(srcVol Volume) (string, error) {
 			return volSize, err
 		}
 
-		// The volume/pool specified size is smaller than image minimum size. We must not continue as
-		// these specified sizes provide protection against unpacking a massive image and filling the pool.
 		if volSizeBytes < imgSizeBytes {
+			// The shared cached image volume must be large enough to hold the image. Grow it to
+			// the image size rather than failing, so instances with a sufficciently sized root
+			// disk can be created even when the pool's volume.size is smaller than the image.
+			// Instance volumes keep the strict check below (their root disk size is honored
+			// separately).
+			if v.volType == VolumeTypeImage {
+				return srcVol.config["volatile.rootfs.size"], nil
+			}
+
+			// The volume/pool specified size is smaller than image minimum size. We must not
+			// continue as these specified sizes provide protection against unpacking a massive
+			// image and filling the pool.
 			return "", fmt.Errorf("Source image size (%d) exceeds specified volume size (%d)", imgSizeBytes, volSizeBytes)
 		}
 

--- a/internal/server/storage/drivers/volume_test.go
+++ b/internal/server/storage/drivers/volume_test.go
@@ -63,6 +63,21 @@ func Test_Volume_ConfigSizeFromSource(t *testing.T) {
 			size:   "20GiB",
 		},
 		{
+			// Check an image volume target grows to the source image size when its specified size
+			// is smaller, rather than erroring (the cached image volume must hold the full image).
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeImage, config: map[string]string{"size": "5GiB"}},
+			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "10GiB"}},
+			err:    nil,
+			size:   "10GiB",
+		},
+		{
+			// Same as above but the smaller size comes from the pool's volume.size setting.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeImage, poolConfig: map[string]string{"volume.size": "5GiB"}},
+			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "10GiB"}},
+			err:    nil,
+			size:   "10GiB",
+		},
+		{
 			// Check returned size is empty when the container volume/pool doesn't specify a size and
 			// the pool is not block backed and the volume is container & fs.
 			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, contentType: ContentTypeFS, config: map[string]string{}},


### PR DESCRIPTION
The Bug:
When the virtual size of a image is larger than the configures volume.size on a pool, instance creation fails because it does not have enough space to unpack the shared cached image.
This adds another check which is hit during the `EnsureImage` function, which pushes the image to the desired storage-pool and allows the shared image to grow to its desired size.