### PR TITLE
feat: Add `bgp.ovn.active_chassis_only` config option

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+export CGO_CFLAGS="-I/home/jakob/go/deps/raft/include/ -I/home/jakob/go/deps/cowsql/include/"
+export CGO_LDFLAGS="-L/home/jakob/go/deps/raft/.libs -L/home/jakob/go/deps/cowsql/.libs/"
+export LD_LIBRARY_PATH="/home/jakob/go/deps/raft/.libs/:/home/jakob/go/deps/cowsql/.libs/"
+export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
+export PATH="${PATH}:$(go env GOPATH)/bin"

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -4012,6 +4012,14 @@ User keys can be used in search.
 
 <!-- config group network_macvlan-common end -->
 <!-- config group network_ovn-common start -->
+```{config:option} bgp.ovn.active_chassis_only network_ovn-common
+:condition: "BGP server"
+:default: "`false`"
+:shortdesc: "Only announce the network's BGP prefixes from the cluster member hosting the active OVN gateway"
+:type: "bool"
+
+```
+
 ```{config:option} bridge.external_interfaces network_ovn-common
 :scope: "local"
 :shortdesc: "Comma-separated list of unconfigured network interfaces to include in the bridge"

--- a/doc/howto/network_bgp.md
+++ b/doc/howto/network_bgp.md
@@ -87,3 +87,14 @@ Set the following configuration options on the uplink network:
 
 Once the uplink network is configured, downstream OVN networks will get their external subnets and addresses announced over BGP.
 The next-hop is set to the address of the OVN router on the uplink network.
+
+### Announce OVN networks only from the active gateway
+
+By default, every cluster member announces an OVN network's prefixes, all using the OVN router's uplink address as the next-hop.
+This relies on the uplink network being a shared layer 2 segment between cluster members, so that the next-hop stays reachable wherever the active OVN gateway runs.
+
+To avoid that layer 2 requirement, set `bgp.ovn.active_chassis_only=true` on the OVN network.
+When enabled, only the cluster member currently hosting the active OVN gateway chassis announces the network's prefixes (network subnets, address forwards, and load balancers).
+On failover, the gaining member starts announcing and the losing member withdraws its prefixes automatically.
+
+This allows each cluster member to use an independent (layer 3 only) uplink: configure a local transit bridge with the same subnet on every member, and let a local routing daemon re-advertise the announced prefixes towards the fabric with next-hop-self.

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -4487,6 +4487,15 @@
 			"common": {
 				"keys": [
 					{
+						"bgp.ovn.active_chassis_only": {
+							"condition": "BGP server",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Only announce the network's BGP prefixes from the cluster member hosting the active OVN gateway",
+							"type": "bool"
+						}
+					},
+					{
 						"bridge.external_interfaces": {
 							"longdesc": "",
 							"scope": "local",

--- a/internal/server/network/driver_common.go
+++ b/internal/server/network/driver_common.go
@@ -98,6 +98,10 @@ type common struct {
 	status      string
 	managed     bool
 	nodes       map[int64]db.NetworkNode
+
+	// bgpAnnounceCheck, when set, gates whether this cluster member currently exports
+	// the network's BGP prefixes. Nil means always announce.
+	bgpAnnounceCheck func() (bool, error)
 }
 
 // init initialize internal variables.
@@ -771,15 +775,35 @@ func (n *common) bgpNextHopAddress(ipVersion uint) net.IP {
 	return nextHopAddr
 }
 
+// bgpShouldAnnouncePrefixes reports whether this cluster member should currently export
+// the network's BGP prefixes. Defaults to true.
+func (n *common) bgpShouldAnnouncePrefixes() (bool, error) {
+	if n.bgpAnnounceCheck == nil {
+		return true, nil
+	}
+
+	return n.bgpAnnounceCheck()
+}
+
 // bgpSetupPrefixes refreshes the prefix list for the network.
 func (n *common) bgpSetupPrefixes(oldConfig map[string]string) error {
-	// Clear existing prefixes.
 	bgpOwner := fmt.Sprintf("network_%d", n.id)
-	if oldConfig != nil {
+
+	announce, err := n.bgpShouldAnnouncePrefixes()
+	if err != nil {
+		return err
+	}
+
+	// Clear existing prefixes when reconfiguring, or whenever this member must not announce.
+	if oldConfig != nil || !announce {
 		err := n.state.BGP.RemovePrefixByOwner(bgpOwner)
 		if err != nil {
 			return err
 		}
+	}
+
+	if !announce {
+		return nil
 	}
 
 	// Add the new prefixes.
@@ -1067,9 +1091,21 @@ func (n *common) ForwardDelete(listenAddress string, clientType request.ClientTy
 
 // forwardBGPSetupPrefixes exports external forward addresses as prefixes.
 func (n *common) forwardBGPSetupPrefixes() error {
+	bgpOwner := fmt.Sprintf("network_%d_forward", n.id)
+
+	announce, err := n.bgpShouldAnnouncePrefixes()
+	if err != nil {
+		return err
+	}
+
+	// If this member must not announce, withdraw any existing prefixes and stop.
+	if !announce {
+		return n.state.BGP.RemovePrefixByOwner(bgpOwner)
+	}
+
 	var fwdListenAddresses map[int64]string
 
-	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		// Retrieve network forwards before clearing existing prefixes, and separate them by IP family.
@@ -1109,10 +1145,6 @@ func (n *common) forwardBGPSetupPrefixes() error {
 			fwdListenAddressesByFamily[4] = append(fwdListenAddressesByFamily[4], fwdListenAddress)
 		}
 	}
-
-	// Use forward specific owner string (different from the network prefixes) so that these can be reapplied
-	// independently of the network's own prefixes.
-	bgpOwner := fmt.Sprintf("network_%d_forward", n.id)
 
 	// Clear existing address forward prefixes for network.
 	err = n.state.BGP.RemovePrefixByOwner(bgpOwner)

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -135,7 +135,46 @@ func (n *ovn) init(s *state.State, id int64, projectName string, netInfo *api.Ne
 		n.ovnsb = ovnsb
 	}
 
-	return n.common.init(s, id, projectName, netInfo, netNodes)
+	err := n.common.init(s, id, projectName, netInfo, netNodes)
+	if err != nil {
+		return err
+	}
+
+	// Restrict BGP announcements to the active gateway chassis when requested.
+	n.bgpAnnounceCheck = n.bgpShouldAnnounce
+
+	return nil
+}
+
+// bgpShouldAnnounce reports whether the local member is the active gateway chassis for this
+// network and should therefore export its BGP prefixes. When bgp.ovn.active_chassis_only is
+// disabled (the default) all members announce and this always returns true.
+func (n *ovn) bgpShouldAnnounce() (bool, error) {
+	// Isolated networks have no uplink, so they never participate in BGP.
+	if n.config["network"] == "none" {
+		return false, nil
+	}
+
+	if util.IsFalseOrEmpty(n.config["bgp.ovn.active_chassis_only"]) {
+		return true, nil
+	}
+
+	chassisName, err := n.getActiveChassisName()
+	if err != nil {
+		return false, err
+	}
+
+	return n.isLocalChassis(chassisName), nil
+}
+
+// isLocalChassis reports whether the given OVN chassis name refers to the local cluster member,
+// matching either the cluster member name or the OS hostname.
+func (n *ovn) isLocalChassis(chassisName string) bool {
+	if chassisName == "" {
+		return false
+	}
+
+	return chassisName == n.state.ServerName || chassisName == n.state.OS.Hostname
 }
 
 // DBType returns the network type DB ID.
@@ -746,6 +785,15 @@ func (n *ovn) Validate(config map[string]string, clientType request.ClientType) 
 		//  default: `false`
 		//  condition: `security.acls`
 		"security.acls.default.egress.logged": validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=bgp.ovn.active_chassis_only)
+		//
+		// ---
+		//  type: bool
+		//  condition: BGP server
+		//  default: `false`
+		//  shortdesc: Only announce the network's BGP prefixes from the cluster member hosting the active OVN gateway
+		"bgp.ovn.active_chassis_only": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=user.*)
 		//
@@ -3945,6 +3993,11 @@ func (n *ovn) Start() error {
 					return
 				}
 
+				announce, err := n.bgpShouldAnnounce()
+				if err != nil {
+					return
+				}
+
 				for _, lb := range lbs {
 					// Check for status of all backends on this load-balancer.
 					online, err := n.ovnsb.CheckLoadBalancerOnline(context.TODO(), lb)
@@ -3993,8 +4046,8 @@ func (n *ovn) Start() error {
 						return
 					}
 
-					// Update the BGP state.
-					if online {
+					// Update the BGP state. Only the active gateway chassis announces (when enabled).
+					if online && announce {
 						err = n.state.BGP.AddPrefix(*ipRouteSubnet, nextHopAddr, bgpOwner)
 						if err != nil {
 							return
@@ -4013,6 +4066,23 @@ func (n *ovn) Start() error {
 				}
 
 				err := n.updateTunnels(n.config, []string{}, true)
+				if err != nil {
+					return
+				}
+
+				// The active gateway chassis just changed; refresh BGP prefixes so the gaining
+				// member starts announcing and the losing member withdraws.
+				err = n.bgpSetupPrefixes(nil)
+				if err != nil {
+					return
+				}
+
+				err = n.forwardBGPSetupPrefixes()
+				if err != nil {
+					return
+				}
+
+				err = n.loadBalancerBGPSetupPrefixes()
 				if err != nil {
 					return
 				}
@@ -8255,6 +8325,15 @@ func (n *ovn) loadBalancerBGPSetupPrefixes() error {
 		return err
 	}
 
+	announce, err := n.bgpShouldAnnounce()
+	if err != nil {
+		return err
+	}
+
+	if !announce {
+		return nil
+	}
+
 	// Add the new prefixes.
 	for _, ipVersion := range []uint{4, 6} {
 		nextHopAddr := n.bgpNextHopAddress(ipVersion)
@@ -8377,7 +8456,7 @@ func (n *ovn) updateTunnels(newConfig map[string]string, changedKeys []string, r
 		return err
 	}
 
-	if chassisName == n.state.ServerName || chassisName == n.state.OS.Hostname {
+	if n.isLocalChassis(chassisName) {
 		err := n.deleteTunnels(changedKeys, true, reinitialize)
 		if err != nil {
 			return err


### PR DESCRIPTION
When enabled, each incus node only announces prefixes for the ovn networks that also have their active ovn gateway on that node. 

Also generally disables pushing ovn prefixes with no uplink to BGP (as there is never a valid next-hop).

###  Why?

We have a setup where our incus nodes do not have a shared L2 connection but we would still want to use OVN networks with uplink.
My plan was to configure the same transit uplink network on each node, but its not connected between the nodes.
Currently all nodes announce all OVN prefixes. However, this requires that the Uplink network is shared between all nodes, which isn't the case in our setup.

This MR adds the option that only the active OVN chassis announces the OVN prefix.

I am also open to other suggestions on how we can solve our problem.
(We are currently using routed NICs, but this doesn't work well with Kubernetes CAPI, etc. as it requires quite complex configuration of the incus instance, and routed NICs can't be supplied by a managed network (see #2702))