### PR TITLE
doc/incus-cli: reword docs for configuration file path

### DIFF
--- a/doc/client-config.md
+++ b/doc/client-config.md
@@ -7,7 +7,7 @@ Changing this configuration file manually may leave the CLI in an inconsistent s
 ```
 
 ## The configuration file
-By default, the Incus CLI will use the `$HOME/.config/incus/config.yml`, but it can also use an arbitrary file provided by the `INCUS_CONF` environment variable.
+By default, the Incus CLI will use the `$HOME/.config/incus/config.yml`, but it can also use the `config.yml` in an arbitrary directory provided by the `INCUS_CONF` environment variable.
 
 If the file or its path don't exist, it will use the default:
 


### PR DESCRIPTION
The [documentation](https://linuxcontainers.org/incus/docs/main/client-config/#the-configuration-file) currently states that `INCUS_CONF` points to a configuration file. However, it only points to a directory.

This PR rewords the documentation accordingly.