### PR TITLE
incusd/storage/ceph: Concurrent Deletion Adjustments

### DIFF
--- a/internal/server/storage/drivers/driver_ceph_utils.go
+++ b/internal/server/storage/drivers/driver_ceph_utils.go
@@ -49,6 +49,22 @@ var cephVolTypePrefixes = map[VolumeType]string{
 	VolumeTypeCustom:    db.StoragePoolVolumeTypeNameCustom,
 }
 
+// isRBDNotFoundExitError checks whether an rbd command failed with ENOENT.
+func isRBDNotFoundExitError(err error) bool {
+	var runError subprocess.RunError
+	if errors.As(err, &runError) {
+		var exitError *exec.ExitError
+		if errors.As(runError.Unwrap(), &exitError) {
+			if exitError.ExitCode() == 2 {
+				// ENOENT (no such image or snapshot).
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // osdPoolExists checks whether a given OSD pool exists.
 func (d *ceph) osdPoolExists() (bool, error) {
 	_, err := subprocess.RunCommand(
@@ -774,11 +790,15 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 		} else if zombies == 0 {
 			// Delete.
 			err = d.rbdDeleteVolume(vol)
-			if err != nil {
+			if err != nil && !isRBDNotFoundExitError(err) {
 				return -1, err
 			}
 		}
 	} else {
+		if isRBDNotFoundExitError(err) {
+			return 0, nil
+		}
+
 		if !response.IsNotFoundError(err) {
 			return -1, err
 		}
@@ -798,7 +818,7 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 
 			// Delete.
 			err = d.rbdDeleteVolume(vol)
-			if err != nil {
+			if err != nil && !isRBDNotFoundExitError(err) {
 				return -1, err
 			}
 
@@ -812,6 +832,10 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 				}
 			}
 		} else {
+			if isRBDNotFoundExitError(err) {
+				return 0, nil
+			}
+
 			if !response.IsNotFoundError(err) {
 				return -1, err
 			}
@@ -824,7 +848,7 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 
 			// Delete.
 			err = d.rbdDeleteVolume(vol)
-			if err != nil {
+			if err != nil && !isRBDNotFoundExitError(err) {
 				return -1, err
 			}
 		}
@@ -853,13 +877,17 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error) {
 	clones, err := d.rbdListSnapshotClones(vol, snapshotName)
 	if err != nil {
+		if isRBDNotFoundExitError(err) {
+			return 1, nil
+		}
+
 		if !response.IsNotFoundError(err) {
 			return -1, err
 		}
 
 		// Unprotect.
 		err = d.rbdUnprotectVolumeSnapshot(vol, snapshotName)
-		if err != nil {
+		if err != nil && !isRBDNotFoundExitError(err) {
 			return -1, err
 		}
 
@@ -871,7 +899,7 @@ func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error
 
 		// Delete.
 		err = d.rbdDeleteVolumeSnapshot(vol, snapshotName)
-		if err != nil {
+		if err != nil && !isRBDNotFoundExitError(err) {
 			return -1, err
 		}
 
@@ -913,7 +941,7 @@ func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error
 	if canDelete {
 		// Unprotect.
 		err = d.rbdUnprotectVolumeSnapshot(vol, snapshotName)
-		if err != nil {
+		if err != nil && !isRBDNotFoundExitError(err) {
 			return -1, err
 		}
 
@@ -925,7 +953,7 @@ func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error
 
 		// Delete.
 		err = d.rbdDeleteVolumeSnapshot(vol, snapshotName)
-		if err != nil {
+		if err != nil && !isRBDNotFoundExitError(err) {
 			return -1, err
 		}
 
@@ -950,6 +978,10 @@ func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error
 		newSnapshotName := fmt.Sprintf("zombie_snapshot_%s", uuid.New().String())
 		err = d.rbdRenameVolumeSnapshot(vol, snapshotName, newSnapshotName)
 		if err != nil {
+			if isRBDNotFoundExitError(err) {
+				return 1, nil
+			}
+
 			return -1, err
 		}
 	}

--- a/internal/server/storage/drivers/driver_ceph_volumes.go
+++ b/internal/server/storage/drivers/driver_ceph_volumes.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -718,7 +719,7 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 			if hasReadonlySnapshot {
 				// Unprotect snapshot.
 				err := d.rbdUnprotectVolumeSnapshot(vol, "readonly")
-				if err != nil {
+				if err != nil && !isRBDNotFoundExitError(err) {
 					return err
 				}
 			}
@@ -733,13 +734,13 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 				"purge",
 				d.getRBDVolumeName(vol, "", false),
 			)
-			if err != nil {
+			if err != nil && !isRBDNotFoundExitError(err) {
 				return err
 			}
 
 			// Delete image.
 			err = d.rbdDeleteVolume(vol)
-			if err != nil {
+			if err != nil && !isRBDNotFoundExitError(err) {
 				return err
 			}
 		}
@@ -750,12 +751,13 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 			return err
 		}
 
-		// If the volume is a clone, lock its parent image volume so concurrent deletions of
-		// sibling clones can't race the cleanup of the shared image snapshot.
+		// If the volume is a clone, lock its parent volume so concurrent deletions of sibling
+		// clones can't race the cleanup of the shared parent snapshot (this applies not only to
+		// image parents, but also to non-image volumes used as the source of a lightweight copy).
 		parent, err := d.rbdGetVolumeParent(vol)
 		if err == nil {
 			parentVol, _, err := d.parseParent(parent)
-			if err == nil && parentVol.volType == VolumeTypeImage {
+			if err == nil {
 				unlock, err := locking.Lock(context.TODO(), OperationLockName("DeleteVolume", d.name, parentVol.volType, parentVol.contentType, parentVol.name))
 				if err != nil {
 					return err
@@ -1519,6 +1521,10 @@ func (d *ceph) RenameVolume(vol Volume, newVolName string, op *operations.Operat
 
 		err := d.rbdRenameVolume(vol, newVolName)
 		if err != nil {
+			if isRBDNotFoundExitError(err) {
+				return api.StatusErrorf(http.StatusNotFound, "Ceph RBD volume not found")
+			}
+
 			return err
 		}
 
@@ -2046,6 +2052,10 @@ func (d *ceph) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *
 
 	err := d.rbdRenameVolumeSnapshot(parentVol, oldSnapOnlyName, newSnapOnlyName)
 	if err != nil {
+		if isRBDNotFoundExitError(err) {
+			return api.StatusErrorf(http.StatusNotFound, "Ceph RBD volume snapshot not found")
+		}
+
 		return err
 	}
 

--- a/internal/server/storage/drivers/driver_ceph_volumes.go
+++ b/internal/server/storage/drivers/driver_ceph_volumes.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lxc/incus/v7/internal/linux"
 	"github.com/lxc/incus/v7/internal/migration"
 	"github.com/lxc/incus/v7/internal/server/backup"
+	"github.com/lxc/incus/v7/internal/server/locking"
 	localMigration "github.com/lxc/incus/v7/internal/server/migration"
 	"github.com/lxc/incus/v7/internal/server/operations"
 	"github.com/lxc/incus/v7/internal/server/response"
@@ -676,8 +677,16 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 	}
 
 	if vol.volType == VolumeTypeImage {
+		// Lock the image volume so concurrent deletions of its clones can't race the cleanup.
+		unlock, err := locking.Lock(context.TODO(), OperationLockName("DeleteVolume", d.name, vol.volType, vol.contentType, vol.name))
+		if err != nil {
+			return err
+		}
+
+		defer unlock()
+
 		// Unmount and unmap.
-		_, err := d.UnmountVolume(vol, false, op)
+		_, err = d.UnmountVolume(vol, false, op)
 		if err != nil {
 			return err
 		}
@@ -739,6 +748,21 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 		_, err := d.UnmountVolume(vol, false, op)
 		if err != nil {
 			return err
+		}
+
+		// If the volume is a clone, lock its parent image volume so concurrent deletions of
+		// sibling clones can't race the cleanup of the shared image snapshot.
+		parent, err := d.rbdGetVolumeParent(vol)
+		if err == nil {
+			parentVol, _, err := d.parseParent(parent)
+			if err == nil && parentVol.volType == VolumeTypeImage {
+				unlock, err := locking.Lock(context.TODO(), OperationLockName("DeleteVolume", d.name, parentVol.volType, parentVol.contentType, parentVol.name))
+				if err != nil {
+					return err
+				}
+
+				defer unlock()
+			}
 		}
 
 		_, err = d.deleteVolume(vol)


### PR DESCRIPTION
## Bug

In a cluster setup with multiple Incus nodes and Ceph as a storage backend, I was seeing mutliple cases of errors such as:

```
Failed to run: rbd --id admin --cluster ceph snap rename ceph-default/zombie_image_52ca1d379f1eaf00619bc6989f31fc0b00638d1668e77522e869455b29189783_ext4.block@readonly ceph-default/zombie_image_52ca1d379f1eaf00619bc6989f31fc0b00638d1668e77522e869455b29189783_ext4.block@zombie_snapshot_e92d0e12-22a5-4a5b-b614-ffc6b298b29c: exit status 2 (rbd: renaming snap failed: (2) No such file or directory)
```

or

```
Failed to run: rbd --id admin --cluster ceph --image-feature layering --image-feature fast-diff --image-feature exclusive-lock --image-feature object-map clone ceph-default/image_08ef018903fa8b634fc1835ed6e319d387c518756aac3bc6b0a14fbb6a013632_ext4@readonly ceph-default/virtual-machine_019cae14-415d-7167-85e1-5a1283723adf_tf-test-7: exit status 2 (2026-07-10T09:55:33.501+0200 7f736f7fe6c0 -1 librbd::image::RefreshRequest: failed to locate snapshot: readonly
2026-07-10T09:55:33.501+0200 7f736f7fe6c0 -1 librbd::image::OpenRequest: failed to find snapshot readonly
2026-07-10T09:55:33.501+0200 7f73627fc6c0 -1 librbd::image::CloneRequest: 0x561a1e294a80 handle_open_parent: failed to open parent image: (2) No such file or directory
rbd: clone error: (2) No such file or directory)
```

The current implementation doesn't protect against concurrent cases, where objects may have already been renamed or deleted, resulting in a lot of `ENOENT` errors from ceph.

## Fix

This PR adds a helper function that detects `ENOENT` exit codes and allows them in cases where we don't mind if an object does not exist anymore.
Additionally this adds a lock in `DeleteVolume` so we don't race the parent cleanup.