### PR TITLE
incusd/metrics: Rename incus_storage_pool_total_bytes to incus_storag…

### DIFF
--- a/cmd/incusd/api_metrics.go
+++ b/cmd/incusd/api_metrics.go
@@ -158,7 +158,7 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 		labels := map[string]string{"pool": poolName, "driver": pool.Driver().Info().Name}
 		intMetrics.AddSamples(metrics.StoragePoolUsedBytes, metrics.Sample{Labels: labels, Value: float64(res.Space.Used)})
-		intMetrics.AddSamples(metrics.StoragePoolTotalBytes, metrics.Sample{Labels: labels, Value: float64(res.Space.Total)})
+		intMetrics.AddSamples(metrics.StoragePoolSizeBytes, metrics.Sample{Labels: labels, Value: float64(res.Space.Total)})
 	}
 
 	// invalidProjectFilters returns project filters which are either not in cache or have expired.

--- a/doc/reference/provided_metrics.md
+++ b/doc/reference/provided_metrics.md
@@ -169,7 +169,7 @@ The following internal metrics are provided:
   - Number of bytes obtained from system
 * - `incus_operations_total`
   - Number of running operations
-* - `incus_storage_pool_total_bytes{pool="<pool>",driver="<driver>"}`
+* - `incus_storage_pool_size_bytes{pool="<pool>",driver="<driver>"}`
   - Total space of the storage pool (in bytes)
 * - `incus_storage_pool_used_bytes{pool="<pool>",driver="<driver>"}`
   - Used space of the storage pool (in bytes)

--- a/internal/server/metrics/types.go
+++ b/internal/server/metrics/types.go
@@ -111,8 +111,8 @@ const (
 	ProjectUsage
 	// StoragePoolUsedBytes represents the used space in bytes on a storage pool.
 	StoragePoolUsedBytes
-	// StoragePoolTotalBytes represents the total space in bytes on a storage pool.
-	StoragePoolTotalBytes
+	// StoragePoolSizeBytes represents the total space in bytes on a storage pool.
+	StoragePoolSizeBytes
 	// GoGoroutines represents the number of goroutines that currently exist.
 	GoGoroutines
 	// GoAllocBytes represents the number of bytes allocated and still in use.
@@ -230,7 +230,7 @@ var MetricNames = map[MetricType]string{
 	ProjectResourcesTotal:       "incus_project_resources_total",
 	ProjectUsage:                "incus_project_usage",
 	StoragePoolUsedBytes:        "incus_storage_pool_used_bytes",
-	StoragePoolTotalBytes:       "incus_storage_pool_total_bytes",
+	StoragePoolSizeBytes:        "incus_storage_pool_size_bytes",
 	TimeSeconds:                 "incus_time_seconds",
 	UptimeSeconds:               "incus_uptime_seconds",
 	WarningsTotal:               "incus_warnings_total",
@@ -305,7 +305,7 @@ var MetricHeaders = map[MetricType]string{
 	ProjectResourcesTotal:       "# HELP incus_project_resources_total Current resource count in a project.",
 	ProjectUsage:                "# HELP incus_project_usage Current project resource usage.",
 	StoragePoolUsedBytes:        "# HELP incus_storage_pool_used_bytes The used space in bytes on a storage pool.",
-	StoragePoolTotalBytes:       "# HELP incus_storage_pool_total_bytes The total space in bytes on a storage pool.",
+	StoragePoolSizeBytes:        "# HELP incus_storage_pool_size_bytes The total space in bytes on a storage pool.",
 	TimeSeconds:                 "# HELP incus_time_seconds The current unix epoch.",
 	UptimeSeconds:               "# HELP incus_uptime_seconds The daemon uptime in seconds.",
 	WarningsTotal:               "# HELP incus_warnings_total The number of active warnings.",


### PR DESCRIPTION
…e_pool_size_bytes

Makes it more consistent with filesystem metrics and general Prometheus preference.