### PR TITLE
incusd/instance/qemu/qmp: Bump timeout for slow synchronous commands

### DIFF
--- a/internal/server/instance/drivers/qmp/qmp.go
+++ b/internal/server/instance/drivers/qmp/qmp.go
@@ -271,14 +271,35 @@ const defaultCommandTimeout = 100 * time.Millisecond
 // blockCommandTimeout is used for block commands that do blocking storage I/O.
 const blockCommandTimeout = 5 * time.Second
 
+// heavyCommandTimeout is used for commands that require I/O flush or VFIO operations.
+const heavyCommandTimeout = 30 * time.Second
+
 // commandTimeouts overrides defaultCommandTimeout for synchronous slow commands.
 var commandTimeouts = map[string]time.Duration{
-	"blockdev-add":     blockCommandTimeout,
-	"blockdev-del":     blockCommandTimeout,
-	"block_resize":     blockCommandTimeout,
-	"block-export-add": blockCommandTimeout,
-	"nbd-server-start": blockCommandTimeout,
-	"screendump":       10 * time.Second,
+	"block-commit":              blockCommandTimeout,
+	"block-dirty-bitmap-remove": blockCommandTimeout,
+	"block-export-add":          blockCommandTimeout,
+	"block-job-cancel":          blockCommandTimeout,
+	"block-job-complete":        blockCommandTimeout,
+	"block_resize":              blockCommandTimeout,
+	"block_set_io_throttle":     blockCommandTimeout,
+	"blockdev-add":              blockCommandTimeout,
+	"blockdev-del":              blockCommandTimeout,
+	"blockdev-mirror":           blockCommandTimeout,
+	"blockdev-snapshot":         blockCommandTimeout,
+	"change-backing-file":       blockCommandTimeout,
+	"nbd-server-start":          blockCommandTimeout,
+	"nbd-server-stop":           blockCommandTimeout,
+	"transaction":               blockCommandTimeout,
+	"cont":                      heavyCommandTimeout,
+	"device_add":                heavyCommandTimeout,
+	"device_del":                heavyCommandTimeout,
+	"netdev_add":                heavyCommandTimeout,
+	"netdev_del":                heavyCommandTimeout,
+	"object-add":                heavyCommandTimeout,
+	"stop":                      heavyCommandTimeout,
+	"system_reset":              heavyCommandTimeout,
+	"screendump":                10 * time.Second,
 }
 
 // commandName extracts the command name from a marshalled QMP request.


### PR DESCRIPTION
This now covers additional I/O commands and also adds an extra long timeout for commands that either touch I/O flush or handle VFIO operations.