### PR TITLE
incusd/instance/qemu: Use a shared memory backend on all architectures

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4399,7 +4399,7 @@ func (d *qemu) writeQemuConfigFile(configPath string) error {
 // getCPUOpts retrieves configuration options for virtualized CPUs and memory.
 func (d *qemu) getCPUOpts(cpuInfo *qemuCPUTopology, memSizeBytes int64) (*qemuCPUOpts, error) {
 	cpuOpts := qemuCPUOpts{
-		architecture: d.architectureName,
+		architecture: d.architecture,
 	}
 
 	hostNodes := []uint64{}
@@ -4504,7 +4504,11 @@ func (d *qemu) getCPUOpts(cpuInfo *qemuCPUTopology, memSizeBytes int64) (*qemuCP
 
 	// Determine per-node memory limit.
 	memSizeMB := memSizeBytes / 1024 / 1024
-	nodeMemory := int64(memSizeMB / int64(len(hostNodes)))
+	nodeMemory := memSizeMB
+	if d.architecture == osarch.ARCH_64BIT_INTEL_X86 {
+		nodeMemory = memSizeMB / int64(len(hostNodes))
+	}
+
 	cpuOpts.memory = nodeMemory
 
 	return &cpuOpts, nil
@@ -7019,8 +7023,8 @@ func (d *qemu) updateMemoryLimit(newLimit string) error {
 			memSlots := map[string]int64{}
 			memSlotsKeys := []string{}
 			for _, memDev := range memDevs {
-				// Skip base memory node.
-				if memDev.ID == "mem0" {
+				// Skip base memory objects.
+				if memDev.ID == "mem0" || memDev.ID == qemuDefaultRAMObject(d.architecture) {
 					continue
 				}
 

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -58,6 +58,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			accel = "kvm"
 			gic-version = "max"
 			graphics = "off"
+			memory-backend = "mach-virt.ram"
 			type = "virt"
 			usb = "off"
 
@@ -70,6 +71,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			accel = "kvm"
 			cap-large-decr = "off"
 			graphics = "off"
+			memory-backend = "ppc_spapr.ram"
 			type = "pseries"
 			usb = "off"
 
@@ -81,6 +83,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[machine]
 			accel = "kvm"
 			graphics = "off"
+			memory-backend = "s390.ram"
 			type = "s390-ccw-virtio"
 			usb = "off"
 
@@ -444,7 +447,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			expected string
 		}{{
 			qemuCPUOpts{
-				architecture:     "x86_64",
+				architecture:     osarch.ARCH_64BIT_INTEL_X86,
 				cpuCount:         8,
 				cpuSockets:       1,
 				cpuCores:         4,
@@ -473,7 +476,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			type = "node"`,
 		}, {
 			qemuCPUOpts{
-				architecture: "x86_64",
+				architecture: osarch.ARCH_64BIT_INTEL_X86,
 				cpuCount:     2,
 				cpuSockets:   1,
 				cpuCores:     2,
@@ -546,7 +549,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			type = "cpu"`,
 		}, {
 			qemuCPUOpts{
-				architecture: "x86_64",
+				architecture: osarch.ARCH_64BIT_INTEL_X86,
 				cpuCount:     2,
 				cpuSockets:   1,
 				cpuCores:     2,
@@ -607,7 +610,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			type = "cpu"`,
 		}, {
 			qemuCPUOpts{
-				architecture: "x86_64",
+				architecture: osarch.ARCH_64BIT_INTEL_X86,
 				cpuCount:     4,
 				cpuSockets:   1,
 				cpuCores:     4,
@@ -676,7 +679,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			type = "cpu"`,
 		}, {
 			qemuCPUOpts{
-				architecture: "arm64",
+				architecture: osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN,
 				cpuCount:     4,
 				cpuSockets:   1,
 				cpuCores:     4,
@@ -695,7 +698,38 @@ func TestQemuConfigTemplates(t *testing.T) {
 			cores = "4"
 			cpus = "4"
 			sockets = "1"
-			threads = "1"`,
+			threads = "1"
+
+			[object "mach-virt.ram"]
+			discard-data = "on"
+			mem-path = "/hugepages"
+			prealloc = "on"
+			qom-type = "memory-backend-file"
+			share = "on"
+			size = "12000M"`,
+		}, {
+			qemuCPUOpts{
+				architecture:    osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN,
+				cpuCount:        2,
+				cpuSockets:      1,
+				cpuCores:        2,
+				cpuThreads:      1,
+				memory:          4096,
+				memoryHostNodes: []int64{0},
+			},
+			`# CPU
+			[smp-opts]
+			cores = "2"
+			cpus = "2"
+			sockets = "1"
+			threads = "1"
+
+			[object "mach-virt.ram"]
+			host-nodes.0 = "0"
+			policy = "bind"
+			qom-type = "memory-backend-memfd"
+			share = "on"
+			size = "4096M"`,
 		}}
 		for _, tc := range testCases {
 			runTest(tc.expected, qemuCPU(&tc.opts, true))

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -80,6 +80,23 @@ func qemuMachineType(architecture int) string {
 	return machineType
 }
 
+// qemuDefaultRAMObject returns QEMU's default RAM object name for the architecture.
+// Reusing that name for an explicit main memory backend preserves migration compatibility.
+func qemuDefaultRAMObject(architecture int) string {
+	switch architecture {
+	case osarch.ARCH_64BIT_INTEL_X86:
+		return "pc.ram"
+	case osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN:
+		return "mach-virt.ram"
+	case osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN:
+		return "ppc_spapr.ram"
+	case osarch.ARCH_64BIT_S390_BIG_ENDIAN:
+		return "s390.ram"
+	}
+
+	return ""
+}
+
 type qemuBaseOpts struct {
 	architecture int
 	iommu        bool
@@ -117,6 +134,11 @@ func qemuBase(opts *qemuBaseOpts) []cfg.Section {
 
 	if opts.iommu {
 		sections[0].Entries["kernel-irqchip"] = "split"
+	}
+
+	// On non-x86_64, the main RAM is an explicit shared memory backend.
+	if opts.architecture != osarch.ARCH_64BIT_INTEL_X86 {
+		sections[0].Entries["memory-backend"] = qemuDefaultRAMObject(opts.architecture)
 	}
 
 	if opts.architecture == osarch.ARCH_64BIT_INTEL_X86 {
@@ -513,7 +535,7 @@ type qemuNumaEntry struct {
 }
 
 type qemuCPUOpts struct {
-	architecture     string
+	architecture     int
 	cpuCount         int
 	cpuRequested     int
 	cpuSockets       int
@@ -586,8 +608,24 @@ func qemuCPU(opts *qemuCPUOpts, pinning bool) []cfg.Section {
 		Entries: entries,
 	}}
 
-	if opts.architecture != "x86_64" {
-		return sections
+	if opts.architecture != osarch.ARCH_64BIT_INTEL_X86 {
+		// Define the main RAM as a shared memory backend so vhost-user devices (virtiofsd) can map it.
+		// It gets attached through the machine's memory-backend property.
+		ramObject := qemuCPUNumaHostNode(opts, 0)[0]
+		ramObject.Name = fmt.Sprintf("object %q", qemuDefaultRAMObject(opts.architecture))
+		ramObject.Entries["share"] = "on"
+
+		// If NUMA memory restrictions are set, apply them.
+		if len(opts.memoryHostNodes) > 0 {
+			ramObject.Entries["policy"] = "bind"
+
+			for index, element := range opts.memoryHostNodes {
+				hostNodesKey := fmt.Sprintf("host-nodes.%d", index)
+				ramObject.Entries[hostNodesKey] = fmt.Sprintf("%d", element)
+			}
+		}
+
+		return append(sections, ramObject)
 	}
 
 	if len(opts.cpuNumaHostNodes) == 0 {


### PR DESCRIPTION
…architectures

This fixes virtiofs on non-x86 as shared memory is required.