### PR TITLE
incusd/operations: Fix nil deref race in Cancel

### DIFF
--- a/internal/server/operations/operations.go
+++ b/internal/server/operations/operations.go
@@ -366,13 +366,22 @@ func (op *Operation) Cancel() (chan error, error) {
 
 	oldStatus := op.status
 	op.status = api.Cancelling
-	op.lock.Unlock()
-
 	hasOnCancel := op.onCancel != nil
+	op.lock.Unlock()
 
 	if hasOnCancel {
 		go func(op *Operation, oldStatus api.StatusCode, chanCancel chan error) {
-			err := op.onCancel(op)
+			op.lock.Lock()
+			onCancel := op.onCancel
+			op.lock.Unlock()
+
+			// The operation completed on its own before it could be cancelled.
+			if onCancel == nil {
+				chanCancel <- nil
+				return
+			}
+
+			err := onCancel(op)
 			if err != nil {
 				op.lock.Lock()
 				op.status = oldStatus


### PR DESCRIPTION
This fixes a race condition where an operation could complete at the same time as it's being canceled, causing Incus to call a nil cancel handler.

A last minute check is now done to confirm the operation still has a cancel handler and a reference on the handler is taken to avoid calling a nil function.

This doesn't fully eliminate the race. It's still technically possible for an instance to both complete and get canceled at the same time, but this narrows the race significantly and eliminates the actual nil pointer deref.

Closes #3572