### PR TITLE
Add a native-context GPU type for VMs (virtio-gpu DRM native context)

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3256,3 +3256,12 @@ upgrade.
 
 ## `network_allocations_network`
 Adds the `network` field to the network allocations API response.
+
+## `gpu_native_context`
+
+This adds a new `native-context` `gputype` for `gpu` devices on virtual machines.
+Instead of passing through a PCI device, it gives the VM an accelerated `virtio-gpu`
+that uses DRM native context, so the guest's own driver drives the host GPU
+directly, with graphics and video acceleration. One host GPU can be shared by several
+VMs and the host keeps using it. The `blob.size` device option sets the
+host-visible blob window (default 2GiB). Requires QEMU 11.0.0 or newer.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -333,6 +333,44 @@ With VMs, this option supports mounting file system disk devices and paths withi
 ```
 
 <!-- config group devices-gpu_mig end -->
+<!-- config group devices-gpu_native_context start -->
+```{config:option} blob.size devices-gpu_native_context
+:default: "2GiB"
+:required: "no"
+:shortdesc: "Size of the host-visible blob memory window for the `virtio-gpu` device"
+:type: "string"
+
+```
+
+```{config:option} id devices-gpu_native_context
+:required: "no"
+:shortdesc: "The DRM card ID of the GPU device"
+:type: "string"
+
+```
+
+```{config:option} pci devices-gpu_native_context
+:required: "no"
+:shortdesc: "The PCI address of the GPU device"
+:type: "string"
+
+```
+
+```{config:option} productid devices-gpu_native_context
+:required: "no"
+:shortdesc: "The product ID of the GPU device"
+:type: "string"
+
+```
+
+```{config:option} vendorid devices-gpu_native_context
+:required: "no"
+:shortdesc: "The vendor ID of the GPU device"
+:type: "string"
+
+```
+
+<!-- config group devices-gpu_native_context end -->
 <!-- config group devices-gpu_physical start -->
 ```{config:option} gid devices-gpu_physical
 :default: "0"

--- a/doc/reference/devices_gpu.md
+++ b/doc/reference/devices_gpu.md
@@ -15,6 +15,7 @@ The following types of GPUs can be added using the `gputype` device option:
 - [`mdev`](gpu-mdev) (VM only): Creates and passes a virtual GPU through into the instance.
 - [`mig`](gpu-mig) (container only): Creates and passes a MIG (Multi-Instance GPU) through into the instance.
 - [`sriov`](gpu-sriov) (VM only): Passes a virtual function of an SR-IOV-enabled GPU into the instance.
+- [`native-context`](gpu-native-context) (VM only): Gives the VM GPU acceleration through `virtio-gpu` DRM native context, without passing the GPU through.
 
 The available device options depend on the GPU type and are listed in the tables in the following sections.
 
@@ -100,4 +101,33 @@ GPU devices of type `sriov` have the following device options:
 ```{include} ../config_options.txt
     :start-after: <!-- config group devices-gpu_sriov start -->
     :end-before: <!-- config group devices-gpu_sriov end -->
+```
+
+(gpu-native-context)=
+## `gputype`: `native-context`
+
+```{note}
+The `native-context` GPU type is supported only for VMs.
+It does not support hotplugging.
+```
+
+A `native-context` GPU device gives the VM GPU acceleration through `virtio-gpu` DRM native context.
+The host GPU is not passed through or rebound to `vfio-pci`; it stays owned by the host and is shared with the guest, so the host can keep using it at the same time.
+
+This requires QEMU 11.0.0 or newer and `virglrenderer` on the host built with DRM native context support.
+DRM native context was introduced in `virglrenderer` 1.0.0, but the version needed in practice depends on the GPU and kernel (for example, AMD support became usable around 1.1 and Intel around 1.3).
+It also needs a host GPU and guest driver that support DRM native context, and a guest with a matching `virtio-gpu` DRM driver.
+
+The selector options below are optional.
+If a GPU is selected, its DRM render node is used as the render node for the QEMU `egl-headless` display.
+If no GPU is selected, QEMU uses its default render node.
+
+### Device options
+
+GPU devices of type `native-context` have the following device options:
+
+% Include content from [config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group devices-gpu_native_context start -->
+    :end-before: <!-- config group devices-gpu_native_context end -->
 ```

--- a/internal/linux/acl.go
+++ b/internal/linux/acl.go
@@ -1,0 +1,125 @@
+package linux
+
+import (
+	"cmp"
+	"encoding/binary"
+	"errors"
+	"slices"
+
+	"golang.org/x/sys/unix"
+)
+
+const posixACLXattr = "system.posix_acl_access"
+
+// POSIX ACL xattr encoding (include/uapi/linux/posix_acl_xattr.h).
+const (
+	posixACLVersion = 2
+
+	aclUserObj  = 0x01
+	aclUser     = 0x02
+	aclGroupObj = 0x04
+	aclGroup    = 0x08
+	aclMask     = 0x10
+	aclOther    = 0x20
+
+	aclUndefinedID = 0xFFFFFFFF
+)
+
+type aclEntry struct {
+	tag  uint16
+	perm uint16
+	id   uint32
+}
+
+// GrantPosixACLUser grants the provided permissions ("rwx" bits) to a uid on path,
+// creating or extending the POSIX access ACL as needed.
+func GrantPosixACLUser(path string, uid uint32, perm uint16) error {
+	var entries []aclEntry
+
+	// Retrieve the current ACL if any.
+	sz, err := unix.Getxattr(path, posixACLXattr, nil)
+	if err != nil && !errors.Is(err, unix.ENODATA) {
+		return err
+	}
+
+	if err == nil {
+		buf := make([]byte, sz)
+
+		sz, err = unix.Getxattr(path, posixACLXattr, buf)
+		if err != nil {
+			return err
+		}
+
+		if sz < 4 || (sz-4)%8 != 0 || binary.LittleEndian.Uint32(buf) != posixACLVersion {
+			return errors.New("Invalid POSIX ACL xattr")
+		}
+
+		for off := 4; off < sz; off += 8 {
+			entries = append(entries, aclEntry{
+				tag:  binary.LittleEndian.Uint16(buf[off:]),
+				perm: binary.LittleEndian.Uint16(buf[off+2:]),
+				id:   binary.LittleEndian.Uint32(buf[off+4:]),
+			})
+		}
+	} else {
+		// No ACL set, derive the base entries from the file mode.
+		var st unix.Stat_t
+
+		err = unix.Stat(path, &st)
+		if err != nil {
+			return err
+		}
+
+		entries = []aclEntry{
+			{tag: aclUserObj, perm: uint16(st.Mode>>6) & 0o7, id: aclUndefinedID},
+			{tag: aclGroupObj, perm: uint16(st.Mode>>3) & 0o7, id: aclUndefinedID},
+			{tag: aclOther, perm: uint16(st.Mode) & 0o7, id: aclUndefinedID},
+		}
+	}
+
+	// Add or extend the user entry.
+	idx := slices.IndexFunc(entries, func(e aclEntry) bool { return e.tag == aclUser && e.id == uid })
+	if idx >= 0 {
+		entries[idx].perm |= perm
+	} else {
+		entries = append(entries, aclEntry{tag: aclUser, perm: perm, id: uid})
+	}
+
+	// Recompute the mask as the union of all group-class entries.
+	mask := uint16(0)
+	maskIdx := -1
+	for i, e := range entries {
+		switch e.tag {
+		case aclUser, aclGroupObj, aclGroup:
+			mask |= e.perm
+		case aclMask:
+			maskIdx = i
+		}
+	}
+
+	if maskIdx >= 0 {
+		entries[maskIdx].perm = mask
+	} else {
+		entries = append(entries, aclEntry{tag: aclMask, perm: mask, id: aclUndefinedID})
+	}
+
+	// The kernel expects entries ordered by tag, then qualifier.
+	slices.SortStableFunc(entries, func(a, b aclEntry) int {
+		if a.tag != b.tag {
+			return cmp.Compare(a.tag, b.tag)
+		}
+
+		return cmp.Compare(a.id, b.id)
+	})
+
+	buf := make([]byte, 4+8*len(entries))
+	binary.LittleEndian.PutUint32(buf, posixACLVersion)
+	for i, e := range entries {
+		off := 4 + 8*i
+		binary.LittleEndian.PutUint16(buf[off:], e.tag)
+		binary.LittleEndian.PutUint16(buf[off+2:], e.perm)
+		binary.LittleEndian.PutUint32(buf[off+4:], e.id)
+	}
+
+	return unix.Setxattr(path, posixACLXattr, buf, 0)
+}

--- a/internal/server/apparmor/instance.go
+++ b/internal/server/apparmor/instance.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	deviceConfig "github.com/lxc/incus/v7/internal/server/device/config"
 	"github.com/lxc/incus/v7/internal/server/instance/drivers/edk2"
 	"github.com/lxc/incus/v7/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v7/internal/server/project"
@@ -26,6 +27,7 @@ type instance interface {
 	Name() string
 	ID() int
 	ExpandedConfig() map[string]string
+	ExpandedDevices() deviceConfig.Devices
 	Type() instancetype.Type
 	LogPath() string
 	RunPath() string
@@ -267,20 +269,31 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 			}
 		}
 
+		// Detect whether any GPU device uses virtio-gpu DRM native context, which
+		// needs the QEMU process to access the host DRM render nodes directly.
+		gpuNativeContext := false
+		for _, dev := range inst.ExpandedDevices() {
+			if dev["type"] == "gpu" && dev["gputype"] == "native-context" {
+				gpuNativeContext = true
+				break
+			}
+		}
+
 		err = qemuProfileTpl.Execute(sb, map[string]any{
-			"devicesPath":    inst.DevicesPath(),
-			"exePath":        execPath,
-			"extra_config":   extraConfig,
-			"extra_binaries": extraBinaries,
-			"libraryPath":    strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
-			"logPath":        logPath,
-			"runPath":        inst.RunPath(),
-			"id":             inst.ID(),
-			"name":           InstanceProfileName(inst),
-			"path":           path,
-			"raw":            rawContent.String(),
-			"edk2Paths":      edk2Paths,
-			"agentPath":      agentPath,
+			"devicesPath":      inst.DevicesPath(),
+			"gpuNativeContext": gpuNativeContext,
+			"exePath":          execPath,
+			"extra_config":     extraConfig,
+			"extra_binaries":   extraBinaries,
+			"libraryPath":      strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
+			"logPath":          logPath,
+			"runPath":          inst.RunPath(),
+			"id":               inst.ID(),
+			"name":             InstanceProfileName(inst),
+			"path":             path,
+			"raw":              rawContent.String(),
+			"edk2Paths":        edk2Paths,
+			"agentPath":        agentPath,
 		})
 		if err != nil {
 			return "", err

--- a/internal/server/apparmor/instance_qemu.profile.go
+++ b/internal/server/apparmor/instance_qemu.profile.go
@@ -48,9 +48,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 {{- end }}
   /usr/share/qemu/**                        kr,
   /usr/share/seabios/**                     kr,
-  /etc/nsswitch.conf         r,
-  /etc/passwd                r,
-  /etc/group                 r,
+  /etc/nsswitch.conf                        r,
+  /etc/passwd                               r,
+  /etc/group                                r,
   @{PROC}/version                           r,
 
   # Extra config paths

--- a/internal/server/apparmor/instance_qemu.profile.go
+++ b/internal/server/apparmor/instance_qemu.profile.go
@@ -53,6 +53,22 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /etc/group                                r,
   @{PROC}/version                           r,
 
+{{- if .gpuNativeContext }}
+  # Extra entries needed for virtio-gpu DRM native context
+  /dev/dri/                                 r,
+  /dev/dri/**                               rw,
+
+  deny capability sys_admin,
+  deny /var/lib/incus/.cache/               wklx,
+  /usr/share/drirc.d/                       r,
+  /usr/share/drirc.d/**                     r,
+  /usr/share/glvnd/egl_vendor.d/            r,
+  /usr/share/glvnd/egl_vendor.d/**          r,
+  /usr/share/libdrm/**                      r,
+  /etc/glvnd/egl_vendor.d/                  r,
+  /etc/glvnd/egl_vendor.d/**                r,
+{{- end }}
+
   # Extra config paths
 {{- range $index, $element := .extra_config }}
   {{ $element }}/**                         kr,

--- a/internal/server/device/device_load.go
+++ b/internal/server/device/device_load.go
@@ -68,6 +68,8 @@ func newByType(s *state.State, projectName string, conf deviceConfig.Device) (de
 			dev = &gpuMdev{}
 		case "sriov":
 			dev = &gpuSRIOV{}
+		case "native-context":
+			dev = &gpuNativeContext{}
 		default:
 			dev = &gpuPhysical{}
 		}

--- a/internal/server/device/gpu.go
+++ b/internal/server/device/gpu.go
@@ -22,6 +22,7 @@ func gpuValidationRules(requiredFields []string, optionalFields []string) map[st
 		"mig.ci":    validate.IsUint8,
 		"mig.uuid":  gpuValidMigUUID,
 		"mdev":      validate.IsAny,
+		"blob.size": validate.Optional(validate.IsSize),
 	}
 
 	validators := map[string]func(value string) error{}

--- a/internal/server/device/gpu_native_context.go
+++ b/internal/server/device/gpu_native_context.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/lxc/incus/v7/internal/linux"
 	deviceConfig "github.com/lxc/incus/v7/internal/server/device/config"
 	pcidev "github.com/lxc/incus/v7/internal/server/device/pci"
 	"github.com/lxc/incus/v7/internal/server/instance"
@@ -129,18 +130,17 @@ func (d *gpuNativeContext) Start() (*deviceConfig.RunConfig, error) {
 func (d *gpuNativeContext) startVM() (*deviceConfig.RunConfig, error) {
 	runConf := deviceConfig.RunConfig{}
 
-	// Render node path to hand to QEMU's egl-headless display. Left empty when no GPU is
-	// selected, in which case QEMU/egl-headless falls back to its default render node.
+	// Render node path to hand to QEMU's egl-headless display.
 	rendernode := ""
 
-	// Only resolve a render node when the user actually selected a card. Any of the
+	gpus, err := resources.GetGPU()
+	if err != nil {
+		return nil, err
+	}
+
+	// Only match on selectors when the user actually selected a card. Any of the
 	// standard GPU selector keys may be used to pick which host GPU to accelerate with.
 	if d.config["id"] != "" || d.config["pci"] != "" || d.config["vendorid"] != "" || d.config["productid"] != "" {
-		gpus, err := resources.GetGPU()
-		if err != nil {
-			return nil, err
-		}
-
 		for _, gpu := range gpus.Cards {
 			// Skip any cards that are not selected.
 			if !gpuSelected(d.Config(), gpu) {
@@ -160,6 +160,35 @@ func (d *gpuNativeContext) startVM() (*deviceConfig.RunConfig, error) {
 
 		if rendernode == "" {
 			return nil, errors.New("Failed to detect requested GPU device")
+		}
+	} else {
+		// With no card selected, default to the host GPU with the lowest render node
+		// so the node is known ahead of time and can be made accessible to QEMU.
+		for _, gpu := range gpus.Cards {
+			if gpu.DRM == nil || gpu.DRM.RenderName == "" {
+				continue
+			}
+
+			node := filepath.Join(gpuDRIDevPath, gpu.DRM.RenderName)
+			if rendernode == "" || node < rendernode {
+				rendernode = node
+			}
+		}
+
+		if rendernode == "" {
+			return nil, errors.New("Failed to find a GPU with a DRM render node")
+		}
+	}
+
+	// QEMU runs as an unprivileged user and virglrenderer only opens the render node
+	// once the guest starts using the GPU, well after privileges were dropped. Grant
+	// that user access through a POSIX ACL on the node. The entry is left in place on
+	// stop: it only covers the Incus unprivileged user and AppArmor keeps VMs without
+	// a native context GPU away from the node.
+	if d.state.OS.UnprivUser != "" {
+		err = linux.GrantPosixACLUser(rendernode, d.state.OS.UnprivUID, 0o6)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to grant %q access to %q: %w", d.state.OS.UnprivUser, rendernode, err)
 		}
 	}
 

--- a/internal/server/device/gpu_native_context.go
+++ b/internal/server/device/gpu_native_context.go
@@ -1,0 +1,192 @@
+package device
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	deviceConfig "github.com/lxc/incus/v7/internal/server/device/config"
+	pcidev "github.com/lxc/incus/v7/internal/server/device/pci"
+	"github.com/lxc/incus/v7/internal/server/instance"
+	"github.com/lxc/incus/v7/internal/server/instance/instancetype"
+	"github.com/lxc/incus/v7/shared/resources"
+	"github.com/lxc/incus/v7/shared/units"
+	"github.com/lxc/incus/v7/shared/util"
+)
+
+// gpuNativeContextDefaultBlobSize is the default size of the host-visible blob window
+// (QEMU "hostmem") reserved for the virtio-gpu device when "blob.size" is not set.
+const gpuNativeContextDefaultBlobSize = "2GiB"
+
+type gpuNativeContext struct {
+	deviceCommon
+}
+
+// validateConfig checks the supplied config for correctness.
+func (d *gpuNativeContext) validateConfig(instConf instance.ConfigReader, partialValidation bool) error {
+	// virtio-gpu DRM native context is only meaningful for VMs (host GPU acceleration
+	// is provided to the guest through QEMU's virtio-gpu device, not into a container).
+	if !instanceSupported(instConf.Type(), instancetype.VM) {
+		return ErrUnsupportedDevType
+	}
+
+	optionalFields := []string{
+		// gendoc:generate(entity=devices, group=gpu_native_context, key=vendorid)
+		//
+		// ---
+		//  type: string
+		//  required: no
+		//  shortdesc: The vendor ID of the GPU device
+		"vendorid",
+
+		// gendoc:generate(entity=devices, group=gpu_native_context, key=productid)
+		//
+		// ---
+		//  type: string
+		//  required: no
+		//  shortdesc: The product ID of the GPU device
+		"productid",
+
+		// gendoc:generate(entity=devices, group=gpu_native_context, key=id)
+		//
+		// ---
+		//  type: string
+		//  required: no
+		//  shortdesc: The DRM card ID of the GPU device
+		"id",
+
+		// gendoc:generate(entity=devices, group=gpu_native_context, key=pci)
+		//
+		// ---
+		//  type: string
+		//  required: no
+		//  shortdesc: The PCI address of the GPU device
+		"pci",
+
+		// gendoc:generate(entity=devices, group=gpu_native_context, key=blob.size)
+		//
+		// ---
+		//  type: string
+		//  default: 2GiB
+		//  required: no
+		//  shortdesc: Size of the host-visible blob memory window for the `virtio-gpu` device
+		"blob.size",
+	}
+
+	err := d.config.Validate(gpuValidationRules(nil, optionalFields))
+	if err != nil {
+		return err
+	}
+
+	if d.config["pci"] != "" {
+		for _, field := range []string{"id", "productid", "vendorid"} {
+			if d.config[field] != "" {
+				return fmt.Errorf(`Cannot use %q when "pci" is set`, field)
+			}
+		}
+
+		d.config["pci"] = pcidev.NormaliseAddress(d.config["pci"])
+	}
+
+	if d.config["id"] != "" {
+		for _, field := range []string{"pci", "productid", "vendorid"} {
+			if d.config[field] != "" {
+				return fmt.Errorf(`Cannot use %q when "id" is set`, field)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateEnvironment checks the runtime environment for correctness.
+func (d *gpuNativeContext) validateEnvironment() error {
+	if d.inst.Type() != instancetype.VM {
+		return ErrUnsupportedDevType
+	}
+
+	if util.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return errors.New("GPU devices cannot be used when migration.stateful is enabled")
+	}
+
+	return validatePCIDevice(d.config["pci"])
+}
+
+// Start is run when the device is added to the instance.
+func (d *gpuNativeContext) Start() (*deviceConfig.RunConfig, error) {
+	err := d.validateEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+	return d.startVM()
+}
+
+// startVM resolves the (optionally) selected GPU to its DRM render node and returns
+// the runtime configuration consumed by the QEMU driver. Unlike physical passthrough
+// it does not rebind anything to vfio-pci; the host GPU stays owned by the host and is
+// shared with the guest through QEMU's virtio-gpu DRM native context.
+func (d *gpuNativeContext) startVM() (*deviceConfig.RunConfig, error) {
+	runConf := deviceConfig.RunConfig{}
+
+	// Render node path to hand to QEMU's egl-headless display. Left empty when no GPU is
+	// selected, in which case QEMU/egl-headless falls back to its default render node.
+	rendernode := ""
+
+	// Only resolve a render node when the user actually selected a card. Any of the
+	// standard GPU selector keys may be used to pick which host GPU to accelerate with.
+	if d.config["id"] != "" || d.config["pci"] != "" || d.config["vendorid"] != "" || d.config["productid"] != "" {
+		gpus, err := resources.GetGPU()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, gpu := range gpus.Cards {
+			// Skip any cards that are not selected.
+			if !gpuSelected(d.Config(), gpu) {
+				continue
+			}
+
+			if rendernode != "" {
+				return nil, errors.New("VMs cannot match multiple GPUs per device")
+			}
+
+			if gpu.DRM == nil || gpu.DRM.RenderName == "" {
+				return nil, fmt.Errorf("Selected GPU %q has no DRM render node", gpu.PCIAddress)
+			}
+
+			rendernode = filepath.Join(gpuDRIDevPath, gpu.DRM.RenderName)
+		}
+
+		if rendernode == "" {
+			return nil, errors.New("Failed to detect requested GPU device")
+		}
+	}
+
+	// Resolve the host-visible blob window size, defaulting when unset. It is passed to
+	// the QEMU driver as a byte count for the device's "hostmem" property.
+	blobSize := d.config["blob.size"]
+	if blobSize == "" {
+		blobSize = gpuNativeContextDefaultBlobSize
+	}
+
+	blobSizeBytes, err := units.ParseByteSizeString(blobSize)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid blob.size %q: %w", blobSize, err)
+	}
+
+	runConf.GPUDevice = append(runConf.GPUDevice,
+		[]deviceConfig.RunConfigItem{
+			{Key: "devName", Value: d.name},
+			{Key: "gpuType", Value: "native-context"},
+			{Key: "rendernode", Value: rendernode},
+			{Key: "hostmem", Value: fmt.Sprintf("%d", blobSizeBytes)},
+		}...)
+
+	return &runConf, nil
+}
+
+// Stop is run when the device is removed from the instance.
+func (d *gpuNativeContext) Stop() (*deviceConfig.RunConfig, error) {
+	return &deviceConfig.RunConfig{}, nil
+}

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1846,6 +1846,19 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		qemuArgs = append(qemuArgs, "-spice", spiceConfig)
 	}
 
+	// When a GPU is using virtio-gpu DRM native context, the guest needs a host-backed
+	// GL display. Switch the default headless setup to egl-headless and point it at the
+	// resolved render node (if any) so rendering is offloaded to the host GPU.
+	nativeContext, rendernode, _ := d.gpuNativeContextConfig(devConfs)
+	if nativeContext {
+		display := "egl-headless,gl=on"
+		if rendernode != "" {
+			display += fmt.Sprintf(",rendernode=%s", rendernode)
+		}
+
+		qemuArgs = append(qemuArgs, "-display", display)
+	}
+
 	// If stateful, restore now.
 	if stateful {
 		if d.stateful {
@@ -3902,6 +3915,50 @@ func (d *qemu) onRTCChange(change int) error {
 	return nil
 }
 
+// gpuNativeContextConfig scans the device run configs for a virtio-gpu DRM native
+// context GPU. It returns whether one is present, its resolved host DRM render node
+// (which may be empty, meaning QEMU should use its default render node), and the
+// host-visible blob window size in bytes for the device's hostmem property.
+func (d *qemu) gpuNativeContextConfig(devConfs []*deviceConfig.RunConfig) (bool, string, string) {
+	enabled := false
+	rendernode := ""
+	hostmem := ""
+
+	for _, runConf := range devConfs {
+		isNativeContext := false
+		devRenderNode := ""
+		devHostmem := ""
+
+		for _, item := range runConf.GPUDevice {
+			switch item.Key {
+			case "gpuType":
+				if item.Value == "native-context" {
+					isNativeContext = true
+				}
+
+			case "rendernode":
+				devRenderNode = item.Value
+
+			case "hostmem":
+				devHostmem = item.Value
+			}
+		}
+
+		if isNativeContext {
+			enabled = true
+			if devRenderNode != "" {
+				rendernode = devRenderNode
+			}
+
+			if devHostmem != "" {
+				hostmem = devHostmem
+			}
+		}
+	}
+
+	return enabled, rendernode, hostmem
+}
+
 // generateQemuConfig generates the QEMU configuration.
 func (d *qemu) generateQemuConfig(bs *qemuBootState, mountInfo *storagePools.MountInfo, busName string, vsockFD int, devConfs []*deviceConfig.RunConfig, fdFiles *[]*os.File) ([]monitorHook, error) {
 	var monHooks []monitorHook
@@ -4213,6 +4270,22 @@ func (d *qemu) generateQemuConfig(bs *qemuBootState, mountInfo *storagePools.Mou
 		devBus, devAddr, multi = bus.allocate(busFunctionGroupNone)
 	}
 
+	// When any attached GPU device requests virtio-gpu DRM native context, the default
+	// emulated GPU is switched to a GL-capable device with blob and native context
+	// enabled rather than a plain virtio-gpu. This requires a recent QEMU.
+	nativeContext, _, hostmem := d.gpuNativeContextConfig(devConfs)
+	if nativeContext {
+		qemuVer, err := d.version()
+		if err != nil {
+			return nil, fmt.Errorf("GPU native context requires a known QEMU version: %w", err)
+		}
+
+		qemuVer11, _ := version.NewDottedVersion("11.0.0")
+		if qemuVer.Compare(qemuVer11) < 0 {
+			return nil, fmt.Errorf("GPU native context requires QEMU 11.0.0 or newer (have %s)", qemuVer.String())
+		}
+	}
+
 	gpuOpts := qemuGpuOpts{
 		dev: qemuDevOpts{
 			busName:       bus.name,
@@ -4220,8 +4293,10 @@ func (d *qemu) generateQemuConfig(bs *qemuBootState, mountInfo *storagePools.Mou
 			devAddr:       devAddr,
 			multifunction: multi,
 		},
-		architecture: d.Architecture(),
-		virtioVGA:    virtioVGA,
+		architecture:  d.Architecture(),
+		virtioVGA:     virtioVGA,
+		nativeContext: nativeContext,
+		hostmem:       hostmem,
 	}
 
 	conf = append(conf, qemuGPU(&gpuOpts)...)
@@ -5645,7 +5720,7 @@ func (d *qemu) addPCIDevConfig(conf *[]cfg.Section, bus *qemuBus, pciConfig []de
 
 // addGPUDevConfig adds the qemu config required for adding a GPU device.
 func (d *qemu) addGPUDevConfig(conf *[]cfg.Section, bus *qemuBus, gpuConfig []deviceConfig.RunConfigItem) error {
-	var devName, pciSlotName, vgpu string
+	var devName, pciSlotName, vgpu, gpuType string
 	for _, gpuItem := range gpuConfig {
 		switch gpuItem.Key {
 		case "devName":
@@ -5654,7 +5729,16 @@ func (d *qemu) addGPUDevConfig(conf *[]cfg.Section, bus *qemuBus, gpuConfig []de
 			pciSlotName = gpuItem.Value
 		case "vgpu":
 			vgpu = gpuItem.Value
+		case "gpuType":
+			gpuType = gpuItem.Value
 		}
+	}
+
+	// A native-context GPU is not passed through as a PCI device. It is realized by the
+	// default virtio-gpu device (configured for GL/blob/native-context in generateQemuConfig)
+	// together with QEMU's egl-headless display, so there is nothing to add here.
+	if gpuType == "native-context" {
+		return nil
 	}
 
 	vgaMode := func() bool {

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -472,15 +472,25 @@ func qemuVsock(opts *qemuVsockOpts) []cfg.Section {
 }
 
 type qemuGpuOpts struct {
-	dev          qemuDevOpts
-	architecture int
-	virtioVGA    bool
+	dev           qemuDevOpts
+	architecture  int
+	virtioVGA     bool
+	nativeContext bool
+	hostmem       string
 }
 
 func qemuGPU(opts *qemuGpuOpts) []cfg.Section {
 	var pciName string
 
-	if opts.architecture == osarch.ARCH_64BIT_INTEL_X86 && opts.virtioVGA {
+	if opts.nativeContext {
+		// DRM native context forwards the guest's native GPU driver context to the
+		// host, so the default emulated GPU must be a GL-capable virtio-gpu device.
+		if opts.architecture == osarch.ARCH_64BIT_INTEL_X86 {
+			pciName = "virtio-vga-gl"
+		} else {
+			pciName = "virtio-gpu-gl-pci"
+		}
+	} else if opts.architecture == osarch.ARCH_64BIT_INTEL_X86 && opts.virtioVGA {
 		pciName = "virtio-vga"
 	} else {
 		pciName = "virtio-gpu-pci"
@@ -492,10 +502,22 @@ func qemuGPU(opts *qemuGpuOpts) []cfg.Section {
 		ccwName: "virtio-gpu-ccw",
 	}
 
+	entries := qemuDeviceEntries(&entriesOpts)
+
+	if opts.nativeContext {
+		// blob=on lets the guest map host GPU buffers directly (required for native
+		// context), drm_native_context=on turns the feature on, and hostmem reserves
+		// the host-visible blob window exposed through the device's PCI BAR. The size
+		// is set from the device's blob.size option, resolved to a byte count.
+		entries["blob"] = "on"
+		entries["drm_native_context"] = "on"
+		entries["hostmem"] = opts.hostmem
+	}
+
 	return []cfg.Section{{
 		Name:    `device "qemu_gpu"`,
 		Comment: "GPU",
-		Entries: qemuDeviceEntries(&entriesOpts),
+		Entries: entries,
 	}}
 }
 

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -344,6 +344,51 @@
 					}
 				]
 			},
+			"gpu_native_context": {
+				"keys": [
+					{
+						"blob.size": {
+							"default": "2GiB",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Size of the host-visible blob memory window for the `virtio-gpu` device",
+							"type": "string"
+						}
+					},
+					{
+						"id": {
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The DRM card ID of the GPU device",
+							"type": "string"
+						}
+					},
+					{
+						"pci": {
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The PCI address of the GPU device",
+							"type": "string"
+						}
+					},
+					{
+						"productid": {
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The product ID of the GPU device",
+							"type": "string"
+						}
+					},
+					{
+						"vendorid": {
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The vendor ID of the GPU device",
+							"type": "string"
+						}
+					}
+				]
+			},
 			"gpu_physical": {
 				"keys": [
 					{

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -554,6 +554,7 @@ var APIExtensions = []string{
 	"projects_restricted_virtual_machines_nesting",
 	"authorization_config",
 	"network_allocations_network",
+	"gpu_native_context",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This implements the feature request in #3563: a new `native-context` option for the `gpu` device on VMs.

Incus already has GPU options that hand a whole GPU, or a vendor slice of one, to a VM (physical, mdev, mig, sriov). This adds a different kind: with QEMU 11 and virglrenderer, `drm_native_context` gives a VM full GPU acceleration (OpenGL, Vulkan, and video encode/decode) from a single GPU, with no vendor SR-IOV or mdev support, and the host keeps using the GPU. One GPU can be shared by several VMs.

I had been setting this up by hand with the raw.qemu options and it works well, so I thought it would be worth offering as a proper GPU option.

## Usage

```
incus config device add v1 gpu0 gpu gputype=native-context
```

You can optionally pick a card with the usual selectors (id, pci, vendorid, productid), and set the host-visible blob window with `blob.size` (default 2GiB). In the guest you just use the normal mesa driver.

## What it does

- A new `native-context` gputype (VM only). When attached, the default emulated GPU becomes a GL-capable virtio-gpu (`virtio-vga-gl` on x86, `virtio-gpu-gl-pci` elsewhere) with blob and drm_native_context, and QEMU is started with `-display egl-headless,gl=on[,rendernode=...]`. It is not a PCI passthrough, so the host keeps the GPU and it can be shared.
- Requires QEMU 11.0.0 or newer (checked, with a clear error otherwise).
- The AppArmor profile is granted access to the host DRM render nodes only when a native-context device is attached.

## Requirements

- virglrenderer on the host. IncusOS and the zabbly builds may not ship it today, but it is a small package and an easy build, and unlike virgl or venus it does not need host-side mesa at all. I think it is a good fit for people who want video transcoding or other GPU features in a VM without full passthrough.
- QEMU 11 or newer.

## Testing

Tested on an AMD Radeon 780M (Phoenix iGPU). A normal Arch VM with stock mesa got, all from the one host GPU:

- Vulkan via RADV (deviceName "AMD Radeon 780M Graphics (RADV PHOENIX)")
- VAAPI H264 and HEVC decode and encode
- OpenGL 4.6

I have only tested AMD. Intel should also work, since i915 already supports native context, though I have not tested it. Intel Xe also works with patches (https://github.com/cmspam/xe-native-context-enablement)

The change is split into the usual commits: the API extension, the device, the QEMU wiring, the AppArmor change, the reference doc, and the regenerated config metadata. Happy to adjust anything.
