### PR TITLE
network/ovn: Tolerate stop failures during network deletion 

### DIFF
--- a/cmd/incusd/networks.go
+++ b/cmd/incusd/networks.go
@@ -1178,7 +1178,11 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	if n.LocalStatus() != api.NetworkStatusPending {
+	// Also run the driver deletion for locally pending OVN networks on the client-facing request,
+	// as their cluster-wide state would otherwise be leaked once the DB record is removed below.
+	// Local-only drivers are still skipped as their deletion could touch host interfaces that were
+	// never created by the daemon.
+	if n.LocalStatus() != api.NetworkStatusPending || (clientType == clusterRequest.ClientTypeNormal && n.Type() == "ovn") {
 		err = n.Delete(clientType)
 		if err != nil {
 			return response.InternalError(err)

--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -1290,7 +1290,7 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 	}
 
 	var ovsExternalOVNPort string
-	if d.config["nested"] == "" {
+	if d.config["nested"] == "" && vswitch != nil {
 		ovsExternalOVNPort, err = vswitch.GetInterfaceAssociatedOVNSwitchPort(context.TODO(), d.config["host_name"])
 		if err != nil {
 			d.logger.Warn("Could not find OVN Switch port associated to OVS interface", logger.Ctx{"interface": d.config["host_name"]})
@@ -1309,7 +1309,7 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 	// Do this early on during the stop process to prevent any future error from leaving the OVS port present
 	// as if the instance is being migrated, this can cause port conflicts in OVN if the instance comes up on
 	// another host later.
-	if integrationBridgeNICName != "" {
+	if integrationBridgeNICName != "" && vswitch != nil {
 		integrationBridge := d.state.GlobalConfig.NetworkOVNIntegrationBridge()
 
 		// Detach host-side end of veth pair from OVS integration bridge.
@@ -1320,15 +1320,21 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 		}
 	}
 
-	instanceUUID := d.inst.LocalConfig()["volatile.uuid"]
-	err = d.network.InstanceDevicePortStop(ovn.OVNSwitchPort(ovsExternalOVNPort), &network.OVNInstanceNICStopOpts{
-		InstanceUUID: instanceUUID,
-		DeviceName:   d.name,
-		DeviceConfig: nicNormalizedAddressConfig(d.config),
-	})
-	if err != nil {
-		// Don't fail here as we still want the postStop hook to run to clean up the local veth pair.
-		d.logger.Error("Failed to remove OVN device port", logger.Ctx{"err": err})
+	// The network is nil when the device config failed validation (e.g. network still pending).
+	// Don't fail here either, so that the postStop hook still runs to clean up the local veth pair.
+	if d.network != nil {
+		instanceUUID := d.inst.LocalConfig()["volatile.uuid"]
+		err = d.network.InstanceDevicePortStop(ovn.OVNSwitchPort(ovsExternalOVNPort), &network.OVNInstanceNICStopOpts{
+			InstanceUUID: instanceUUID,
+			DeviceName:   d.name,
+			DeviceConfig: nicNormalizedAddressConfig(d.config),
+		})
+		if err != nil {
+			// Don't fail here as we still want the postStop hook to run to clean up the local veth pair.
+			d.logger.Error("Failed to remove OVN device port", logger.Ctx{"err": err})
+		}
+	} else {
+		d.logger.Error("Skipping OVN device port removal, network could not be loaded", logger.Ctx{"network": d.config["network"]})
 	}
 
 	// Remove BGP announcements.
@@ -1422,6 +1428,11 @@ func (d *nicOVN) postStop() error {
 
 // Remove is run when the device is removed from the instance or the instance is deleted.
 func (d *nicOVN) Remove(cleanupDependencies bool) error {
+	// The network is nil when the device config failed validation (e.g. network still pending).
+	if d.network == nil {
+		return fmt.Errorf("Failed removing OVN port for NIC %q: network %q could not be loaded", d.name, d.config["network"])
+	}
+
 	// Check for port groups that will become unused (and need deleting) as this NIC is deleted.
 	securityACLs := util.SplitNTrimSpace(d.config["security.acls"], ",", -1, true)
 	if len(securityACLs) > 0 {

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -3673,9 +3673,10 @@ func (n *ovn) deleteChassisGroupEntry() error {
 func (n *ovn) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", logger.Ctx{"clientType": clientType})
 
+	// Don't fail on stop errors as that would prevent the northbound database cleanup below.
 	err := n.Stop()
 	if err != nil {
-		return err
+		n.logger.Warn("Failed stopping network during delete, continuing with deletion", logger.Ctx{"err": err})
 	}
 
 	if clientType == request.ClientTypeNormal {


### PR DESCRIPTION
I was seeing multiple counts of orphaned logical-routers in my OVN database after running some load-testing on my Incus cluster. It seems that deleting an OVN network stuck in `Pending` state currently leaks its northbound DB objects, since the driver deletion is skipped but the db record still gets removed. After some digging, this is the only trigger I could make out.
### Proposed Fix:
- tolerate `Stop()` failures during `Delete()` so the NB cleanup still runs
- run driver deletion for locally pending networks on the client-facing request
- handle `network` being nil on stop/remove instead of panicking

Feel free to edit/comment.