### PR TITLE
Fix typo in documented behavior in setting `restricted.containers.privilege` to `isolated`

### DIFF
--- a/cmd/incusd/api_project.go
+++ b/cmd/incusd/api_project.go
@@ -1660,7 +1660,7 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		// Possible values are `unprivileged`, `isolated`, and `allow`.
 		//
 		// - When set to `unprivileged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.
-		// - When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `true`.
+		// - When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `false`.
 		// - When set to `allow`, there is no restriction.
 		// ---
 		//  type: string

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -4678,7 +4678,7 @@ When set to `allow`, {config:option}`instance-security:security.nesting` can be 
 Possible values are `unprivileged`, `isolated`, and `allow`.
 
 - When set to `unprivileged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.
-- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `true`.
+- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `false`.
 - When set to `allow`, there is no restriction.
 ```
 

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -5267,7 +5267,7 @@
 					{
 						"restricted.containers.privilege": {
 							"defaultdesc": "`unprivileged`",
-							"longdesc": "Possible values are `unprivileged`, `isolated`, and `allow`.\n\n- When set to `unprivileged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.\n- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `true`.\n- When set to `allow`, there is no restriction.",
+							"longdesc": "Possible values are `unprivileged`, `isolated`, and `allow`.\n\n- When set to `unprivileged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.\n- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `false`.\n- When set to `allow`, there is no restriction.",
 							"shortdesc": "Which settings for privileged containers to prevent",
 							"type": "string"
 						}


### PR DESCRIPTION
This PR documents the behavior of setting `restricted.containers.privilege` to `isolated` on a project in the configurable options index.

**Additional Context:**
Currently, Incus's configurable options index documents setting the `restricted.containers.privilege` key to `isolated` on a project as preventing setting `security.idmap.isolated` to `true` on an instance.

The actual behavior is the opposite according to [internal/server/project/permissions.go L631-634](https://github.com/lxc/incus/blob/39fc84139dc6c88fe070bc6f81684af80f5cd4b9/internal/server/project/permissions.go#L631-L634).

Other areas of the documentation (and general logic to why an isolated option would exist) suggest the codepath is correct and the definition contained within the configurable options index is a typo.