### PR TITLE
client: Only pass device overrides to sources supporting them

### DIFF
--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -877,7 +877,12 @@ func (r *ProtocolIncus) CopyInstance(source InstanceServer, instance api.Instanc
 		Live:              req.Source.Live,
 		InstanceOnly:      req.Source.InstanceOnly,
 		AllowInconsistent: req.Source.AllowInconsistent,
-		Devices:           req.Devices,
+	}
+
+	// When dependent volumes are supported, Devices are sent to the
+	// migration source to allow overriding the per-device pools.
+	if source.HasExtension("dependent") {
+		sourceReq.Devices = req.Devices
 	}
 
 	// Push mode migration


### PR DESCRIPTION
Passing Devices during migration requests has been introduced with the dependent volume support. When interacting with a server that predates that feature, we should avoid passing the Devices as that can cause the server to assume a local cross-pool migration is being requested.