### PR TITLE
incusd/devices: Allow /32 and /128 for OCI addresses

### DIFF
--- a/cmd/incus/admin_init_interactive.go
+++ b/cmd/incus/admin_init_interactive.go
@@ -169,11 +169,11 @@ func (c *cmdAdminInit) askNetworking(config *api.InitPreseed, d incus.InstanceSe
 
 		// IPv4
 		network.Config["ipv4.address"], err = c.global.asker.AskString(i18n.G("What IPv4 address should be used?")+" (CIDR subnet notation, “auto” or “none”) [default=auto]: ", "auto", func(value string) error {
-			if slices.Contains([]string{"auto", "none"}, value) {
+			if slices.Contains([]string{"auto", "none", ""}, value) {
 				return nil
 			}
 
-			return validate.Optional(validate.IsNetworkAddressCIDRV4)(value)
+			return validate.IsNetworkAddressCIDRV4(value, false)
 		})
 		if err != nil {
 			return err
@@ -190,11 +190,11 @@ func (c *cmdAdminInit) askNetworking(config *api.InitPreseed, d incus.InstanceSe
 
 		// IPv6
 		network.Config["ipv6.address"], err = c.global.asker.AskString(i18n.G("What IPv6 address should be used?")+" (CIDR subnet notation, “auto” or “none”) [default=auto]: ", "auto", func(value string) error {
-			if slices.Contains([]string{"auto", "none"}, value) {
+			if slices.Contains([]string{"auto", "none", ""}, value) {
 				return nil
 			}
 
-			return validate.Optional(validate.IsNetworkAddressCIDRV6)(value)
+			return validate.IsNetworkAddressCIDRV6(value, false)
 		})
 		if err != nil {
 			return err

--- a/internal/server/device/nic_bridged.go
+++ b/internal/server/device/nic_bridged.go
@@ -608,7 +608,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 		}
 
 		if strings.Contains(value, "/") {
-			return validate.IsNetworkAddressCIDRV4(value)
+			return validate.IsNetworkAddressCIDRV4(value, true)
 		}
 
 		return validate.IsNetworkAddressV4(value)
@@ -620,7 +620,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 		}
 
 		if strings.Contains(value, "/") {
-			return validate.IsNetworkAddressCIDRV6(value)
+			return validate.IsNetworkAddressCIDRV6(value, true)
 		}
 
 		return validate.IsNetworkAddressV6(value)

--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -509,7 +509,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader, partialValidatio
 		}
 
 		if strings.Contains(value, "/") {
-			return validate.IsNetworkAddressCIDRV4(value)
+			return validate.IsNetworkAddressCIDRV4(value, true)
 		}
 
 		return validate.IsNetworkAddressV4(value)
@@ -521,7 +521,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader, partialValidatio
 		}
 
 		if strings.Contains(value, "/") {
-			return validate.IsNetworkAddressCIDRV6(value)
+			return validate.IsNetworkAddressCIDRV6(value, true)
 		}
 
 		return validate.IsNetworkAddressV6(value)

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -269,7 +269,7 @@ func (n *bridge) Validate(config map[string]string, clientType request.ClientTyp
 				return nil
 			}
 
-			return validate.IsNetworkAddressCIDRV4(value)
+			return validate.IsNetworkAddressCIDRV4(value, false)
 		}),
 
 		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.firewall)
@@ -398,7 +398,7 @@ func (n *bridge) Validate(config map[string]string, clientType request.ClientTyp
 				return nil
 			}
 
-			return validate.Or(validate.IsNetworkAddressCIDRV6, validate.IsNetworkV6)(value)
+			return validate.Or(func(value string) error { return validate.IsNetworkAddressCIDRV6(value, false) }, validate.IsNetworkV6)(value)
 		}),
 
 		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.firewall)

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -510,7 +510,7 @@ func (n *ovn) Validate(config map[string]string, clientType request.ClientType) 
 				return nil
 			}
 
-			return validate.IsNetworkAddressCIDRV4(value)
+			return validate.IsNetworkAddressCIDRV4(value, true)
 		}),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.dhcp)
@@ -578,7 +578,7 @@ func (n *ovn) Validate(config map[string]string, clientType request.ClientType) 
 				return nil
 			}
 
-			return validate.IsNetworkAddressCIDRV6(value)
+			return validate.IsNetworkAddressCIDRV6(value, true)
 		}),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.dhcp)

--- a/internal/server/network/driver_physical.go
+++ b/internal/server/network/driver_physical.go
@@ -95,7 +95,7 @@ func (n *physical) Validate(config map[string]string, clientType request.ClientT
 		// type: string
 		// condition: standard mode
 		// shortdesc: IPv4 address for the gateway and network (CIDR)
-		"ipv4.gateway": validate.Optional(validate.IsNetworkAddressCIDRV4),
+		"ipv4.gateway": validate.Optional(func(value string) error { return validate.IsNetworkAddressCIDRV4(value, false) }),
 
 		// gendoc:generate(entity=network_physical, group=ipv6, key=ipv6.gateway)
 		//
@@ -103,7 +103,7 @@ func (n *physical) Validate(config map[string]string, clientType request.ClientT
 		// type: string
 		// condition: standard mode
 		// shortdesc: IPv6 address for the gateway and network (CIDR)
-		"ipv6.gateway": validate.Optional(validate.IsNetworkAddressCIDRV6),
+		"ipv6.gateway": validate.Optional(func(value string) error { return validate.IsNetworkAddressCIDRV6(value, false) }),
 
 		// gendoc:generate(entity=network_physical, group=ipv4, key=ipv4.gateway.hwaddr)
 		//

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -367,7 +367,7 @@ func IsNetworkAddressV4(value string) error {
 }
 
 // IsNetworkAddressCIDRV4 validates an IPv4 address string in CIDR format.
-func IsNetworkAddressCIDRV4(value string) error {
+func IsNetworkAddressCIDRV4(value string, allowSingle bool) error {
 	ip, subnet, err := net.ParseCIDR(value)
 	if err != nil {
 		return err
@@ -375,6 +375,12 @@ func IsNetworkAddressCIDRV4(value string) error {
 
 	if ip.To4() == nil {
 		return fmt.Errorf("Not an IPv4 address %q", value)
+	}
+
+	subnetSize, _ := subnet.Mask.Size()
+	if allowSingle && subnetSize == 32 {
+		// Single addresses are allowed through.
+		return nil
 	}
 
 	if ip.String() == subnet.IP.String() {
@@ -430,7 +436,7 @@ func IsNetworkAddressV6(value string) error {
 }
 
 // IsNetworkAddressCIDRV6 validates an IPv6 address string in CIDR format.
-func IsNetworkAddressCIDRV6(value string) error {
+func IsNetworkAddressCIDRV6(value string, allowSingle bool) error {
 	ip, subnet, err := net.ParseCIDR(value)
 	if err != nil {
 		return err
@@ -438,6 +444,12 @@ func IsNetworkAddressCIDRV6(value string) error {
 
 	if ip.To4() != nil {
 		return fmt.Errorf("Not an IPv6 address %q", value)
+	}
+
+	subnetSize, _ := subnet.Mask.Size()
+	if allowSingle && subnetSize == 128 {
+		// Single addresses are allowed through.
+		return nil
 	}
 
 	if ip.String() == subnet.IP.String() {


### PR DESCRIPTION
It's a valid configuration to set ipv4.address to a /32 or ipv6.address to a /128 as LXC will make the gateway as an on-link gateway.

This is particularly useful when dealing with public addresses.