### PR TITLE
 incusd/instance/qemu: Handle missing kvm64

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -10379,7 +10379,11 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 	if hostArch == osarch.ARCH_64BIT_INTEL_X86 {
 		model, err := monitor.QueryCPUModel("kvm64")
 		if err != nil {
-			return nil, err
+			// Fallback to qemu64 if kvm64 is missing (RHEL).
+			model, err = monitor.QueryCPUModel("qemu64")
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		cpuFlags := map[string]bool{}


### PR DESCRIPTION
Fixes #3603 

qemu >= 10.0 removed the legacy `kvm64` CPU model. The host-CPU baseline probe
in the qemu driver still requests `kvm64`, so on qemu 10.x the feature check
fails ("CPU model 'kvm64' not found") and the qemu driver is marked not
operational — VMs are disabled entirely on AlmaLinux/RHEL 10 (qemu-kvm 10.1.0).

This switches the x86_64 baseline probe to `qemu64`, which is the generic
baseline still present in qemu 10.x. Verified on AlmaLinux 10.2 / qemu-kvm
10.1.0: the qemu driver becomes operational again.

Note: 

qemu64 is itself marked deprecated in qemu 10.1, so a longer-term fix may
prefer to fall back gracefully when the probed baseline model is absent, rather
than hard-coding another named model.