### PR TITLE
Fallback to sending agent state data through vserial ringbuffer

### DIFF
--- a/cmd/incus-agent/main_agent.go
+++ b/cmd/incus-agent/main_agent.go
@@ -214,8 +214,24 @@ func (c *cmdAgent) run(cmd *cobra.Command, args []string) error {
 // startStatusNotifier sends status of agent to vserial ring buffer every 10s or when context is done.
 // Returns a function that can be used to update the running status to STOPPED in the ring buffer.
 func (c *cmdAgent) startStatusNotifier(ctx context.Context, chConnected <-chan struct{}) context.CancelFunc {
+	msgWithState := func(status string) []string {
+		msg := []string{status}
+
+		// If there's no server running, send state data through the ring-buffer.
+		_, ok := servers["http"]
+		if !ok {
+			b, err := json.Marshal(renderState())
+			if err == nil {
+				logger.Error("Including VM state in status message")
+				msg = append(msg, string(b))
+			}
+		}
+
+		return msg
+	}
+
 	// Write initial started status.
-	_ = c.writeStatus("STARTED")
+	_ = c.writeStatus(msgWithState("STARTED")...)
 
 	wg := sync.WaitGroup{}
 	exitCtx, exit := context.WithCancel(ctx) // Allows manual synchronous cancellation via cancel function.
@@ -233,7 +249,7 @@ func (c *cmdAgent) startStatusNotifier(ctx context.Context, chConnected <-chan s
 			case <-chConnected:
 				_ = c.writeStatus("CONNECTED") // Indicate we were able to connect.
 			case <-ticker.C:
-				_ = c.writeStatus("STARTED") // Re-populate status periodically in case the daemon restarts.
+				_ = c.writeStatus(msgWithState("STARTED")...) // Re-populate status periodically in case the daemon restarts.
 			case <-exitCtx.Done():
 				_ = c.writeStatus("STOPPED") // Indicate we are stopping and exit go routine.
 				return
@@ -245,7 +261,7 @@ func (c *cmdAgent) startStatusNotifier(ctx context.Context, chConnected <-chan s
 }
 
 // writeStatus writes a status code to the vserial ring buffer used to detect agent status on host.
-func (c *cmdAgent) writeStatus(status string) error {
+func (c *cmdAgent) writeStatus(status ...string) error {
 	if util.PathExists(osVioSerialPath) {
 		vSerial, err := os.OpenFile(osVioSerialPath, os.O_RDWR, 0o600)
 		if err != nil {
@@ -254,7 +270,7 @@ func (c *cmdAgent) writeStatus(status string) error {
 
 		defer logger.WarnOnError(vSerial.Close, "Failed to close vserial device")
 
-		_, err = vSerial.Write(fmt.Appendf(nil, "%s\n", status))
+		_, err = vSerial.Write([]byte(strings.Join(status, "\n") + "\n"))
 		if err != nil {
 			return err
 		}

--- a/cmd/incus-agent/main_agent.go
+++ b/cmd/incus-agent/main_agent.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -122,8 +123,10 @@ func (c *cmdAgent) run(cmd *cobra.Command, args []string) error {
 	// Load the kernel driver.
 	err = osLoadModules()
 	if err != nil {
-		return err
+		logger.Error("Failed to check for agent server compatibility", logger.Ctx{"error": err})
 	}
+
+	canStartServer := err == nil
 
 	d := newDaemon(c.global.flagLogDebug, c.global.flagLogVerbose, c.global.flagSecretsLocation)
 
@@ -138,32 +141,34 @@ func (c *cmdAgent) run(cmd *cobra.Command, args []string) error {
 		c.mountHostShares()
 	}
 
-	// Start the server.
-	err = startHTTPServer(d, c.global.flagLogDebug)
-	if err != nil {
-		return fmt.Errorf("Failed to start HTTP server: %w", err)
-	}
-
-	// Check whether we should start the DevIncus server in the early setup. This way, /dev/incus/sock
-	// will be available for any systemd services starting after the agent.
-	if util.PathExists("agent.conf") {
-		f, err := os.Open("agent.conf")
+	if canStartServer {
+		// Start the server.
+		err = startHTTPServer(d, c.global.flagLogDebug)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed to start HTTP server: %w", err)
 		}
 
-		err = setConnectionInfo(d, f)
-		if err != nil {
-			_ = f.Close()
-			return err
-		}
-
-		_ = f.Close()
-
-		if d.DevIncusEnabled {
-			err = startDevIncusServer(d)
+		// Check whether we should start the DevIncus server in the early setup. This way, /dev/incus/sock
+		// will be available for any systemd services starting after the agent.
+		if util.PathExists("agent.conf") {
+			f, err := os.Open("agent.conf")
 			if err != nil {
 				return err
+			}
+
+			err = setConnectionInfo(d, f)
+			if err != nil {
+				_ = f.Close()
+				return err
+			}
+
+			_ = f.Close()
+
+			if d.DevIncusEnabled {
+				err = startDevIncusServer(d)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/cmd/incus-agent/os_common.go
+++ b/cmd/incus-agent/os_common.go
@@ -27,11 +27,6 @@ var (
 	osGuestAPISupport  = false
 )
 
-func osLoadModules() error {
-	// No OS drivers to load by default.
-	return nil
-}
-
 func osGetCPUMetrics(d *Daemon) ([]metrics.CPUMetrics, error) {
 	cpuTimes, err := cpu.Times(true)
 	if err != nil {

--- a/cmd/incus-agent/os_darwin.go
+++ b/cmd/incus-agent/os_darwin.go
@@ -22,6 +22,11 @@ import (
 	"github.com/lxc/incus/v7/shared/subprocess"
 )
 
+func osLoadModules() error {
+	// No OS drivers to load by default.
+	return nil
+}
+
 func osMountShared(src string, dst string, fstype string, opts []string) error {
 	if fstype != "9p" {
 		return errors.New("Only 9p shares are supported on Darwin")

--- a/cmd/incus-agent/os_freebsd.go
+++ b/cmd/incus-agent/os_freebsd.go
@@ -25,6 +25,11 @@ import (
 	"github.com/lxc/incus/v7/shared/util"
 )
 
+func osLoadModules() error {
+	// No OS drivers to load by default.
+	return nil
+}
+
 // isMountPoint returns true if path is a mount point.
 func isMountPoint(path string) bool {
 	// Get the stat details.

--- a/cmd/incus-agent/os_windows.go
+++ b/cmd/incus-agent/os_windows.go
@@ -129,11 +129,14 @@ func (m *incusAgentService) Execute(args []string, r <-chan svc.ChangeRequest, c
 	d := newDaemon(m.agentCmd.global.flagLogDebug, m.agentCmd.global.flagLogVerbose, m.agentCmd.global.flagSecretsLocation)
 
 	// Start the server.
-	err := startHTTPServer(d, m.agentCmd.global.flagLogDebug)
-	if err != nil {
-		changes <- svc.Status{State: svc.StopPending}
-		elog.Error(1, fmt.Sprintf("Failed to start HTTP server: %s", err))
-		return
+	err := osLoadModules()
+	if err == nil {
+		err := startHTTPServer(d, m.agentCmd.global.flagLogDebug)
+		if err != nil {
+			changes <- svc.Status{State: svc.StopPending}
+			elog.Error(1, fmt.Sprintf("Failed to start HTTP server: %s", err))
+			return
+		}
 	}
 
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}

--- a/cmd/incus-agent/os_windows.go
+++ b/cmd/incus-agent/os_windows.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
+	"golang.org/x/sys/windows/svc/mgr"
 
 	"github.com/lxc/incus/v7/internal/ports"
 	"github.com/lxc/incus/v7/internal/server/metrics"
@@ -36,6 +37,62 @@ var (
 	osAgentConfigPath      = "C:\\Program Files\\Incus-Agent\\incus-agent.yml"
 	osVioSerialPath        = `\\.\org.linuxcontainers.incus`
 )
+
+// Check for the VirtioSocketWSP service for vsock support.
+func osLoadModules() error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return err
+	}
+
+	defer m.Disconnect()
+
+	viosockSvc := "VirtioSocketWSP"
+	s, err := m.OpenService(viosockSvc)
+	if err != nil {
+		return err
+	}
+
+	defer s.Close()
+
+	tryStart := func() (bool, error) {
+		status, err := s.Query()
+		if err != nil {
+			return false, err
+		}
+
+		if status.State == svc.Stopped {
+			err = s.Start()
+			if err != nil {
+				return false, err
+			}
+		}
+
+		return status.State == svc.Running, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
+	defer cancel()
+
+	// Try for 5s to start the service.
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("Unable to start viosock service: %w", ctx.Err())
+		default:
+			running, err := tryStart()
+			if err != nil {
+				return err
+			}
+
+			if running {
+				return nil
+			}
+
+			time.Sleep(time.Second)
+		}
+	}
+}
 
 func osGetListener(port int64) (net.Listener, error) {
 	const CIDAny uint32 = 4294967295 // Equivalent to VMADDR_CID_ANY.

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -447,7 +447,7 @@ func (d *qemu) getAgentClient() (*http.Client, error) {
 		return nil, err
 	}
 
-	if !monitor.AgenStarted() {
+	if !monitor.AgenStarted() || monitor.GetInstanceState() != nil {
 		return nil, errQemuAgentOffline
 	}
 
@@ -9460,8 +9460,15 @@ func (d *qemu) renderState(statusCode api.StatusCode) (*api.InstanceState, error
 		if err != nil {
 			if !errors.Is(err, errQemuAgentOffline) {
 				d.logger.Warn("Could not get VM state from agent", logger.Ctx{"err": err})
+			} else {
+				monitor, err := d.qmpConnect()
+				if err == nil && monitor.AgenStarted() {
+					agentStatus = monitor.GetInstanceState()
+				}
 			}
-		} else {
+		}
+
+		if agentStatus != nil {
 			status = agentStatus
 		}
 	}

--- a/internal/server/instance/drivers/qmp/monitor.go
+++ b/internal/server/instance/drivers/qmp/monitor.go
@@ -22,7 +22,7 @@ var (
 )
 
 // RingbufSize is the size of the agent serial ringbuffer in bytes.
-var RingbufSize = 16
+var RingbufSize = 1024 * 16
 
 // EventAgentStarted is the event sent once the agent has started.
 var EventAgentStarted = "AGENT-STARTED"

--- a/internal/server/instance/drivers/qmp/monitor.go
+++ b/internal/server/instance/drivers/qmp/monitor.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/lxc/incus/v7/internal/linux"
+	"github.com/lxc/incus/v7/shared/api"
 	"github.com/lxc/incus/v7/shared/logger"
 	"github.com/lxc/incus/v7/shared/util"
 )
@@ -83,6 +84,7 @@ type Monitor struct {
 	detachDisk     func(name string) error
 	eventMap       map[string]chan Event
 	eventMapLock   sync.Mutex
+	instanceState  *api.InstanceState
 }
 
 // TransactionAction represents a single action within a QMP transaction.
@@ -115,7 +117,21 @@ func (m *Monitor) start() error {
 		// Extract the last entry.
 		entries := strings.Split(resp.Return, "\n")
 		if len(entries) > 1 {
-			m.processAgentStatus(entries[len(entries)-2])
+			status := entries[len(entries)-2]
+			var instanceState *api.InstanceState
+			if len(entries) > 2 {
+				var s api.InstanceState
+				err := json.Unmarshal([]byte(status), &s)
+
+				if err == nil && s.Pid == 1 {
+					instanceState = &s
+				}
+
+				status = entries[len(entries)-3]
+			}
+
+			m.SetInstanceState(instanceState)
+			m.processAgentStatus(status)
 		}
 	}
 
@@ -445,6 +461,22 @@ func (m *Monitor) Wait() (chan struct{}, error) {
 	}
 
 	return m.chDisconnect, nil
+}
+
+// GetInstanceState fetches the recorded instance state.
+func (m *Monitor) GetInstanceState() *api.InstanceState {
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
+
+	return m.instanceState
+}
+
+// SetInstanceState updates the recorded instance state.
+func (m *Monitor) SetInstanceState(s *api.InstanceState) {
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
+
+	m.instanceState = s
 }
 
 // SetInitialized enables or disables the on disconnect event.

--- a/internal/server/instance/drivers/qmp/qmp.go
+++ b/internal/server/instance/drivers/qmp/qmp.go
@@ -266,7 +266,7 @@ func (qmp *qemuMachineProtocol) listen(r io.Reader, events chan<- qmpEvent, repl
 }
 
 // defaultCommandTimeout is how long we wait for a QMP reply before giving up.
-const defaultCommandTimeout = 100 * time.Millisecond
+const defaultCommandTimeout = 500 * time.Millisecond
 
 // blockCommandTimeout is used for block commands that do blocking storage I/O.
 const blockCommandTimeout = 5 * time.Second
@@ -288,6 +288,7 @@ var commandTimeouts = map[string]time.Duration{
 	"blockdev-mirror":           blockCommandTimeout,
 	"blockdev-snapshot":         blockCommandTimeout,
 	"change-backing-file":       blockCommandTimeout,
+	"query-block-jobs":          blockCommandTimeout,
 	"nbd-server-start":          blockCommandTimeout,
 	"nbd-server-stop":           blockCommandTimeout,
 	"transaction":               blockCommandTimeout,
@@ -299,6 +300,7 @@ var commandTimeouts = map[string]time.Duration{
 	"object-add":                heavyCommandTimeout,
 	"stop":                      heavyCommandTimeout,
 	"system_reset":              heavyCommandTimeout,
+	"query-migrate":             5 * time.Second,
 	"screendump":                10 * time.Second,
 }
 


### PR DESCRIPTION
Closes #3196

I used 16KiB for the ring buffer size after testing a VM with 9 NICs attached creating a 4KiB state object. Most of them didn't have addresses set, so once that's accounted for (as well as multiple addresses per NIC), I think 16KiB should be more than sufficient for most real-world use cases.

