### PR TITLE
incusd/storage/btrfs: Fix daemon dir prefix check

### DIFF
--- a/internal/server/storage/drivers/driver_btrfs.go
+++ b/internal/server/storage/drivers/driver_btrfs.go
@@ -216,7 +216,7 @@ func (d *btrfs) Create() error {
 				}
 			}
 
-			if strings.HasPrefix(cleanSource, daemonDir) {
+			if cleanSource == daemonDir || strings.HasPrefix(cleanSource, daemonDir+"/") {
 				if cleanSource != GetPoolMountPath(d.name) {
 					return fmt.Errorf("Only allowed source path under %q is %q", internalUtil.VarPath(), GetPoolMountPath(d.name))
 				}


### PR DESCRIPTION
https://discuss.linuxcontainers.org/t/btrfs-received-uuid-set-after-move-copy-to-other-storage-pool-or-other-host/26862/2