### PR TITLE
incusd/storage: Honor btrfs.compression on instances from optimized images

### DIFF
--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -4156,7 +4156,11 @@ func volumeConfigsMatch(vol1, vol2 drivers.Volume) bool {
 	// they're considered unequal ("" != "8KiB"), preventing the use of a matching optimized image.
 	blockSizeChanged := vol1.IsBlockBacked() && vol1.Config()["zfs.blocksize"] != vol2.Config()["zfs.blocksize"]
 
-	return !blockModeChanged && !blockFSChanged && !blockSizeChanged
+	// btrfs.compression sets the volume's compression and nodatacow state at creation time, which an
+	// optimized image snapshot would not carry over.
+	compressionChanged := vol1.Config()["btrfs.compression"] != vol2.Config()["btrfs.compression"]
+
+	return !blockModeChanged && !blockFSChanged && !blockSizeChanged && !compressionChanged
 }
 
 // DeleteImage removes an image from the database and underlying storage device if needed.

--- a/test/suites/storage_driver_btrfs.sh
+++ b/test/suites/storage_driver_btrfs.sh
@@ -47,6 +47,12 @@ test_storage_driver_btrfs() {
         # Import image into default storage pool.
         ensure_import_testimage
 
+        # btrfs.compression set on an instance is honored even when the root volume
+        # is created from an optimized image snapshot rather than a fresh volume.
+        incus init testimage c-comp-none -d root,initial.btrfs.compression=none
+        btrfs property get "${INCUS_DIR}/storage-pools/${compPool}/containers/c-comp-none" compression | grep -q "compression=none"
+        incus delete c-comp-none
+
         # Create first container in pool1 with subvolumes.
         incus launch testimage c1pool1 -s "incustest-$(basename "${INCUS_DIR}")-pool1"
 


### PR DESCRIPTION
Follow-up to #3511 / #3540, fixing #3590.

btrfs.compression=none works for a directly created volume (a custom volume, or a VM on a pool where volume.btrfs.compression=none is the default), but not for a VM created from an image with the setting only on the instance.

An instance from an image gets its root volume as a snapshot of the cached optimized image volume, so it inherits that volume's compression and nodatacow state. EnsureImage builds the image volume from the pool defaults, not the per-instance btrfs.compression, and CreateVolumeFromCopy does not apply it, so the instance's value is stored but never acted on. It only appears to work when the image volume already happens to be nodatacow, for example with a pool-wide volume.btrfs.compression=none.

This makes btrfs.compression significant in volumeConfigsMatch, alongside the existing zfs.blocksize case. When the instance value differs from the pool default the optimized image is skipped and the volume is created directly, where the compression and nodatacow handling added in #3540 runs. When it matches the default, including the pool-wide none case, the optimized image is still used.

Extended the Btrfs storage test to cover an instance created from an image with btrfs.compression=none ending up with the compression property applied. Confirmed it fails against the pre-fix code.
