### PR TITLE
Fix typo in documented behavior in setting `restricted.containers.privilege` to `isolated`

### DIFF
--- a/cmd/incusd/api_project.go
+++ b/cmd/incusd/api_project.go
@@ -1660,7 +1660,7 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		// Possible values are `unprivileged`, `isolated`, and `allow`.
 		//
 		// - When set to `unprivileged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.
-		// - When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `false`.
+		// - When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` to `true` and {config:option}`instance-security:security.idmap.isolated` to `false`.
 		// - When set to `allow`, there is no restriction.
 		// ---
 		//  type: string

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -4678,7 +4678,7 @@ When set to `allow`, {config:option}`instance-security:security.nesting` can be 
 Possible values are `unprivileged`, `isolated`, and `allow`.
 
 - When set to `unprivileged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.
-- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `false`.
+- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` to `true` and {config:option}`instance-security:security.idmap.isolated` to `false`.
 - When set to `allow`, there is no restriction.
 ```
 

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -5267,7 +5267,7 @@
 					{
 						"restricted.containers.privilege": {
 							"defaultdesc": "`unprivileged`",
-							"longdesc": "Possible values are `unprivileged`, `isolated`, and `allow`.\n\n- When set to `unprivileged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.\n- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `false`.\n- When set to `allow`, there is no restriction.",
+							"longdesc": "Possible values are `unprivileged`, `isolated`, and `allow`.\n\n- When set to `unprivileged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.\n- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` to `true` and {config:option}`instance-security:security.idmap.isolated` to `false`.\n- When set to `allow`, there is no restriction.",
 							"shortdesc": "Which settings for privileged containers to prevent",
 							"type": "string"
 						}


### PR DESCRIPTION
This PR documents the behavior of setting `restricted.containers.privilege` to `isolated` on a project in the configurable options index.

**Additional Context:**
Recently, #3545 was merged, fixing a discrepancy in the configurable options index of the behavior of `security.idmap.isolated` when setting `restricted.containers.privilege` to `isolated` on a project.

This fix actually introduced a similar discrepancy to the documented behavior of `security.privileged`, stating `isolated` prevents `security.privileged` from being set to `false`, when in reality, it prevents `security.privileged` from being set to `true`.