### PR TITLE
doc: fix `config set` deprectation warning

### DIFF
--- a/doc/howto/cluster_config_networks.md
+++ b/doc/howto/cluster_config_networks.md
@@ -46,7 +46,7 @@ To do so, you must specify different addresses for {config:option}`server-cluste
 1. After joining your members, set the `core.https_address` configuration to the address for the REST API.
    For example:
 
-       incus config set core.https_address 0.0.0.0:8443
+       incus config set core.https_address=0.0.0.0:8443
 
    ```{note}
    `core.https_address` is specific to the cluster member, so you can use different addresses on different members.

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -61,7 +61,7 @@ You can check this with [`incus cluster list`](incus_cluster_list.md).
 
 If you are intending to convert an existing Incus server with instances into the bootstrap server for a new cluster, there is a slightly different procedure.
 
-Firstly, ensure the `core.https_address` (or `cluster.https_address`) is configured to a specific IP or DNS address using `incus config set core.https_address [IP_OR_DNS]:8443`. The default wildcard value cannot be used in clustered mode.
+Firstly, ensure the `core.https_address` (or `cluster.https_address`) is configured to a specific IP or DNS address using `incus config set core.https_address=[IP_OR_DNS]:8443`. The default wildcard value cannot be used in clustered mode.
 
 Then you can run `incus cluster enable memberName` and continue with the steps below to join in additional cluster members.
 

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -32,7 +32,7 @@ To see state and usage information for a cluster member, run the following comma
 To configure your cluster, use [`incus config`](incus_config.md).
 For example:
 
-    incus config set cluster.max_voters 5
+    incus config set cluster.max_voters=5
 
 Keep in mind that some {ref}`server configuration options <server>` are global and others are local.
 You can configure the global options on any cluster member, and the changes are propagated to the other cluster members through the distributed database.

--- a/doc/howto/instances_backup.md
+++ b/doc/howto/instances_backup.md
@@ -87,11 +87,11 @@ To do so, set the {config:option}`instance-snapshots:snapshots.schedule` instanc
 
 For example, to configure daily snapshots, use the following command:
 
-    incus config set <instance_name> snapshots.schedule @daily
+    incus config set <instance_name> snapshots.schedule=@daily
 
 To configure taking a snapshot every day at 6 am, use the following command:
 
-    incus config set <instance_name> snapshots.schedule "0 6 * * *"
+    incus config set <instance_name> snapshots.schedule="0 6 * * *"
 
 When scheduling regular snapshots, consider setting an automatic expiry ({config:option}`instance-snapshots:snapshots.expiry`) and a naming pattern for snapshots ({config:option}`instance-snapshots:snapshots.pattern`).
 You should also configure whether you want to take snapshots of instances that are not running ({config:option}`instance-snapshots:snapshots.schedule.stopped`).

--- a/doc/howto/instances_troubleshoot.md
+++ b/doc/howto/instances_troubleshoot.md
@@ -50,12 +50,12 @@ As this is an unprivileged container, `systemd` does not have the ability to do 
 So you can see the environment before anything is changed, and you can explicitly change the init system in a container using the `raw.lxc` configuration parameter.
 This is equivalent to setting `init=/bin/bash` on the Linux kernel command line.
 
-    incus config set systemd raw.lxc 'lxc.init.cmd = /bin/bash'
+    incus config set systemd raw.lxc='lxc.init.cmd = /bin/bash'
 
 Here is what it looks like:
 
 ```{terminal}
-:input: incus config set systemd raw.lxc 'lxc.init.cmd = /bin/bash'
+:input: incus config set systemd raw.lxc='lxc.init.cmd = /bin/bash'
 
 :input: incus start systemd
 :input: incus console --show-log systemd

--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -156,7 +156,7 @@ In addition, you can add any number of servers to the Incus cluster that run onl
 1. Still on the first machine, configure Incus to be able to communicate with the OVN DB cluster.
    To do so, find the value for `ovn-northd-nb-db` in `/etc/default/ovn-central` and provide it to Incus with the following command:
 
-       incus config set network.ovn.northbound_connection <ovn-northd-nb-db>
+       incus config set network.ovn.northbound_connection=<ovn-northd-nb-db>
 
 1. Finally, create the actual OVN network (on the first machine):
 

--- a/doc/howto/server_configure.md
+++ b/doc/howto/server_configure.md
@@ -10,16 +10,16 @@ In the {ref}`server` option tables, options that apply to the cluster are marked
 
 You can configure a server option with the following command:
 
-    incus config set <key> <value>
+    incus config set <key>=<value>
 
 For example, to allow remote access to the Incus server on port 8443, enter the following command:
 
-    incus config set core.https_address :8443
+    incus config set core.https_address=:8443
 
 In a cluster setup, to configure a server option for a cluster member only, add the `--target` flag.
 For example, to configure where to store image tarballs on a specific cluster member, enter a command similar to the following:
 
-    incus config set storage.images_volume my-pool/my-volume --target member02
+    incus config set storage.images_volume=my-pool/my-volume --target member02
 
 ## Display the server configuration
 

--- a/doc/howto/server_expose.md
+++ b/doc/howto/server_expose.md
@@ -8,7 +8,7 @@ To do so, set the {config:option}`server-core:core.https_address` server configu
 
 For example, to allow access to the Incus server on port `8443`, enter the following command:
 
-    incus config set core.https_address :8443
+    incus config set core.https_address=:8443
 
 To allow access through a specific IP address, use `ip addr` to find an available address and then set it.
 For example:
@@ -36,7 +36,7 @@ For example:
        valid_lft forever preferred_lft forever
     inet6 fd42:f4ab:4399:e6eb::1/64 scope global
        valid_lft forever preferred_lft forever
-:input: incus config set core.https_address 10.68.216.12
+:input: incus config set core.https_address=10.68.216.12
 ```
 
 All remote clients can then connect to Incus and access any image that is marked for public use.

--- a/doc/howto/storage_buckets.md
+++ b/doc/howto/storage_buckets.md
@@ -11,7 +11,7 @@ This is the address that you can then use to access the buckets through the S3 p
 To configure the S3 address, set the {config:option}`server-core:core.storage_buckets_address` server configuration option.
 For example:
 
-    incus config set core.storage_buckets_address :8555
+    incus config set core.storage_buckets_address=:8555
 
 ## Manage storage buckets
 

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -100,11 +100,11 @@ To do so, you must set the corresponding {ref}`server configuration <server-opti
 
 - To use a custom volume to store the backup tarballs:
 
-      incus config set storage.backups_volume <pool_name>/<volume_name>
+      incus config set storage.backups_volume=<pool_name>/<volume_name>
 
 - To use a custom volume to store the image tarballs:
 
-      incus config set storage.images_volume <pool_name>/<volume_name>
+      incus config set storage.images_volume=<pool_name>/<volume_name>
 
 (storage-configure-volume)=
 ## Configure storage volume settings


### PR DESCRIPTION
These changes fixes the following warning that started to appear with Incus 7.x:

	Warning: the “<key> <value>” syntax is deprecated;
	please switch to the “<key>=<value>” syntax

The new syntax was tested on the 6.x release available in Debian trixie and was found to work, so I think this is a reasonable change to make.