### PR TITLE
incusd/device/disk: Use resolved project for Ceph ISO RBD names

### DIFF
--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -1481,6 +1481,10 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				Limits:  diskLimits,
 			}
 
+			if strings.HasSuffix(fields[1], ".iso") {
+				mount.FSType = "iso9660"
+			}
+
 			err := d.setBus(&mount)
 			if err != nil {
 				return nil, err
@@ -1552,8 +1556,17 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						clusterName = storageDrivers.CephDefaultUser
 					}
 
+					driverContentType, err := storagePools.VolumeDBContentTypeToContentType(contentType)
+					if err != nil {
+						return nil, err
+					}
+
+					volStorageName := project.StorageVolume(storageProjectName, volName)
+					vol := d.pool.GetVolume(storageDrivers.VolumeTypeCustom, driverContentType, volStorageName, dbVolume.Config)
+					rbdImageName := storageDrivers.CephGetRBDImageName(vol, "", false)
+
 					mount := deviceConfig.MountEntryItem{
-						DevPath: DiskGetRBDFormat(clusterName, userName, poolName, d.config["source"]),
+						DevPath: DiskGetRBDFormat(clusterName, userName, poolName, rbdImageName),
 						DevName: d.name,
 						Opts:    opts,
 						Limits:  diskLimits,

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4571,7 +4571,8 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]any, mountInfo *storagePool
 				clusterName = storageDrivers.CephDefaultUser
 			}
 
-			driveConf.DevPath = device.DiskGetRBDFormat(clusterName, userName, config["ceph.osd.pool_name"], vol.Name())
+			rbdImageName := storageDrivers.CephGetRBDImageName(vol, "", false)
+			driveConf.DevPath = device.DiskGetRBDFormat(clusterName, userName, config["ceph.osd.pool_name"], rbdImageName)
 		}
 	}
 
@@ -4895,37 +4896,17 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 	} else if isRBDImage {
 		blockDev["driver"] = "rbd"
 
-		poolName, volName, opts, err := device.DiskParseRBDFormat(driveConf.DevPath)
+		poolName, imageName, opts, err := device.DiskParseRBDFormat(driveConf.DevPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed parsing rbd string: %w", err)
 		}
-
-		// Driver and pool name arguments can be ignored as CephGetRBDImageName doesn't need them.
-		volumeType := storageDrivers.VolumeTypeCustom
-		volumeName := project.StorageVolume(d.project.Name, volName)
-
-		// Handle different name for instance volumes.
-		if driveConf.TargetPath == "/" {
-			volumeType = storageDrivers.VolumeTypeVM
-			volumeName = volName
-		}
-
-		// Identify the right content type.
-		rbdContentType := storageDrivers.ContentTypeBlock
-		if driveConf.FSType == "iso9660" {
-			rbdContentType = storageDrivers.ContentTypeISO
-		}
-
-		// Get the RBD image name.
-		vol := storageDrivers.NewVolume(nil, "", volumeType, rbdContentType, volumeName, nil, nil)
-		rbdImageName := storageDrivers.CephGetRBDImageName(vol, "", false)
 
 		// Scan & pass through options.
 		clusterName := storageDrivers.CephDefaultCluster
 		userName := storageDrivers.CephDefaultUser
 
 		blockDev["pool"] = poolName
-		blockDev["image"] = rbdImageName
+		blockDev["image"] = imageName
 		for key, val := range opts {
 			// We use 'id' where qemu uses 'user'.
 			switch key {


### PR DESCRIPTION
This fixes attaching inherited custom ISO volumes to VMs when the storage pool is backed by Ceph/RBD.

## Expected behavior

If a project has `features.storage.volumes=false`, custom storage volumes are shared from the default project. A VM in that project should therefore use the real owner project when attaching one of those volumes.

For example, an ISO imported into the default project should use this RBD image:

`custom_default_<volume>.iso`

## Actual behavior

The volume lookup used the effective storage project correctly, but the VM RBD setup later rebuilt the image name from the VM's project.

So a VM in another project tried to use:

`custom_<vm project>_<volume>.iso`

That image does not exist for inherited custom volumes, so VM start failed.

## Changes

- `internal/server/device/disk.go`
  - Build the Ceph custom block/ISO volume using the effective storage project.
  - Generate the RBD image name there, while the resolved volume identity is still available.
  - Treat external `source=ceph:<pool>/<image>` values ending in `.iso` as ISO media.

- `internal/server/instance/drivers/driver_qemu.go`
  - Pass Ceph root disks to QEMU with an already-resolved RBD image name.
  - Stop deriving a new Incus custom volume name inside the generic QEMU RBD path.
  - Use the image name from the RBD source string as-is.