### PR TITLE
incusd/storage/drivers: Fix btrfs.compression=none and pool-wide default

### DIFF
--- a/internal/server/storage/drivers/driver_btrfs.go
+++ b/internal/server/storage/drivers/driver_btrfs.go
@@ -357,7 +357,7 @@ func (d *btrfs) Validate(config map[string]string) error {
 		"btrfs.create_options": validate.IsAny,
 	}
 
-	return d.validatePool(config, rules, nil)
+	return d.validatePool(config, rules, d.commonVolumeRules())
 }
 
 // Update applies any driver changes required from a configuration change.

--- a/internal/server/storage/drivers/driver_btrfs_volumes.go
+++ b/internal/server/storage/drivers/driver_btrfs_volumes.go
@@ -56,9 +56,13 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 	})
 
 	// Apply the per-volume compression property if set, so that the files created inside the
-	// subvolume (including the root disk file for block volumes) inherit it.
+	// subvolume (including the root disk file for block volumes) inherit it. For block volumes
+	// "none" is applied as nodatacow below, which also disables compression; setting the
+	// nocompress property would leave an inode flag that the chattr +C is rejected on, so it is
+	// skipped here.
 	compression := vol.ExpandedConfig("btrfs.compression")
-	if compression != "" {
+	compressionNone := compression == "none" || compression == "no"
+	if compression != "" && (!compressionNone || !IsContentBlock(vol.contentType)) {
 		_, err = subprocess.RunCommand("btrfs", "property", "set", volPath, "compression", compression)
 		if err != nil {
 			return fmt.Errorf("Failed setting compression on %q: %w", volPath, err)
@@ -87,7 +91,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		// even on a compressed pool, and any other value enables it.
 		compressed := strings.Contains(mountinfo[len(mountinfo)-1], "compress")
 		if compression != "" {
-			compressed = compression != "none" && compression != "no"
+			compressed = !compressionNone
 		}
 
 		// Enable nodatacow on the parent directory so that when the root disk file is created the setting
@@ -102,8 +106,12 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		//
 		// nodatacow and compression are mutually exclusive, so this is skipped when the volume is
 		// compressed. Setting "btrfs.compression=none" disables compression for the volume and so
-		// allows nodatacow to be applied on a pool that is otherwise compressed.
+		// allows nodatacow to be applied on a pool that is otherwise compressed. A compression flag
+		// inherited from the parent subvolume is cleared first, as the chattr +C is rejected on an
+		// inode that still carries it.
 		if !slices.Contains(mountOptions, "datacow") && !compressed {
+			_, _ = subprocess.RunCommand("chattr", "-c", volPath)
+
 			_, err = subprocess.RunCommand("chattr", "+C", volPath)
 			if err != nil {
 				return fmt.Errorf("Failed setting nodatacow on %q: %w", volPath, err)

--- a/internal/server/storage/drivers/driver_btrfs_volumes.go
+++ b/internal/server/storage/drivers/driver_btrfs_volumes.go
@@ -1029,16 +1029,29 @@ func (d *btrfs) HasVolume(vol Volume) (bool, error) {
 	return genericVFSHasVolume(vol)
 }
 
+// commonVolumeRules returns validation rules which are common for pool and volume.
+func (d *btrfs) commonVolumeRules() map[string]func(value string) error {
+	return map[string]func(value string) error{
+		// gendoc:generate(entity=storage_volume_btrfs, group=common, key=btrfs.compression)
+		//
+		// ---
+		//  type: string
+		//  condition: appropriate driver
+		//  default: same as `volume.btrfs.compression`
+		//  shortdesc: Compression algorithm to set on the volume, mapping to the Btrfs `compression` property (for example `zstd`, `lzo`, `zlib` or `none`)
+		"btrfs.compression": validate.Optional(func(value string) error {
+			algo, _, _ := strings.Cut(value, ":")
+			if !slices.Contains([]string{"none", "no", "zlib", "lzo", "zstd"}, algo) {
+				return fmt.Errorf("Unsupported compression algorithm %q", value)
+			}
+
+			return nil
+		}),
+	}
+}
+
 // ValidateVolume validates the supplied volume config.
 func (d *btrfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
-	// gendoc:generate(entity=storage_volume_btrfs, group=common, key=btrfs.compression)
-	//
-	// ---
-	//  type: string
-	//  condition: appropriate driver
-	//  default: same as `volume.btrfs.compression`
-	//  shortdesc: Compression algorithm to set on the volume, mapping to the Btrfs `compression` property (for example `zstd`, `lzo`, `zlib` or `none`)
-
 	// gendoc:generate(entity=storage_volume_btrfs, group=common, key=initial.gid)
 	//
 	// ---
@@ -1135,18 +1148,7 @@ func (d *btrfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	//  default: same as `volume.size`
 	//  shortdesc: Size/quota of the storage bucket
 
-	rules := map[string]func(value string) error{
-		"btrfs.compression": validate.Optional(func(value string) error {
-			algo, _, _ := strings.Cut(value, ":")
-			if !slices.Contains([]string{"none", "no", "zlib", "lzo", "zstd"}, algo) {
-				return fmt.Errorf("Unsupported compression algorithm %q", value)
-			}
-
-			return nil
-		}),
-	}
-
-	return d.validateVolume(vol, rules, removeUnknownKeys)
+	return d.validateVolume(vol, d.commonVolumeRules(), removeUnknownKeys)
 }
 
 // UpdateVolume applies config changes to the volume.

--- a/test/suites/storage_driver_btrfs.sh
+++ b/test/suites/storage_driver_btrfs.sh
@@ -20,6 +20,27 @@ test_storage_driver_btrfs() {
         incus storage create "incustest-$(basename "${INCUS_DIR}")-pool1" btrfs
         incus storage create "incustest-$(basename "${INCUS_DIR}")-pool2" btrfs
 
+        # btrfs.compression: "none" applies nodatacow to block volumes, a real
+        # algorithm compresses instead, and it is accepted as a pool-wide
+        # volume default.
+        compPool="incustest-$(basename "${INCUS_DIR}")-pool1"
+        compPath="${INCUS_DIR}/storage-pools/${compPool}/custom"
+
+        incus storage volume create "${compPool}" vol-nocow --type=block size=32MiB btrfs.compression=none
+        lsattr -d "${compPath}/default_vol-nocow" | awk '{print $1}' | grep -q "C"
+
+        incus storage volume create "${compPool}" vol-zstd --type=block size=32MiB btrfs.compression=zstd
+        lsattr -d "${compPath}/default_vol-zstd" | awk '{print $1}' | grep -q "c"
+
+        incus storage set "${compPool}" volume.btrfs.compression=none
+        incus storage volume create "${compPool}" vol-default --type=block size=32MiB
+        lsattr -d "${compPath}/default_vol-default" | awk '{print $1}' | grep -q "C"
+        incus storage unset "${compPool}" volume.btrfs.compression
+
+        incus storage volume delete "${compPool}" vol-nocow
+        incus storage volume delete "${compPool}" vol-zstd
+        incus storage volume delete "${compPool}" vol-default
+
         # Set default storage pool for image import.
         incus profile device add default root disk path="/" pool="incustest-$(basename "${INCUS_DIR}")-pool1"
 


### PR DESCRIPTION
Follow-up to #3511. After it merged I did some more testing and ran into two things that don't actually work, so this fixes both.

First, `btrfs.compression=none` doesn't enable nodatacow, it breaks volume creation. For `none` we ran `btrfs property set ... compression none`, which sets the nocompress flag on the inode, and the kernel won't allow `chattr +C` on an inode that already carries a compression flag (compress or nocompress). So the `+C` failed and the create got aborted. This wires `none` to apply the nodatacow chattr directly, like you suggested, and clears any inherited compression flag first so it also works when the volume sits under a compressed parent subvolume.

Second, `volume.btrfs.compression` was never accepted pool-wide, for any value. The Btrfs pool validator was passing `nil` for its volume rules, so none of the driver's volume options got exposed with the `volume.*` prefix (lvm passes `commonVolumeRules()` there). I factored the rule into `commonVolumeRules()` the same way and passed it to `validatePool`, so `volume.btrfs.compression=...` works as a pool default now.

There's a test in the Btrfs suite covering both: a block volume with `btrfs.compression=none` comes out nodatacow, a real algorithm compresses instead, and `volume.btrfs.compression` is accepted pool-wide. I confirmed it fails against the pre-fix code (the create errors out and the pool option gets rejected), so it does catch the regressions.

Sorry for missing these on the original PR.
