### PR TITLE
Add storage pool usage metrics

### DIFF
--- a/cmd/incusd/api_metrics.go
+++ b/cmd/incusd/api_metrics.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lxc/incus/v7/internal/server/request"
 	"github.com/lxc/incus/v7/internal/server/response"
 	"github.com/lxc/incus/v7/internal/server/state"
+	storagePools "github.com/lxc/incus/v7/internal/server/storage"
 	"github.com/lxc/incus/v7/shared/api"
 	"github.com/lxc/incus/v7/shared/logger"
 )
@@ -104,6 +105,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	metricSet := metrics.NewMetricSet(nil)
 
 	var projectNames []string
+	var poolNames []string
 	var intMetrics *metrics.MetricSet
 
 	err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -123,6 +125,14 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
+		// Get the storage pool names.
+		var err error
+
+		poolNames, err = tx.GetCreatedStoragePoolNames(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed loading storage pools: %w", err)
+		}
+
 		// Add internal metrics.
 		intMetrics = internalMetrics(ctx, s, tx)
 
@@ -130,6 +140,25 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	})
 	if err != nil {
 		return response.SmartError(err)
+	}
+
+	// Add storage pool metrics (outside of the transaction as it loads the pools).
+	for _, poolName := range poolNames {
+		pool, err := storagePools.LoadByName(s, poolName)
+		if err != nil {
+			logger.Warn("Failed loading storage pool", logger.Ctx{"pool": poolName, "err": err})
+			continue
+		}
+
+		res, err := pool.GetResources()
+		if err != nil {
+			logger.Warn("Failed getting storage pool resources", logger.Ctx{"pool": poolName, "err": err})
+			continue
+		}
+
+		labels := map[string]string{"pool": poolName, "driver": pool.Driver().Info().Name}
+		intMetrics.AddSamples(metrics.StoragePoolUsedBytes, metrics.Sample{Labels: labels, Value: float64(res.Space.Used)})
+		intMetrics.AddSamples(metrics.StoragePoolTotalBytes, metrics.Sample{Labels: labels, Value: float64(res.Space.Total)})
 	}
 
 	// invalidProjectFilters returns project filters which are either not in cache or have expired.

--- a/doc/reference/provided_metrics.md
+++ b/doc/reference/provided_metrics.md
@@ -169,6 +169,10 @@ The following internal metrics are provided:
   - Number of bytes obtained from system
 * - `incus_operations_total`
   - Number of running operations
+* - `incus_storage_pool_total_bytes{pool="<pool>",driver="<driver>"}`
+  - Total space of the storage pool (in bytes)
+* - `incus_storage_pool_used_bytes{pool="<pool>",driver="<driver>"}`
+  - Used space of the storage pool (in bytes)
 * - `incus_uptime_seconds`
   - Daemon uptime (in seconds)
 * - `incus_warnings_total`

--- a/internal/server/metrics/types.go
+++ b/internal/server/metrics/types.go
@@ -109,7 +109,11 @@ const (
 	ProjectLimit
 	// ProjectUsage represents the current project resource usage.
 	ProjectUsage
-	// GoGoroutines represents the number of goroutines that currently exist..
+	// StoragePoolUsedBytes represents the used space in bytes on a storage pool.
+	StoragePoolUsedBytes
+	// StoragePoolTotalBytes represents the total space in bytes on a storage pool.
+	StoragePoolTotalBytes
+	// GoGoroutines represents the number of goroutines that currently exist.
 	GoGoroutines
 	// GoAllocBytes represents the number of bytes allocated and still in use.
 	GoAllocBytes
@@ -225,6 +229,8 @@ var MetricNames = map[MetricType]string{
 	ProjectLimit:                "incus_project_limit",
 	ProjectResourcesTotal:       "incus_project_resources_total",
 	ProjectUsage:                "incus_project_usage",
+	StoragePoolUsedBytes:        "incus_storage_pool_used_bytes",
+	StoragePoolTotalBytes:       "incus_storage_pool_total_bytes",
 	TimeSeconds:                 "incus_time_seconds",
 	UptimeSeconds:               "incus_uptime_seconds",
 	WarningsTotal:               "incus_warnings_total",
@@ -298,6 +304,8 @@ var MetricHeaders = map[MetricType]string{
 	ProjectLimit:                "# HELP incus_project_limit Current project resource limit.",
 	ProjectResourcesTotal:       "# HELP incus_project_resources_total Current resource count in a project.",
 	ProjectUsage:                "# HELP incus_project_usage Current project resource usage.",
+	StoragePoolUsedBytes:        "# HELP incus_storage_pool_used_bytes The used space in bytes on a storage pool.",
+	StoragePoolTotalBytes:       "# HELP incus_storage_pool_total_bytes The total space in bytes on a storage pool.",
 	TimeSeconds:                 "# HELP incus_time_seconds The current unix epoch.",
 	UptimeSeconds:               "# HELP incus_uptime_seconds The daemon uptime in seconds.",
 	WarningsTotal:               "# HELP incus_warnings_total The number of active warnings.",


### PR DESCRIPTION
Closes #3626 

Adds storage pool usage to the /1.0/metrics endpoint, so pool capacity can be scraped and alerted on from Prometheus/Grafana like every other Incus metric.

Two gauges, sourced from the same place as the storage pool resources API:

    incus_storage_pool_used_bytes{pool="...", driver="..."}
    incus_storage_pool_total_bytes{pool="...", driver="..."}

Until now the only pool-level metrics were per-instance filesystem stats (the guest rootfs), which don't tell you how full the underlying pool is.

Example:

    $ incus query /1.0/metrics | grep storage_pool_used_bytes
    incus_storage_pool_used_bytes{driver="dir",pool="default"} 1.82748770304e+11
    incus_storage_pool_used_bytes{driver="dir",pool="testpool2"} 1.82748770304e+11

On cost: collecting a pool's resources measured ~21ms per call on a dir pool, well within a scrape interval. For remote drivers this could be cached in a follow-up if it proves expensive.