### PR TITLE
incusd/storage/zfs: Batch snapshot GUID lookups

### DIFF
--- a/internal/server/storage/drivers/driver_zfs_utils.go
+++ b/internal/server/storage/drivers/driver_zfs_utils.go
@@ -197,6 +197,31 @@ func (d *zfs) getDatasets(dataset string, types string) ([]string, error) {
 	return children, nil
 }
 
+// getSnapshotGUIDs returns a map of snapshot dataset name to guid for all snapshots of the dataset in a single call.
+func (d *zfs) getSnapshotGUIDs(dataset string) (map[string]string, error) {
+	out, err := subprocess.RunCommand("zfs", "get", "-H", "-p", "-r", "-o", "name,value", "-t", "snapshot", "guid", dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	guids := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+
+		guids[fields[0]] = fields[1]
+	}
+
+	return guids, nil
+}
+
 func (d *zfs) setDatasetProperties(dataset string, options ...string) error {
 	args := []string{"set"}
 	args = append(args, options...)
@@ -439,6 +464,11 @@ type ZFSMetaDataHeader struct {
 }
 
 func (d *zfs) datasetHeader(vol Volume, snapshots []string) (*ZFSMetaDataHeader, error) {
+	guids, err := d.getSnapshotGUIDs(d.dataset(vol, false))
+	if err != nil {
+		return nil, err
+	}
+
 	migrationHeader := ZFSMetaDataHeader{
 		SnapshotDatasets: make([]ZFSDataset, len(snapshots)),
 	}
@@ -446,13 +476,8 @@ func (d *zfs) datasetHeader(vol Volume, snapshots []string) (*ZFSMetaDataHeader,
 	for i, snapName := range snapshots {
 		snapVol, _ := vol.NewSnapshot(snapName)
 
-		guid, err := d.getDatasetProperty(d.dataset(snapVol, false), "guid")
-		if err != nil {
-			return nil, err
-		}
-
 		migrationHeader.SnapshotDatasets[i].Name = snapName
-		migrationHeader.SnapshotDatasets[i].GUID = guid
+		migrationHeader.SnapshotDatasets[i].GUID = guids[d.dataset(snapVol, false)]
 	}
 
 	return &migrationHeader, nil

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -1053,15 +1053,15 @@ func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 		var syncSnapshots []*migration.Snapshot
 
 		// Get the GUIDs of all target snapshots.
-		for _, snapVol := range snapshots {
-			guid, err := d.getDatasetProperty(d.dataset(snapVol, false), "guid")
-			if err != nil {
-				return err
-			}
+		guids, err := d.getSnapshotGUIDs(d.dataset(vol, false))
+		if err != nil {
+			return err
+		}
 
+		for _, snapVol := range snapshots {
 			_, snapName, _ := api.GetParentAndSnapshotName(snapVol.name)
 
-			respSnapshots = append(respSnapshots, ZFSDataset{Name: snapName, GUID: guid})
+			respSnapshots = append(respSnapshots, ZFSDataset{Name: snapName, GUID: guids[d.dataset(snapVol, false)]})
 		}
 
 		if volumeOnly {


### PR DESCRIPTION
This should cut down on individual ZFS calls during refresh migration, reducing the changes of overrunning the 2min timeout.


Sponsored-by: https://webdock.io