### PR TITLE
Fix concurrent image unpacking on ceph

### DIFF
--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -3884,6 +3884,48 @@ func (b *backend) UnmountInstanceSnapshot(inst instance.Instance, op *operations
 	return err
 }
 
+// waitImageCloneSourceReady blocks until the optimized image volume's clone source is ready to be cloned from.
+func (b *backend) waitImageCloneSourceReady(imgVol drivers.Volume) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Minute)
+	defer cancel()
+
+	for {
+		// Only drivers that build a separate clone source (a protected readonly snapshot) after
+		// unpacking are affected by this race and implement the readiness check. For all other drivers
+		// the clone source is the image volume itself, so there is nothing to wait for.
+		ready, err := b.driver.IsImageCloneSourceReady(imgVol)
+		if err != nil {
+			return err
+		}
+
+		if ready {
+			return nil
+		}
+
+		// Detect creator abort/revert so we fail fast instead of blocking until the timeout: if
+		// the base image volume or its cluster DB row has disappeared, the creating member gave up.
+		exists, err := b.driver.HasVolume(imgVol)
+		if err != nil {
+			return err
+		}
+
+		dbVol, err := VolumeDBGet(b, api.ProjectDefaultName, imgVol.Name(), drivers.VolumeTypeImage)
+		if err != nil && !response.IsNotFoundError(err) {
+			return err
+		}
+
+		if !exists || dbVol == nil {
+			return fmt.Errorf("Image %q clone source is unavailable because its creation was aborted on another cluster member; please retry", imgVol.Name())
+		}
+
+		select {
+		case <-time.After(1 * time.Second):
+		case <-ctx.Done():
+			return fmt.Errorf("Timed out waiting for image %q clone source to become ready: %w", imgVol.Name(), ctx.Err())
+		}
+	}
+}
+
 // EnsureImage creates an optimized volume of the image if supported by the storage pool driver and the volume
 // doesn't already exist. If the volume already exists then it is checked to ensure it matches the pools current
 // volume settings ("volume.size" and "block.filesystem" if applicable). If not the optimized volume is removed
@@ -3992,6 +4034,18 @@ func (b *backend) EnsureImage(fingerprint string, op *operations.Operation) erro
 
 	if volExists {
 		if imgDBVol != nil {
+			// The image volume (and its cluster DB row) can become visible to other cluster
+			// members on a shared pool before the creating member has finished unpacking and
+			// preparing the clone source (e.g. a protected readonly snapshot). Wait for the clone
+			// source to be ready before inspecting/resizing or returning, so we neither race the
+			// in-progress creation nor return a volume that cannot yet be cloned from.
+			if b.driver.Info().Remote {
+				err = b.waitImageCloneSourceReady(imgVol)
+				if err != nil {
+					return err
+				}
+			}
+
 			// Work out what size the image volume should be as if we were creating from scratch.
 			// This takes into account the existing volume's "volatile.rootfs.size" setting if set so
 			// as to avoid trying to shrink a larger image volume back to the default size when it is

--- a/internal/server/storage/drivers/driver_ceph_utils.go
+++ b/internal/server/storage/drivers/driver_ceph_utils.go
@@ -391,6 +391,46 @@ func (d *ceph) rbdUnprotectVolumeSnapshot(vol Volume, snapshotName string) error
 	return nil
 }
 
+// rbdSnapshotIsProtected reports whether the named snapshot of the given volume exists and is
+// protected. Both conditions are required before the snapshot can be used as a clone source by
+// rbdCreateClone. A non-existent snapshot (or volume) is reported as (false, nil).
+func (d *ceph) rbdSnapshotIsProtected(vol Volume, snapshotName string) (bool, error) {
+	snapInfo := struct {
+		Protected string `json:"protected"`
+	}{}
+
+	jsonInfo, err := subprocess.RunCommand(
+		"rbd",
+		"info",
+		"--format", "json",
+		"--id", d.config["ceph.user.name"],
+		"--cluster", d.config["ceph.cluster_name"],
+		"--pool", d.config["ceph.osd.pool_name"],
+		d.getRBDVolumeName(vol, snapshotName, false),
+	)
+	if err != nil {
+		var runErr subprocess.RunError
+		if errors.As(err, &runErr) {
+			var exitError *exec.ExitError
+			if errors.As(runErr.Unwrap(), &exitError) {
+				if exitError.ExitCode() == 2 {
+					// ENOENT: the volume or the snapshot doesn't exist yet.
+					return false, nil
+				}
+			}
+		}
+
+		return false, err
+	}
+
+	err = json.Unmarshal([]byte(jsonInfo), &snapInfo)
+	if err != nil {
+		return false, err
+	}
+
+	return snapInfo.Protected == "true", nil
+}
+
 // rbdCreateClone creates a clone from a protected RBD snapshot.
 func (d *ceph) rbdCreateClone(sourceVol Volume, sourceSnapshotName string, targetVol Volume) error {
 	cmd := []string{

--- a/internal/server/storage/drivers/driver_ceph_volumes.go
+++ b/internal/server/storage/drivers/driver_ceph_volumes.go
@@ -809,6 +809,32 @@ func (d *ceph) HasVolume(vol Volume) (bool, error) {
 	return d.hasVolume(d.getRBDVolumeName(vol, "", false))
 }
 
+// IsImageCloneSourceReady reports whether the image volume's clone source is ready to be cloned
+// from. Instances are created by cloning the image volume's protected "readonly" snapshot (see
+// CreateVolumeFromCopy), which is only created and protected at the very end of CreateVolume, after
+// the (potentially slow) image unpack. On a shared pool a different cluster member may still be
+// unpacking the image, so the base volume existing is not sufficcient: the readonly snapshot must
+// also exist and be protected before a clone can succeed.
+func (d *ceph) IsImageCloneSourceReady(vol Volume) (bool, error) {
+	ready, err := d.rbdSnapshotIsProtected(vol, "readonly")
+	if err != nil || !ready {
+		return false, err
+	}
+
+	// For VM block images the associated filesystem config volume carries its own readonly
+	// snapshot that is used as the clone source for the config volume, so it must be ready too.
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+
+		fsReady, err := d.rbdSnapshotIsProtected(fsVol, "readonly")
+		if err != nil || !fsReady {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
 // FillVolumeConfig populate volume with default config.
 func (d *ceph) FillVolumeConfig(vol Volume) error {
 	// Copy volume.* configuration options from pool.

--- a/internal/server/storage/drivers/driver_cephfs_volumes.go
+++ b/internal/server/storage/drivers/driver_cephfs_volumes.go
@@ -704,3 +704,9 @@ func (d *cephfs) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op
 
 	return nil
 }
+
+// IsImageCloneSourceReady checks if the image clone source is ready.
+func (d *cephfs) IsImageCloneSourceReady(vol Volume) (bool, error) {
+	// TODO: Further implementation required
+	return true, nil
+}

--- a/internal/server/storage/drivers/driver_common.go
+++ b/internal/server/storage/drivers/driver_common.go
@@ -606,3 +606,8 @@ func (d *common) Qcow2DeletionCleanup(vol Volume, childName string) error {
 func (d *common) ActivateTask(vol Volume, task func(devPath string, op *operations.Operation) error, op *operations.Operation) error {
 	return ErrNotSupported
 }
+
+// IsImageCloneSourceReady checks if the image clone source is ready.
+func (d *common) IsImageCloneSourceReady(vol Volume) (bool, error) {
+	return false, ErrNotSupported
+}

--- a/internal/server/storage/drivers/driver_linstor_volumes.go
+++ b/internal/server/storage/drivers/driver_linstor_volumes.go
@@ -1410,3 +1410,9 @@ func (d *linstor) BackupVolume(vol Volume, writer instancewriter.InstanceWriter,
 func (d *linstor) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, basePrefix string, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, basePrefix, op)
 }
+
+// IsImageCloneSourceReady checks if the image clone source is ready.
+func (d *linstor) IsImageCloneSourceReady(vol Volume) (bool, error) {
+	// TODO: Further implementation required
+	return true, nil
+}

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -2025,3 +2025,10 @@ func (d *lvm) Qcow2DeletionCleanup(snapVol Volume, childName string) error {
 
 	return nil
 }
+
+// IsImageCloneSourceReady checks if the image clone source is ready if clustered LVM is used.
+func (d *lvm) IsImageCloneSourceReady(vol Volume) (bool, error) {
+	// TODO: Further implementation required
+	// This will only be hit, if using clustered lvm
+	return true, nil
+}

--- a/internal/server/storage/drivers/driver_mock.go
+++ b/internal/server/storage/drivers/driver_mock.go
@@ -223,3 +223,9 @@ func (d *mock) RestoreVolume(vol Volume, snapshotName string, op *operations.Ope
 func (d *mock) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error {
 	return nil
 }
+
+// IsImageCloneSourceReady checks if the image clone source is ready.
+func (d *mock) IsImageCloneSourceReady(vol Volume) (bool, error) {
+	// To not have unnecessary wait loops, we always pretend that the source is ready.
+	return true, nil
+}

--- a/internal/server/storage/drivers/driver_truenas_volumes.go
+++ b/internal/server/storage/drivers/driver_truenas_volumes.go
@@ -2167,3 +2167,9 @@ func (d *truenas) FillVolumeConfig(vol Volume) error {
 
 	return nil
 }
+
+// IsImageCloneSourceReady checks if the image clone source is ready.
+func (d *truenas) IsImageCloneSourceReady(vol Volume) (bool, error) {
+	// TODO: Further implementation required
+	return true, nil
+}

--- a/internal/server/storage/drivers/interface.go
+++ b/internal/server/storage/drivers/interface.go
@@ -28,6 +28,7 @@ type Driver interface {
 	// Internal.
 	Info() Info
 	HasVolume(vol Volume) (bool, error)
+	IsImageCloneSourceReady(vol Volume) (bool, error)
 	roundVolumeBlockSizeBytes(vol Volume, sizeBytes int64) (int64, error)
 	isBlockBacked(vol Volume) bool
 


### PR DESCRIPTION
The Bug:
I was seeing the error:
`Failed creating instance from image: Failed to run: rbd --id admin --cluster ceph --image-feature exclusive-lock --image-feature object-map --image-feature fast-diff --image-feature layering clone ceph-default/image_f7cb36e58c37989e8073fb579874cf251d3e94e6077e182579d1e195e2c8874b_ext4.block@readonly     
  ceph-default/virtual-machine_0199f257-a97e-7c91-bee4-8537f74ce4e7_test.block: exit status 2 (2026-07-02T12:21:06.068+0000 7efc667fc6c0 -1 librbd::image::RefreshRequest: failed to locate snapshot: readonly\n2026-07-02T12:21:06.068+0000 7efc667fc6c0 -1 librbd::image::OpenRequest: failed to find snapshot   
  readonly\n2026-07-02T12:21:06.072+0000 7efc55ffb6c0 -1 librbd::image::CloneRequest: 0x5561bd98bda0 handle_open_parent: failed to open parent image: (2) No such file or directory\nrbd: clone error: (2) No such file or directory)`
during concurrent VM creation on multiple cluster members from the same image.
This caused a failure during the creation.

The problem was that incus  (via the ceph rbd driver) considers an image to be a viable clone source, once its in the DB and the image has been created on ceph.
This unfortunately is not enough as the image needs to have the `readonly` snapshot and this snapshot also needs to be protected.

Since the protection is the last stage that happens after a fresh unpack, I implemented a check, that check that polls until the image has the protected `readonly` snapshot. Only then is it considered to be a viable clone source.
This of course only happens if the image is detected and the snapshot is not ready yet.

The ugly downcasting is there, because i haven't worked with the other storage drivers yet.
As soon as it's implemented there as well the casting can be safely removed.