### PR TITLE
Add support for multiple authorizers

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -813,7 +813,9 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	bgpChanged := false
 	dnsChanged := false
 	oidcChanged := false
-	openFGAChanged := false
+	authorizationChanged := false
+	openfgaChanged := false
+	authorizationScriptletChanged := false
 	ovnChanged := false
 	linstorChanged := false
 	ovsChanged := false
@@ -862,8 +864,16 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.claim", "oidc.scopes":
 			oidcChanged = true
 
-		case "authorization.openfga.api.url", "authorization.openfga.api.token", "authorization.openfga.store.id":
-			openFGAChanged = true
+		case "authorization.openfga.api.url", "authorization.openfga.api.token", "authorization.openfga.store.id", "authorization.openfga.tls.identifier":
+			authorizationChanged = true
+			openfgaChanged = true
+
+		case "authorization.scriptlet":
+			authorizationChanged = true
+			authorizationScriptletChanged = true
+
+		case "authorization.client.default", "authorization.client.unix", "authorization.client.tls", "authorization.client.tls-restricted", "authorization.client.oidc":
+			authorizationChanged = true
 
 		case "storage.linstor.controller_connection", "storage.linstor.ca_cert", "storage.linstor.client_cert", "storage.linstor.client_key":
 			linstorChanged = true
@@ -1017,9 +1027,18 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		}
 	}
 
-	if openFGAChanged {
-		openfgaAPIURL, openfgaAPIToken, openfgaStoreID := d.globalConfig.OpenFGA()
-		err := d.setupOpenFGA(openfgaAPIURL, openfgaAPIToken, openfgaStoreID)
+	if authorizationChanged {
+		// Reload only the optional drivers whose config changed.
+		var reload []string
+		if openfgaChanged {
+			reload = append(reload, auth.DriverOpenFGA)
+		}
+
+		if authorizationScriptletChanged {
+			reload = append(reload, auth.DriverScriptlet)
+		}
+
+		err := d.setupAuthorization(reload...)
 		if err != nil {
 			return err
 		}
@@ -1059,15 +1078,6 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		err := scriptletLoad.InstancePlacementSet(value)
 		if err != nil {
 			return fmt.Errorf("Failed saving instance placement scriptlet: %w", err)
-		}
-	}
-
-	// Setup the authorization scriptlet.
-	value, ok = clusterChanged["authorization.scriptlet"]
-	if ok {
-		err := d.setupAuthorizationScriptlet(value)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -76,7 +76,6 @@ import (
 	"github.com/lxc/incus/v7/shared/cancel"
 	"github.com/lxc/incus/v7/shared/logger"
 	"github.com/lxc/incus/v7/shared/proxy"
-	"github.com/lxc/incus/v7/shared/revert"
 	localtls "github.com/lxc/incus/v7/shared/tls"
 	"github.com/lxc/incus/v7/shared/util"
 	"github.com/lxc/incus/v7/shared/ws"
@@ -155,7 +154,8 @@ type Daemon struct {
 	loggingController *logging.Controller
 
 	// Authorization.
-	authorizer auth.Authorizer
+	authorizer   *auth.Router
+	authorizerMu sync.Mutex
 
 	// Syslog listener cancel function.
 	syslogSocketCancel context.CancelFunc
@@ -735,6 +735,14 @@ func (d *Daemon) createCmd(restAPI *http.ServeMux, apiVersion string, c APIEndpo
 			ctx := context.WithValue(r.Context(), request.CtxUsername, username)
 			ctx = context.WithValue(ctx, request.CtxProtocol, protocol)
 
+			// Flag requests made by the root user over the local unix socket.
+			if protocol == "unix" {
+				cred, err := ucred.GetCredFromContext(r.Context())
+				if err == nil && cred.Uid == uint32(0) {
+					ctx = context.WithValue(ctx, request.CtxUnixIsRoot, true)
+				}
+			}
+
 			// Add forwarded requestor data.
 			if protocol == "cluster" {
 				// Add authentication/authorization context data.
@@ -951,8 +959,8 @@ func (d *Daemon) init() error {
 
 	var dbWarnings []dbCluster.Warning
 
-	// Set default authorizer.
-	d.authorizer, err = auth.LoadAuthorizer(d.shutdownCtx, auth.DriverTLS, logger.Log, d.clientCerts)
+	// Set up the authorization router.
+	d.authorizer, err = auth.NewRouter(d.shutdownCtx, logger.Log, d.clientCerts)
 	if err != nil {
 		return err
 	}
@@ -1370,9 +1378,7 @@ func (d *Daemon) init() error {
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim := d.globalConfig.OIDCServer()
 	syslogSocketEnabled := d.localConfig.SyslogSocket()
-	openfgaAPIURL, openfgaAPIToken, openfgaStoreID := d.globalConfig.OpenFGA()
 	instancePlacementScriptlet := d.globalConfig.InstancesPlacementScriptlet()
-	authorizationScriptlet := d.globalConfig.AuthorizationScriptlet()
 
 	d.endpoints.NetworkUpdateTrustedProxy(d.globalConfig.HTTPSTrustedProxy())
 	ws.SetTrustedOrigins(d.globalConfig.HTTPSAllowedWebsocketOrigin())
@@ -1400,20 +1406,10 @@ func (d *Daemon) init() error {
 		}
 	}
 
-	// Setup OpenFGA authorization.
-	if openfgaAPIURL != "" && openfgaStoreID != "" && openfgaAPIToken != "" {
-		err = d.setupOpenFGA(openfgaAPIURL, openfgaAPIToken, openfgaStoreID)
-		if err != nil {
-			return fmt.Errorf("Failed to configure OpenFGA: %w", err)
-		}
-	}
-
-	// Setup the authorization scriptlet.
-	if authorizationScriptlet != "" {
-		err = d.setupAuthorizationScriptlet(authorizationScriptlet)
-		if err != nil {
-			return err
-		}
+	// Setup authorization, loading every optional driver.
+	err = d.setupAuthorization(auth.DriverOpenFGA, auth.DriverScriptlet)
+	if err != nil {
+		return fmt.Errorf("Failed to configure authorization: %w", err)
 	}
 
 	// Setup BGP listener.
@@ -1889,40 +1885,83 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 	return err
 }
 
-// Setup OpenFGA.
-func (d *Daemon) setupOpenFGA(apiURL string, apiToken string, storeID string) error {
-	var err error
+// setupAuthorization builds the authorization router from the current global configuration.
+func (d *Daemon) setupAuthorization(reload ...string) error {
+	d.authorizerMu.Lock()
+	defer d.authorizerMu.Unlock()
 
-	if d.authorizer != nil {
-		err := d.authorizer.StopService(d.shutdownCtx)
-		if err != nil {
-			logger.Error("Failed to stop authorizer service", logger.Ctx{"error": err})
+	optional := map[string]auth.Authorizer{}
+
+	// Carry over the optional drivers we are not reloading from the running router.
+	for _, name := range []string{auth.DriverOpenFGA, auth.DriverScriptlet} {
+		if slices.Contains(reload, name) {
+			continue
+		}
+
+		authDriver := d.authorizer.LoadedDriver(name)
+		if authDriver != nil {
+			optional[name] = authDriver
 		}
 	}
 
-	if apiURL == "" || apiToken == "" || storeID == "" {
-		// Reset to default authorizer.
-		d.authorizer, err = auth.LoadAuthorizer(d.shutdownCtx, auth.DriverTLS, logger.Log, d.clientCerts)
+	if slices.Contains(reload, auth.DriverOpenFGA) {
+		openfgaAPIURL, openfgaAPIToken, openfgaStoreID, openfgaTLSIdentifier := d.globalConfig.OpenFGA()
+
+		// Stop the previously loaded OpenFGA driver if loaded.
+		previousOpenFGA := d.authorizer.LoadedDriver(auth.DriverOpenFGA)
+		if previousOpenFGA != nil {
+			err := previousOpenFGA.StopService(d.shutdownCtx)
+			if err != nil {
+				logger.Error("Failed to stop OpenFGA authorizer service", logger.Ctx{"error": err})
+			}
+		}
+
+		if openfgaAPIURL != "" && openfgaStoreID != "" && openfgaAPIToken != "" {
+			openfgaDriver, err := d.setupOpenFGA(openfgaAPIURL, openfgaAPIToken, openfgaStoreID, openfgaTLSIdentifier)
+			if err != nil {
+				return err
+			}
+
+			optional[auth.DriverOpenFGA] = openfgaDriver
+		}
+	}
+
+	if slices.Contains(reload, auth.DriverScriptlet) {
+		scriptletDriver, err := d.setupAuthorizationScriptlet(d.globalConfig.AuthorizationScriptlet())
 		if err != nil {
 			return err
 		}
 
-		return nil
+		if scriptletDriver != nil {
+			optional[auth.DriverScriptlet] = scriptletDriver
+		}
 	}
 
+	return d.authorizer.Configure(d.globalConfig.AuthorizationClientRoutes(), optional)
+}
+
+// setupAuthorizationScriptlet loads scriptlet driver.
+func (d *Daemon) setupAuthorizationScriptlet(scriptlet string) (auth.Authorizer, error) {
+	err := scriptletLoad.AuthorizationSet(scriptlet)
+	if err != nil {
+		return nil, fmt.Errorf("Failed saving authorization scriptlet: %w", err)
+	}
+
+	if scriptlet == "" {
+		return nil, nil
+	}
+
+	return auth.LoadAuthorizer(d.shutdownCtx, auth.DriverScriptlet, logger.Log, d.clientCerts)
+}
+
+// setupOpenFGA loads the OpenFGA authorization driver.
+func (d *Daemon) setupOpenFGA(apiURL string, apiToken string, storeID string, tlsIdentifier string) (auth.Authorizer, error) {
 	config := map[string]any{
-		"authorization.openfga.api.url":   apiURL,
-		"authorization.openfga.api.token": apiToken,
-		"authorization.openfga.store.id":  storeID,
+		"authorization.openfga.api.url":        apiURL,
+		"authorization.openfga.api.token":      apiToken,
+		"authorization.openfga.store.id":       storeID,
+		"authorization.openfga.tls.identifier": tlsIdentifier,
 	}
-
-	reverter := revert.New()
-	defer reverter.Fail()
-
-	reverter.Add(func() {
-		// Reset to default authorizer.
-		d.authorizer, _ = auth.LoadAuthorizer(d.shutdownCtx, auth.DriverTLS, logger.Log, d.clientCerts)
-	})
 
 	// Build the list of resources to update the model.
 	refreshResources := func() (*auth.Resources, error) {
@@ -2168,47 +2207,7 @@ func (d *Daemon) setupOpenFGA(apiURL string, apiToken string, storeID string) er
 		return &resources, nil
 	}
 
-	openfgaAuthorizer, err := auth.LoadAuthorizer(d.shutdownCtx, auth.DriverOpenFGA, logger.Log, d.clientCerts, auth.WithConfig(config), auth.WithResourcesFunc(refreshResources))
-	if err != nil {
-		return err
-	}
-
-	d.authorizer = openfgaAuthorizer
-
-	reverter.Success()
-	return nil
-}
-
-// Setup authorization scriptlet.
-func (d *Daemon) setupAuthorizationScriptlet(scriptlet string) error {
-	err := scriptletLoad.AuthorizationSet(scriptlet)
-	if err != nil {
-		return fmt.Errorf("Failed saving authorization scriptlet: %w", err)
-	}
-
-	if scriptlet == "" {
-		// Reset to default authorizer.
-		d.authorizer, err = auth.LoadAuthorizer(d.shutdownCtx, auth.DriverTLS, logger.Log, d.clientCerts)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	// Fail if not using the default tls or scriptlet authorizer.
-	switch d.authorizer.(type) {
-	case *auth.TLS, *auth.Scriptlet:
-		d.authorizer, err = auth.LoadAuthorizer(d.shutdownCtx, auth.DriverScriptlet, logger.Log, d.clientCerts)
-		if err != nil {
-			return err
-		}
-
-	default:
-		return errors.New("Attempting to setup scriptlet authorization while another authorizer is already set")
-	}
-
-	return nil
+	return auth.LoadAuthorizer(d.shutdownCtx, auth.DriverOpenFGA, logger.Log, d.clientCerts, auth.WithConfig(config), auth.WithResourcesFunc(refreshResources))
 }
 
 // Syslog listener.

--- a/cmd/incusd/patches.go
+++ b/cmd/incusd/patches.go
@@ -15,6 +15,7 @@ import (
 	linstorClient "github.com/LINBIT/golinstor/client"
 
 	internalInstance "github.com/lxc/incus/v7/internal/instance"
+	"github.com/lxc/incus/v7/internal/server/auth"
 	"github.com/lxc/incus/v7/internal/server/backup"
 	"github.com/lxc/incus/v7/internal/server/certificate"
 	"github.com/lxc/incus/v7/internal/server/cluster"
@@ -102,6 +103,7 @@ var patches = []patch{
 	{name: "linstor_tune_rs_discard_granularity", stage: patchPostDaemonStorage, run: patchLinstorDiscardGranularity},
 	{name: "storage_lvmcluster_qcow2_overhead", stage: patchPostDaemonStorage, run: patchGenericStorage},
 	{name: "authorization_openfga_config_keys", stage: patchPreDaemonStorage, run: patchAuthorizationOpenFGAConfigKeys},
+	{name: "authorization_client_routes_from_driver", stage: patchPreDaemonStorage, run: patchAuthorizationClientRoutesFromDriver},
 }
 
 type patchRun func(name string, d *Daemon) error
@@ -1873,6 +1875,49 @@ func patchAuthorizationOpenFGAConfigKeys(_ string, d *Daemon) error {
 
 		if len(changes) == 0 {
 			return nil
+		}
+
+		err = tx.UpdateClusterConfig(changes)
+		if err != nil {
+			return fmt.Errorf("Failed updating cluster config: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// patchAuthorizationClientRoutesFromDriver seeds authorization.client.* config
+// from the current authorizer class, so an upgrade keeps enforcing the same driver.
+func patchAuthorizationClientRoutesFromDriver(_ string, d *Daemon) error {
+	return d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		config, err := tx.Config(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed getting cluster config: %w", err)
+		}
+
+		// If any explicit route is already set, the routing table has been
+		// configured directly; leave it untouched.
+		for _, class := range []string{"default", "unix", "tls", "tls-restricted", "oidc"} {
+			if config["authorization.client."+class] != "" {
+				return nil
+			}
+		}
+
+		// Determine the implicitly selected driver, matching the legacy startup
+		// precedence: scriptlet over OpenFGA over the default (TLS) driver.
+		var changes map[string]string
+		switch {
+		case config["authorization.scriptlet"] != "":
+			changes = map[string]string{
+				"authorization.client.tls":            auth.DriverScriptlet,
+				"authorization.client.tls-restricted": auth.DriverScriptlet,
+				"authorization.client.oidc":           auth.DriverScriptlet,
+			}
+
+		case config["authorization.openfga.api.url"] != "" && config["authorization.openfga.api.token"] != "" && config["authorization.openfga.store.id"] != "":
+			changes = map[string]string{
+				"authorization.client.oidc": auth.DriverOpenFGA,
+			}
 		}
 
 		err = tx.UpdateClusterConfig(changes)

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -180,6 +180,7 @@ MiB
 Mibit
 MicroCeph
 MicroCloud
+misconfigured
 MCS
 MII
 MITM

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3285,3 +3285,29 @@ a local TCP listener which forwards every connection to the instance.
 This adds the `limits.read` and `limits.write` configuration keys to
 `unix-block` devices. These behave similarly to their `disk` device
 equivalents, accepting either a byte/s value or an IOPS value.
+
+## `authorization_client_routing`
+
+This allows loading multiple authorization drivers at once and routing each
+request to one of them based on the authentication class of the client.
+
+The following server configuration keys are added:
+
+* `authorization.client.default`: driver for clients without a more specific class route
+* `authorization.client.unix`: driver for local (`unix` socket) clients
+* `authorization.client.tls`: driver for unrestricted TLS clients
+* `authorization.client.tls-restricted`: driver for restricted (project-scoped) TLS clients
+* `authorization.client.oidc`: driver for OIDC-authenticated clients
+
+Each key accepts one of `allow`, `deny`, `openfga` or `scriptlet`. A per-class
+key falls back to `authorization.client.default` when unset.
+
+`authorization.client.tls-restricted` additionally accepts `tls`, as the TLS
+authorization method exists to enforce the per-certificate project restrictions
+that only apply to restricted certificates.
+
+The following server configuration key is also added:
+
+* `authorization.openfga.tls.identifier`: certificate attribute (`fingerprint`
+  or `name`) used as the OpenFGA user when a TLS client is authorized by
+  OpenFGA (defaults to `name`).

--- a/doc/authorization.md
+++ b/doc/authorization.md
@@ -11,6 +11,10 @@ There are three supported authorization methods:
 - {ref}`authorization-openfga`
 - {ref}`authorization-scriptlet`
 
+By default, the method used for a request is determined automatically from the
+client's authentication protocol. This can be customized so that different kinds
+of clients are handled by different methods; see {ref}`authorization-client-routing`.
+
 (authorization-tls)=
 ## TLS authorization
 
@@ -21,7 +25,9 @@ To restrict access, use [`incus config trust edit <fingerprint>`](incus_config_t
 Set the `restricted` key to `true` and specify a list of projects to restrict the client to.
 If the list of projects is empty, the client will not be allowed access to any of them.
 
-This authorization method is used if a client authenticates with TLS even if {ref}`OpenFGA authorization <authorization-openfga>` is configured.
+By default, this authorization method is used for clients authenticating with a restricted TLS certificate.
+Clients using an unrestricted certificate are granted full access instead.
+Both can be changed, see {ref}`authorization-client-routing`.
 
 (authorization-openfga)=
 ## Open Fine-Grained Authorization (OpenFGA)
@@ -35,6 +41,14 @@ Incus will connect to the OpenFGA server, write the {ref}`openfga-model`, and qu
 
 To enable this authorization method in Incus, set the [`authorization.openfga.*`](server-options-authorization) server configuration options.
 All options must be set in order to enable OpenFGA. Though, you do not have to create the authorization-model yourself, Incus will generate it including the initial tuple to allow only authenticated users: `server:incus#authenticated@user:*`.
+
+```{warning}
+Setting the `authorization.openfga.*` options only makes OpenFGA available.
+It does not on its own cause any request to be authorized by it.
+
+OpenFGA is only consulted for clients whose class is routed to it with an
+`authorization.client.*` option, see {ref}`authorization-client-routing`.
+```
 
 (openfga-model)=
 ### OpenFGA model
@@ -71,6 +85,14 @@ However, you must apply appropriate {ref}`project-restrictions`.
 
 Incus supports defining a scriptlet to manage fine-grained authorization, allowing to write precise authorization rules with no dependency on external tools.
 
+```{warning}
+Setting `authorization.scriptlet` only makes the scriptlet available.
+It does not on its own cause any request to be authorized by it.
+
+The scriptlet is only run for clients whose class is routed to it with an
+`authorization.client.*` option, see {ref}`authorization-client-routing`.
+```
+
 To use scriptlet authorization, you can write a scriptlet in the `authorization.scriptlet` server configuration option implementing a function `authorize`, which takes three arguments:
 
 - `details`, an object with the following attributes:
@@ -89,3 +111,69 @@ Additionally, two optional functions can be defined so that users can be listed 
 
 - `get_instance_access`, with two arguments (`project_name` and `instance_name`), returning a list of users able to access a given instance
 - `get_project_access`, with one argument (`project_name`), returning a list of users able to access a given project
+
+(authorization-client-routing)=
+## Client routing
+
+More than one authorization method can be loaded at the same time, with each
+request routed to exactly one of them based on the authentication class of the
+client. This is controlled through the `authorization.client.*` server
+configuration options, one per client class:
+
+- `authorization.client.unix`: local clients connecting over the Unix socket
+- `authorization.client.tls`: clients using an unrestricted client certificate
+- `authorization.client.tls-restricted`: clients using a restricted (project-scoped) client certificate
+- `authorization.client.oidc`: OIDC-authenticated clients
+- `authorization.client.default`: any client class not set above
+
+Each option accepts one of the following values:
+
+- `allow`: unconditionally grant access
+- `deny`: unconditionally refuse access
+- `tls`: use {ref}`authorization-tls`, only valid for `authorization.client.tls-restricted`
+- `openfga`: use {ref}`authorization-openfga`
+- `scriptlet`: use {ref}`authorization-scriptlet`
+
+A per-class option falls back to `authorization.client.default` when unset.
+When that is unset too, the following built-in routing applies:
+
+| Client class     | Built-in route |
+|------------------|----------------|
+| `unix`           | `allow`        |
+| `tls`            | `allow`        |
+| `tls-restricted` | `tls`          |
+| `oidc`           | `allow`        |
+| `default`        | `deny`         |
+
+This routing is fixed.
+
+```{warning}
+The per-certificate project restrictions described in {ref}`authorization-tls`
+are enforced by the TLS authorization method only.
+
+If `authorization.client.tls-restricted` is set to any value other than `tls`,
+the project list of the client certificate are no longer consulted, and a restricted
+certificate may gain access well beyond the projects it is limited to.
+Only set this option to something other than `tls` if the method you route to
+reproduces the restrictions you rely on.
+```
+
+```{warning}
+Always set `authorization.client.default` last, once you have confirmed that
+every explicitly configured client class behaves as expected.
+
+The default applies to every class that is not set explicitly, so a single
+mistake affects all of them at once. If it is set to `openfga` or `scriptlet`
+while that method is misconfigured or unreachable, or to `deny`, every remote
+client is refused.
+
+The `root` user is always allowed to interact with the API over the Unix
+socket, regardless of the configured authorization method. This is what allows
+a server locked out by a bad routing configuration to be recovered.
+```
+
+For example, to have OpenFGA authorize OIDC clients while restricted TLS clients
+keep using TLS authorization:
+
+    incus config set authorization.client.oidc=openfga
+    incus config set authorization.client.tls-restricted=scriptlet

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -5096,6 +5096,46 @@ DNS resolvers to use for performing (recursive) `CNAME` resolving and apex domai
 
 <!-- config group server-acme end -->
 <!-- config group server-authorization start -->
+```{config:option} authorization.client.default server-authorization
+:scope: "global"
+:shortdesc: "Authorization driver for clients without a more specific class route"
+:type: "string"
+Routes clients that do not match a more specific class to an authorization driver.
+Possible values are `allow`, `deny`, `openfga` and `scriptlet`.
+```
+
+```{config:option} authorization.client.oidc server-authorization
+:scope: "global"
+:shortdesc: "Authorization driver for OIDC-authenticated clients"
+:type: "string"
+Routes OIDC-authenticated clients to an authorization driver.
+Possible values are `allow`, `deny`, `openfga` and `scriptlet`.
+```
+
+```{config:option} authorization.client.tls server-authorization
+:scope: "global"
+:shortdesc: "Authorization driver for unrestricted TLS clients"
+:type: "string"
+Routes clients using an unrestricted client certificate to an authorization driver.
+Possible values are `allow`, `deny`, `openfga` and `scriptlet`.
+```
+
+```{config:option} authorization.client.tls-restricted server-authorization
+:scope: "global"
+:shortdesc: "Authorization driver for restricted TLS clients"
+:type: "string"
+Routes clients using a restricted (project-scoped) client certificate to an authorization driver.
+Possible values are `allow`, `deny`, `tls`, `openfga` and `scriptlet`.
+```
+
+```{config:option} authorization.client.unix server-authorization
+:scope: "global"
+:shortdesc: "Authorization driver for local (`unix` socket) clients"
+:type: "string"
+Routes local clients connecting over the `unix` socket to an authorization driver.
+Possible values are `allow`, `deny`, `openfga` and `scriptlet`.
+```
+
 ```{config:option} authorization.openfga.api.token server-authorization
 :scope: "global"
 :shortdesc: "API token of the OpenFGA server"
@@ -5115,6 +5155,15 @@ DNS resolvers to use for performing (recursive) `CNAME` resolving and apex domai
 :shortdesc: "ID of the OpenFGA permission store"
 :type: "string"
 
+```
+
+```{config:option} authorization.openfga.tls.identifier server-authorization
+:defaultdesc: "`name`"
+:scope: "global"
+:shortdesc: "Certificate attribute used as the OpenFGA user for TLS clients"
+:type: "string"
+When a TLS client is authorized by OpenFGA, this selects the certificate
+attribute used as the OpenFGA user: `fingerprint` or `name`.
 ```
 
 ```{config:option} authorization.scriptlet server-authorization

--- a/internal/server/auth/authorization.go
+++ b/internal/server/auth/authorization.go
@@ -20,6 +20,12 @@ const (
 
 	// DriverScriptlet provides scriptlet-based authorization. It is compatible with any authentication method.
 	DriverScriptlet string = "scriptlet"
+
+	// DriverAllow is a terminal driver that unconditionally allows every request.
+	DriverAllow string = "allow"
+
+	// DriverDeny is a terminal driver that unconditionally denies every request.
+	DriverDeny string = "deny"
 )
 
 // ErrUnknownDriver is the "Unknown driver" error.
@@ -29,6 +35,8 @@ var authorizers = map[string]func() authorizer{
 	DriverTLS:       func() authorizer { return &TLS{} },
 	DriverOpenFGA:   func() authorizer { return &FGA{} },
 	DriverScriptlet: func() authorizer { return &Scriptlet{} },
+	DriverAllow:     func() authorizer { return &allowDenyAuthorizer{allowed: true} },
+	DriverDeny:      func() authorizer { return &allowDenyAuthorizer{allowed: false} },
 }
 
 type authorizer interface {

--- a/internal/server/auth/driver_allowdeny.go
+++ b/internal/server/auth/driver_allowdeny.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/lxc/incus/v7/internal/server/certificate"
+	"github.com/lxc/incus/v7/shared/api"
+)
+
+// allowDenyAuthorizer is a terminal Authorizer that unconditionally allows or
+// denies every request-scoped check.
+type allowDenyAuthorizer struct {
+	commonAuthorizer
+
+	allowed bool
+}
+
+// load is a no-op.
+func (a *allowDenyAuthorizer) load(ctx context.Context, certificateCache *certificate.Cache, opts Opts) error {
+	return nil
+}
+
+// CheckPermission allows or denies the request based on the terminal's setting.
+func (a *allowDenyAuthorizer) CheckPermission(ctx context.Context, r *http.Request, object Object, entitlement Entitlement) error {
+	if a.allowed {
+		return nil
+	}
+
+	return api.StatusErrorf(http.StatusForbidden, "User does not have entitlement %q on object %q", entitlement, object)
+}
+
+// GetPermissionChecker returns a checker that allows or denies every object based on the terminal's setting.
+func (a *allowDenyAuthorizer) GetPermissionChecker(ctx context.Context, r *http.Request, entitlement Entitlement, objectType ObjectType) (PermissionChecker, error) {
+	allowed := a.allowed
+
+	return func(Object) bool { return allowed }, nil
+}
+
+// GetInstanceAccess returns an empty access list.
+func (a *allowDenyAuthorizer) GetInstanceAccess(ctx context.Context, projectName string, instanceName string) (*api.Access, error) {
+	return &api.Access{}, nil
+}
+
+// GetProjectAccess returns an empty access list.
+func (a *allowDenyAuthorizer) GetProjectAccess(ctx context.Context, projectName string) (*api.Access, error) {
+	return &api.Access{}, nil
+}

--- a/internal/server/auth/driver_openfga.go
+++ b/internal/server/auth/driver_openfga.go
@@ -22,11 +22,12 @@ import (
 // FGA represents an OpenFGA authorizer.
 type FGA struct {
 	commonAuthorizer
-	tls *TLS
+	certificates *certificate.Cache
 
-	apiURL   string
-	apiToken string
-	storeID  string
+	apiURL        string
+	apiToken      string
+	storeID       string
+	tlsIdentifier string
 
 	onlineMu sync.Mutex
 	online   bool
@@ -72,11 +73,25 @@ func (f *FGA) configure(opts Opts) error {
 		return fmt.Errorf("Expected a string for configuration key %q, got: %T", "authorization.openfga.store.id", val)
 	}
 
+	// TLS clients mapping to an OpenFGA user (defaults to "name").
+	f.tlsIdentifier = "name"
+	val, ok = opts.config["authorization.openfga.tls.identifier"]
+	if ok && val != nil {
+		identifier, ok := val.(string)
+		if !ok {
+			return fmt.Errorf("Expected a string for configuration key %q, got: %T", "authorization.openfga.tls.identifier", val)
+		}
+
+		if identifier != "" {
+			f.tlsIdentifier = identifier
+		}
+	}
+
 	return nil
 }
 
 func (f *FGA) load(ctx context.Context, certificateCache *certificate.Cache, opts Opts) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	_, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	err := f.configure(opts)
@@ -84,11 +99,7 @@ func (f *FGA) load(ctx context.Context, certificateCache *certificate.Cache, opt
 		return err
 	}
 
-	f.tls = &TLS{}
-	err = f.tls.load(ctx, certificateCache, opts)
-	if err != nil {
-		return err
-	}
+	f.certificates = certificateCache
 
 	conf := client.ClientConfiguration{
 		ApiUrl:  f.apiURL,
@@ -262,6 +273,20 @@ func (f *FGA) connect(ctx context.Context, certificateCache *certificate.Cache, 
 	return nil
 }
 
+// userForRequest returns the OpenFGA user identifier for a request.
+func (f *FGA) userForRequest(details *requestDetails) string {
+	username := details.username()
+
+	if details.authenticationProtocol() == api.AuthenticationMethodTLS && f.tlsIdentifier == "name" && f.certificates != nil {
+		cert := f.certificates.GetAPICertificate(username)
+		if cert != nil && cert.Name != "" {
+			return cert.Name
+		}
+	}
+
+	return username
+}
+
 // CheckPermission returns an error if the user does not have the given Entitlement on the given Object.
 func (f *FGA) CheckPermission(ctx context.Context, r *http.Request, object Object, entitlement Entitlement) error {
 	logCtx := logger.Ctx{"object": object, "entitlement": entitlement, "url": r.URL.String(), "method": r.Method}
@@ -277,11 +302,6 @@ func (f *FGA) CheckPermission(ctx context.Context, r *http.Request, object Objec
 		return nil
 	}
 
-	// Use the TLS driver if the user authenticated with TLS.
-	if details.authenticationProtocol() == api.AuthenticationMethodTLS {
-		return f.tls.CheckPermission(ctx, r, object, entitlement)
-	}
-
 	// If offline, return a clear error to the user.
 	f.onlineMu.Lock()
 	defer f.onlineMu.Unlock()
@@ -289,7 +309,7 @@ func (f *FGA) CheckPermission(ctx context.Context, r *http.Request, object Objec
 		return api.StatusErrorf(http.StatusForbidden, "The authorization server is currently offline, please try again later")
 	}
 
-	username := details.username()
+	username := f.userForRequest(details)
 	logCtx["username"] = username
 	logCtx["protocol"] = details.Protocol
 
@@ -331,12 +351,7 @@ func (f *FGA) GetPermissionChecker(ctx context.Context, r *http.Request, entitle
 		return allowFunc(true), nil
 	}
 
-	// Use the TLS driver if the user authenticated with TLS.
-	if details.authenticationProtocol() == api.AuthenticationMethodTLS {
-		return f.tls.GetPermissionChecker(ctx, r, entitlement, objectType)
-	}
-
-	username := details.username()
+	username := f.userForRequest(details)
 	logCtx["username"] = username
 	logCtx["protocol"] = details.Protocol
 

--- a/internal/server/auth/router.go
+++ b/internal/server/auth/router.go
@@ -1,0 +1,533 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/lxc/incus/v7/internal/server/certificate"
+	"github.com/lxc/incus/v7/internal/server/request"
+	"github.com/lxc/incus/v7/shared/api"
+	"github.com/lxc/incus/v7/shared/logger"
+)
+
+// clientClass identifies the authentication class of a request.
+type clientClass string
+
+const (
+	// clientClassDefault is the fallback used when no more specific class matches.
+	clientClassDefault clientClass = "default"
+
+	// clientClassUnix covers local unix-socket.
+	clientClassUnix clientClass = "unix"
+
+	// clientClassTLS covers unrestricted client certificates.
+	clientClassTLS clientClass = "tls"
+
+	// clientClassTLSRestricted covers restricted (project-scoped) client certificates.
+	clientClassTLSRestricted clientClass = "tls-restricted"
+
+	// clientClassOIDC covers OIDC-authenticated clients.
+	clientClassOIDC clientClass = "oidc"
+)
+
+// allClientClasses lists every routable client class.
+var allClientClasses = []clientClass{
+	clientClassUnix,
+	clientClassTLS,
+	clientClassTLSRestricted,
+	clientClassOIDC,
+	clientClassDefault,
+}
+
+// defaultRoutes is the built-in routing used for any client class with no
+// explicit configuration and no explicit default.
+func defaultRoutes() map[clientClass]string {
+	return map[clientClass]string{
+		clientClassDefault:       DriverDeny,
+		clientClassUnix:          DriverAllow,
+		clientClassTLS:           DriverAllow,
+		clientClassTLSRestricted: DriverTLS,
+		clientClassOIDC:          DriverAllow,
+	}
+}
+
+// routerState is an immutable snapshot of the router's configuration.
+type routerState struct {
+	// drivers holds the loaded authorizers.
+	drivers map[string]Authorizer
+
+	// routes maps each client class to the authorizer.
+	routes map[clientClass]Authorizer
+}
+
+// Router is an Authorizer that dispatches each request to other authorizers.
+type Router struct {
+	commonAuthorizer
+
+	certificates *certificate.Cache
+	state        atomic.Pointer[routerState]
+}
+
+// baseDrivers are the always present drivers.
+var baseDrivers = []string{DriverAllow, DriverDeny, DriverTLS}
+
+// NewRouter returns a Router with the base drivers loaded.
+func NewRouter(ctx context.Context, l logger.Logger, certificateCache *certificate.Cache) (*Router, error) {
+	rt := &Router{certificates: certificateCache}
+
+	err := rt.init("router", l)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the base drivers into the driver set. They are reused across
+	// reconfigurations and never stopped.
+	drivers := make(map[string]Authorizer, len(baseDrivers))
+	for _, name := range baseDrivers {
+		driver, err := LoadAuthorizer(ctx, name, l, certificateCache)
+		if err != nil {
+			return nil, err
+		}
+
+		drivers[name] = driver
+	}
+
+	// Install the built-in default routing over the base drivers.
+	err = rt.store(nil, drivers)
+	if err != nil {
+		return nil, err
+	}
+
+	return rt, nil
+}
+
+// Configure installs the routing table (from the explicit authorization.client.* configuration).
+func (rt *Router) Configure(routes map[string]string, optional map[string]Authorizer) error {
+	previous := rt.state.Load().drivers
+
+	// Keep the base drivers loaded at construction and swap in the new optional
+	// set (openfga/scriptlet).
+	drivers := make(map[string]Authorizer, len(baseDrivers)+len(optional))
+	for _, name := range baseDrivers {
+		drivers[name] = previous[name]
+	}
+
+	maps.Copy(drivers, optional)
+
+	return rt.store(routes, drivers)
+}
+
+// LoadedDriver returns the loaded driver registered under name.
+func (rt *Router) LoadedDriver(name string) Authorizer {
+	return rt.state.Load().drivers[name]
+}
+
+// store resolves the routing table from the explicit authorization.client.* configuration.
+func (rt *Router) store(routes map[string]string, drivers map[string]Authorizer) error {
+	base := defaultRoutes()
+	defaultTarget := routes[string(clientClassDefault)]
+
+	resolved := make(map[clientClass]Authorizer, len(allClientClasses))
+	for _, class := range allClientClasses {
+		var target string
+		switch {
+		case routes[string(class)] != "":
+			target = routes[string(class)]
+		case defaultTarget != "":
+			target = defaultTarget
+		default:
+			target = base[class]
+		}
+
+		driver, ok := drivers[target]
+		if !ok {
+			driver = drivers[DriverDeny]
+			rt.logger.Error("No loaded authorizer for route target", logger.Ctx{"target": target})
+		}
+
+		resolved[class] = driver
+	}
+
+	rt.state.Store(&routerState{drivers: drivers, routes: resolved})
+
+	return nil
+}
+
+// classify determines the client class of a request from its details.
+func (rt *Router) classify(details *requestDetails) clientClass {
+	if details.isInternalOrUnix() {
+		return clientClassUnix
+	}
+
+	switch details.authenticationProtocol() {
+	case api.AuthenticationMethodTLS:
+		if rt.isRestrictedTLS(details.username()) {
+			return clientClassTLSRestricted
+		}
+
+		return clientClassTLS
+	case api.AuthenticationMethodOIDC:
+		return clientClassOIDC
+	}
+
+	return clientClassDefault
+}
+
+// isRestrictedTLS reports whether the given certificate fingerprint corresponds
+// to a restricted (project-scoped) certificate.
+func (rt *Router) isRestrictedTLS(fingerprint string) bool {
+	if rt.certificates == nil {
+		return false
+	}
+
+	_, projects := rt.certificates.GetCertificatesAndProjects()
+	projectNames, ok := projects[fingerprint]
+
+	return ok && projectNames != nil
+}
+
+// isRootUnixRequest reports whether the request was made by the root user over the local unix socket.
+func isRootUnixRequest(r *http.Request, details *requestDetails) bool {
+	if details.Protocol != "unix" {
+		return false
+	}
+
+	val := r.Context().Value(request.CtxUnixIsRoot)
+	if val == nil {
+		return false
+	}
+
+	isRoot, ok := val.(bool)
+	if !ok {
+		return false
+	}
+
+	return isRoot
+}
+
+// authorizerForRequest returns the single authorizer responsible for the given request.
+func (rt *Router) authorizerForRequest(r *http.Request) Authorizer {
+	st := rt.state.Load()
+
+	if r == nil {
+		return st.drivers[DriverDeny]
+	}
+
+	details, err := rt.requestDetails(r)
+	if err != nil {
+		return st.drivers[DriverDeny]
+	}
+
+	// The root user is always granted full access over the local unix socket.
+	if isRootUnixRequest(r, details) {
+		return st.drivers[DriverAllow]
+	}
+
+	class := rt.classify(details)
+	a, ok := st.routes[class]
+	if !ok {
+		a, ok = st.routes[clientClassDefault]
+		if !ok {
+			return st.drivers[DriverDeny]
+		}
+	}
+
+	return a
+}
+
+// fanout runs fn against every loaded driver, joining any errors.
+func (rt *Router) fanout(fn func(Authorizer) error) error {
+	st := rt.state.Load()
+
+	var errs []error
+	for _, drv := range st.drivers {
+		err := fn(drv)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Request-scoped methods: route to a single authorizer.
+
+// CheckPermission returns an error if the user does not have the given Entitlement on the given Object.
+func (rt *Router) CheckPermission(ctx context.Context, r *http.Request, object Object, entitlement Entitlement) error {
+	return rt.authorizerForRequest(r).CheckPermission(ctx, r, object, entitlement)
+}
+
+// GetPermissionChecker returns a function that checks whether a user has the required entitlement on an object.
+func (rt *Router) GetPermissionChecker(ctx context.Context, r *http.Request, entitlement Entitlement, objectType ObjectType) (PermissionChecker, error) {
+	return rt.authorizerForRequest(r).GetPermissionChecker(ctx, r, entitlement, objectType)
+}
+
+// Access queries: union across every loaded driver.
+
+// GetInstanceAccess returns the union of entities who have access to the instance across all loaded drivers.
+func (rt *Router) GetInstanceAccess(ctx context.Context, projectName string, instanceName string) (*api.Access, error) {
+	st := rt.state.Load()
+
+	var merged api.Access
+	var errs []error
+	for _, drv := range st.drivers {
+		access, err := drv.GetInstanceAccess(ctx, projectName, instanceName)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if access != nil {
+			merged = append(merged, *access...)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return &merged, nil
+}
+
+// GetProjectAccess returns the union of entities who have access to the project across all loaded drivers.
+func (rt *Router) GetProjectAccess(ctx context.Context, projectName string) (*api.Access, error) {
+	st := rt.state.Load()
+
+	var merged api.Access
+	var errs []error
+	for _, drv := range st.drivers {
+		access, err := drv.GetProjectAccess(ctx, projectName)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if access != nil {
+			merged = append(merged, *access...)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return &merged, nil
+}
+
+// Lifecycle methods: fan out to every loaded driver.
+
+// StopService stops every loaded driver.
+func (rt *Router) StopService(ctx context.Context) error {
+	return rt.fanout(func(a Authorizer) error { return a.StopService(ctx) })
+}
+
+// ApplyPatch applies the named patch to every loaded driver.
+func (rt *Router) ApplyPatch(ctx context.Context, name string) error {
+	return rt.fanout(func(a Authorizer) error { return a.ApplyPatch(ctx, name) })
+}
+
+// Resource-notification methods: fan out to every loaded driver.
+
+// AddProject notifies every loaded driver of a new project.
+func (rt *Router) AddProject(ctx context.Context, projectID int64, projectName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddProject(ctx, projectID, projectName) })
+}
+
+// DeleteProject notifies every loaded driver of a deleted project.
+func (rt *Router) DeleteProject(ctx context.Context, projectID int64, projectName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteProject(ctx, projectID, projectName) })
+}
+
+// RenameProject notifies every loaded driver of a renamed project.
+func (rt *Router) RenameProject(ctx context.Context, projectID int64, oldName string, newName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.RenameProject(ctx, projectID, oldName, newName) })
+}
+
+// AddCertificate notifies every loaded driver of a new certificate.
+func (rt *Router) AddCertificate(ctx context.Context, fingerprint string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddCertificate(ctx, fingerprint) })
+}
+
+// DeleteCertificate notifies every loaded driver of a deleted certificate.
+func (rt *Router) DeleteCertificate(ctx context.Context, fingerprint string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteCertificate(ctx, fingerprint) })
+}
+
+// AddStoragePool notifies every loaded driver of a new storage pool.
+func (rt *Router) AddStoragePool(ctx context.Context, storagePoolName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddStoragePool(ctx, storagePoolName) })
+}
+
+// DeleteStoragePool notifies every loaded driver of a deleted storage pool.
+func (rt *Router) DeleteStoragePool(ctx context.Context, storagePoolName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteStoragePool(ctx, storagePoolName) })
+}
+
+// AddImage notifies every loaded driver of a new image.
+func (rt *Router) AddImage(ctx context.Context, projectName string, fingerprint string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddImage(ctx, projectName, fingerprint) })
+}
+
+// DeleteImage notifies every loaded driver of a deleted image.
+func (rt *Router) DeleteImage(ctx context.Context, projectName string, fingerprint string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteImage(ctx, projectName, fingerprint) })
+}
+
+// AddImageAlias notifies every loaded driver of a new image alias.
+func (rt *Router) AddImageAlias(ctx context.Context, projectName string, imageAliasName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddImageAlias(ctx, projectName, imageAliasName) })
+}
+
+// DeleteImageAlias notifies every loaded driver of a deleted image alias.
+func (rt *Router) DeleteImageAlias(ctx context.Context, projectName string, imageAliasName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteImageAlias(ctx, projectName, imageAliasName) })
+}
+
+// RenameImageAlias notifies every loaded driver of a renamed image alias.
+func (rt *Router) RenameImageAlias(ctx context.Context, projectName string, oldAliasName string, newAliasName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.RenameImageAlias(ctx, projectName, oldAliasName, newAliasName) })
+}
+
+// AddInstance notifies every loaded driver of a new instance.
+func (rt *Router) AddInstance(ctx context.Context, projectName string, instanceName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddInstance(ctx, projectName, instanceName) })
+}
+
+// DeleteInstance notifies every loaded driver of a deleted instance.
+func (rt *Router) DeleteInstance(ctx context.Context, projectName string, instanceName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteInstance(ctx, projectName, instanceName) })
+}
+
+// RenameInstance notifies every loaded driver of a renamed instance.
+func (rt *Router) RenameInstance(ctx context.Context, projectName string, oldInstanceName string, newInstanceName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.RenameInstance(ctx, projectName, oldInstanceName, newInstanceName) })
+}
+
+// AddNetwork notifies every loaded driver of a new network.
+func (rt *Router) AddNetwork(ctx context.Context, projectName string, networkName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddNetwork(ctx, projectName, networkName) })
+}
+
+// DeleteNetwork notifies every loaded driver of a deleted network.
+func (rt *Router) DeleteNetwork(ctx context.Context, projectName string, networkName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteNetwork(ctx, projectName, networkName) })
+}
+
+// RenameNetwork notifies every loaded driver of a renamed network.
+func (rt *Router) RenameNetwork(ctx context.Context, projectName string, oldNetworkName string, newNetworkName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.RenameNetwork(ctx, projectName, oldNetworkName, newNetworkName) })
+}
+
+// AddNetworkZone notifies every loaded driver of a new network zone.
+func (rt *Router) AddNetworkZone(ctx context.Context, projectName string, networkZoneName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddNetworkZone(ctx, projectName, networkZoneName) })
+}
+
+// DeleteNetworkZone notifies every loaded driver of a deleted network zone.
+func (rt *Router) DeleteNetworkZone(ctx context.Context, projectName string, networkZoneName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteNetworkZone(ctx, projectName, networkZoneName) })
+}
+
+// AddNetworkIntegration notifies every loaded driver of a new network integration.
+func (rt *Router) AddNetworkIntegration(ctx context.Context, networkIntegrationName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddNetworkIntegration(ctx, networkIntegrationName) })
+}
+
+// DeleteNetworkIntegration notifies every loaded driver of a deleted network integration.
+func (rt *Router) DeleteNetworkIntegration(ctx context.Context, networkIntegrationName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteNetworkIntegration(ctx, networkIntegrationName) })
+}
+
+// RenameNetworkIntegration notifies every loaded driver of a renamed network integration.
+func (rt *Router) RenameNetworkIntegration(ctx context.Context, oldNetworkIntegrationName string, newNetworkIntegrationName string) error {
+	return rt.fanout(func(a Authorizer) error {
+		return a.RenameNetworkIntegration(ctx, oldNetworkIntegrationName, newNetworkIntegrationName)
+	})
+}
+
+// AddNetworkACL notifies every loaded driver of a new network ACL.
+func (rt *Router) AddNetworkACL(ctx context.Context, projectName string, networkACLName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddNetworkACL(ctx, projectName, networkACLName) })
+}
+
+// DeleteNetworkACL notifies every loaded driver of a deleted network ACL.
+func (rt *Router) DeleteNetworkACL(ctx context.Context, projectName string, networkACLName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteNetworkACL(ctx, projectName, networkACLName) })
+}
+
+// RenameNetworkACL notifies every loaded driver of a renamed network ACL.
+func (rt *Router) RenameNetworkACL(ctx context.Context, projectName string, oldNetworkACLName string, newNetworkACLName string) error {
+	return rt.fanout(func(a Authorizer) error {
+		return a.RenameNetworkACL(ctx, projectName, oldNetworkACLName, newNetworkACLName)
+	})
+}
+
+// AddNetworkAddressSet notifies every loaded driver of a new network address set.
+func (rt *Router) AddNetworkAddressSet(ctx context.Context, projectName string, networkAddressSetName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddNetworkAddressSet(ctx, projectName, networkAddressSetName) })
+}
+
+// DeleteNetworkAddressSet notifies every loaded driver of a deleted network address set.
+func (rt *Router) DeleteNetworkAddressSet(ctx context.Context, projectName string, networkAddressSetName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteNetworkAddressSet(ctx, projectName, networkAddressSetName) })
+}
+
+// RenameNetworkAddressSet notifies every loaded driver of a renamed network address set.
+func (rt *Router) RenameNetworkAddressSet(ctx context.Context, projectName string, oldNetworkAddressSetName string, newNetworkAddressSetName string) error {
+	return rt.fanout(func(a Authorizer) error {
+		return a.RenameNetworkAddressSet(ctx, projectName, oldNetworkAddressSetName, newNetworkAddressSetName)
+	})
+}
+
+// AddProfile notifies every loaded driver of a new profile.
+func (rt *Router) AddProfile(ctx context.Context, projectName string, profileName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.AddProfile(ctx, projectName, profileName) })
+}
+
+// DeleteProfile notifies every loaded driver of a deleted profile.
+func (rt *Router) DeleteProfile(ctx context.Context, projectName string, profileName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.DeleteProfile(ctx, projectName, profileName) })
+}
+
+// RenameProfile notifies every loaded driver of a renamed profile.
+func (rt *Router) RenameProfile(ctx context.Context, projectName string, oldProfileName string, newProfileName string) error {
+	return rt.fanout(func(a Authorizer) error { return a.RenameProfile(ctx, projectName, oldProfileName, newProfileName) })
+}
+
+// AddStoragePoolVolume notifies every loaded driver of a new storage pool volume.
+func (rt *Router) AddStoragePoolVolume(ctx context.Context, projectName string, storagePoolName string, storageVolumeType string, storageVolumeName string, storageVolumeLocation string) error {
+	return rt.fanout(func(a Authorizer) error {
+		return a.AddStoragePoolVolume(ctx, projectName, storagePoolName, storageVolumeType, storageVolumeName, storageVolumeLocation)
+	})
+}
+
+// DeleteStoragePoolVolume notifies every loaded driver of a deleted storage pool volume.
+func (rt *Router) DeleteStoragePoolVolume(ctx context.Context, projectName string, storagePoolName string, storageVolumeType string, storageVolumeName string, storageVolumeLocation string) error {
+	return rt.fanout(func(a Authorizer) error {
+		return a.DeleteStoragePoolVolume(ctx, projectName, storagePoolName, storageVolumeType, storageVolumeName, storageVolumeLocation)
+	})
+}
+
+// RenameStoragePoolVolume notifies every loaded driver of a renamed storage pool volume.
+func (rt *Router) RenameStoragePoolVolume(ctx context.Context, projectName string, storagePoolName string, storageVolumeType string, oldStorageVolumeName string, newStorageVolumeName string, storageVolumeLocation string) error {
+	return rt.fanout(func(a Authorizer) error {
+		return a.RenameStoragePoolVolume(ctx, projectName, storagePoolName, storageVolumeType, oldStorageVolumeName, newStorageVolumeName, storageVolumeLocation)
+	})
+}
+
+// AddStorageBucket notifies every loaded driver of a new storage bucket.
+func (rt *Router) AddStorageBucket(ctx context.Context, projectName string, storagePoolName string, storageBucketName string, storageBucketLocation string) error {
+	return rt.fanout(func(a Authorizer) error {
+		return a.AddStorageBucket(ctx, projectName, storagePoolName, storageBucketName, storageBucketLocation)
+	})
+}
+
+// DeleteStorageBucket notifies every loaded driver of a deleted storage bucket.
+func (rt *Router) DeleteStorageBucket(ctx context.Context, projectName string, storagePoolName string, storageBucketName string, storageBucketLocation string) error {
+	return rt.fanout(func(a Authorizer) error {
+		return a.DeleteStorageBucket(ctx, projectName, storagePoolName, storageBucketName, storageBucketLocation)
+	})
+}

--- a/internal/server/auth/router_test.go
+++ b/internal/server/auth/router_test.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lxc/incus/v7/internal/server/auth/common"
+	"github.com/lxc/incus/v7/internal/server/certificate"
+	"github.com/lxc/incus/v7/shared/api"
+	"github.com/lxc/incus/v7/shared/logger"
+)
+
+// TestClassify checks that classify maps a request's details to the expected client class.
+func TestClassify(t *testing.T) {
+	rt, err := NewRouter(context.Background(), logger.Log, &certificate.Cache{})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		protocol string
+		expected clientClass
+	}{
+		{"unix", "unix", clientClassUnix},
+		{"tls", api.AuthenticationMethodTLS, clientClassTLS},
+		{"oidc", api.AuthenticationMethodOIDC, clientClassOIDC},
+		{"unknown", "other", clientClassDefault},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			details := &requestDetails{RequestDetails: common.RequestDetails{Protocol: c.protocol}}
+			assert.Equal(t, c.expected, rt.classify(details))
+		})
+	}
+}
+
+// TestFanout checks that fanout invokes fn once per loaded driver and joins their errors.
+func TestFanout(t *testing.T) {
+	rt, err := NewRouter(context.Background(), logger.Log, &certificate.Cache{})
+	require.NoError(t, err)
+
+	drivers := rt.state.Load().drivers
+
+	// fn runs once for every loaded driver; no errors joins to nil.
+	var count int
+	err = rt.fanout(func(a Authorizer) error {
+		count++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, len(drivers), count)
+
+	// Errors returned by drivers are joined into the result.
+	boom := errors.New("boom")
+	err = rt.fanout(func(a Authorizer) error { return boom })
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+}

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -240,6 +240,17 @@ func (c *Config) AuthorizationScriptlet() string {
 	return c.m.GetString("authorization.scriptlet")
 }
 
+// AuthorizationClientRoutes returns the explicit per-client-class authorization routing configuration.
+func (c *Config) AuthorizationClientRoutes() map[string]string {
+	return map[string]string{
+		"default":        c.m.GetString("authorization.client.default"),
+		"unix":           c.m.GetString("authorization.client.unix"),
+		"tls":            c.m.GetString("authorization.client.tls"),
+		"tls-restricted": c.m.GetString("authorization.client.tls-restricted"),
+		"oidc":           c.m.GetString("authorization.client.oidc"),
+	}
+}
+
 // InstancesLXCFSPerInstance returns whether LXCFS should be run on a per-instance basis.
 func (c *Config) InstancesLXCFSPerInstance() bool {
 	return c.m.GetBool("instances.lxcfs.per_instance")
@@ -347,8 +358,8 @@ func (c *Config) ClusterHealingThreshold() time.Duration {
 }
 
 // OpenFGA returns all OpenFGA settings need to interact with an OpenFGA server.
-func (c *Config) OpenFGA() (apiURL string, apiToken string, storeID string) {
-	return c.m.GetString("authorization.openfga.api.url"), c.m.GetString("authorization.openfga.api.token"), c.m.GetString("authorization.openfga.store.id")
+func (c *Config) OpenFGA() (apiURL string, apiToken string, storeID string, tlsIdentifier string) {
+	return c.m.GetString("authorization.openfga.api.url"), c.m.GetString("authorization.openfga.api.token"), c.m.GetString("authorization.openfga.store.id"), c.m.GetString("authorization.openfga.tls.identifier")
 }
 
 // NetworkHWAddrPattern returns the MAC address pattern used in the cluster.
@@ -564,6 +575,51 @@ var ConfigSchema = config.Schema{
 	//  shortdesc: Port and interface for HTTP server (used by HTTP-01)
 	"acme.http.port": {Default: ":80", Validator: validate.Optional(validate.IsListenAddress(true, true, false))},
 
+	// gendoc:generate(entity=server, group=authorization, key=authorization.client.default)
+	// Routes clients that do not match a more specific class to an authorization driver.
+	// Possible values are `allow`, `deny`, `openfga` and `scriptlet`.
+	// ---
+	// type: string
+	// scope: global
+	// shortdesc: Authorization driver for clients without a more specific class route
+	"authorization.client.default": {Validator: validate.Optional(validate.IsOneOf("allow", "deny", "openfga", "scriptlet"))},
+
+	// gendoc:generate(entity=server, group=authorization, key=authorization.client.oidc)
+	// Routes OIDC-authenticated clients to an authorization driver.
+	// Possible values are `allow`, `deny`, `openfga` and `scriptlet`.
+	// ---
+	// type: string
+	// scope: global
+	// shortdesc: Authorization driver for OIDC-authenticated clients
+	"authorization.client.oidc": {Validator: validate.Optional(validate.IsOneOf("allow", "deny", "openfga", "scriptlet"))},
+
+	// gendoc:generate(entity=server, group=authorization, key=authorization.client.tls)
+	// Routes clients using an unrestricted client certificate to an authorization driver.
+	// Possible values are `allow`, `deny`, `openfga` and `scriptlet`.
+	// ---
+	// type: string
+	// scope: global
+	// shortdesc: Authorization driver for unrestricted TLS clients
+	"authorization.client.tls": {Validator: validate.Optional(validate.IsOneOf("allow", "deny", "openfga", "scriptlet"))},
+
+	// gendoc:generate(entity=server, group=authorization, key=authorization.client.tls-restricted)
+	// Routes clients using a restricted (project-scoped) client certificate to an authorization driver.
+	// Possible values are `allow`, `deny`, `tls`, `openfga` and `scriptlet`.
+	// ---
+	// type: string
+	// scope: global
+	// shortdesc: Authorization driver for restricted TLS clients
+	"authorization.client.tls-restricted": {Validator: validate.Optional(validate.IsOneOf("allow", "deny", "tls", "openfga", "scriptlet"))},
+
+	// gendoc:generate(entity=server, group=authorization, key=authorization.client.unix)
+	// Routes local clients connecting over the `unix` socket to an authorization driver.
+	// Possible values are `allow`, `deny`, `openfga` and `scriptlet`.
+	// ---
+	// type: string
+	// scope: global
+	// shortdesc: Authorization driver for local (`unix` socket) clients
+	"authorization.client.unix": {Validator: validate.Optional(validate.IsOneOf("allow", "deny", "openfga", "scriptlet"))},
+
 	// gendoc:generate(entity=server, group=authorization, key=authorization.openfga.api.token)
 	//
 	// ---
@@ -587,6 +643,16 @@ var ConfigSchema = config.Schema{
 	// scope: global
 	// shortdesc: ID of the OpenFGA permission store
 	"authorization.openfga.store.id": {},
+
+	// gendoc:generate(entity=server, group=authorization, key=authorization.openfga.tls.identifier)
+	// When a TLS client is authorized by OpenFGA, this selects the certificate
+	// attribute used as the OpenFGA user: `fingerprint` or `name`.
+	// ---
+	//  type: string
+	//  scope: global
+	//  defaultdesc: `name`
+	//  shortdesc: Certificate attribute used as the OpenFGA user for TLS clients
+	"authorization.openfga.tls.identifier": {Default: "name", Validator: validate.Optional(validate.IsOneOf("fingerprint", "name"))},
 
 	// gendoc:generate(entity=server, group=authorization, key=authorization.scriptlet)
 	// When using scriptlet-based authorization, this option stores the scriptlet.

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -5715,6 +5715,46 @@
 			"authorization": {
 				"keys": [
 					{
+						"authorization.client.default": {
+							"longdesc": "Routes clients that do not match a more specific class to an authorization driver.\nPossible values are `allow`, `deny`, `openfga` and `scriptlet`.",
+							"scope": "global",
+							"shortdesc": "Authorization driver for clients without a more specific class route",
+							"type": "string"
+						}
+					},
+					{
+						"authorization.client.oidc": {
+							"longdesc": "Routes OIDC-authenticated clients to an authorization driver.\nPossible values are `allow`, `deny`, `openfga` and `scriptlet`.",
+							"scope": "global",
+							"shortdesc": "Authorization driver for OIDC-authenticated clients",
+							"type": "string"
+						}
+					},
+					{
+						"authorization.client.tls": {
+							"longdesc": "Routes clients using an unrestricted client certificate to an authorization driver.\nPossible values are `allow`, `deny`, `openfga` and `scriptlet`.",
+							"scope": "global",
+							"shortdesc": "Authorization driver for unrestricted TLS clients",
+							"type": "string"
+						}
+					},
+					{
+						"authorization.client.tls-restricted": {
+							"longdesc": "Routes clients using a restricted (project-scoped) client certificate to an authorization driver.\nPossible values are `allow`, `deny`, `tls`, `openfga` and `scriptlet`.",
+							"scope": "global",
+							"shortdesc": "Authorization driver for restricted TLS clients",
+							"type": "string"
+						}
+					},
+					{
+						"authorization.client.unix": {
+							"longdesc": "Routes local clients connecting over the `unix` socket to an authorization driver.\nPossible values are `allow`, `deny`, `openfga` and `scriptlet`.",
+							"scope": "global",
+							"shortdesc": "Authorization driver for local (`unix` socket) clients",
+							"type": "string"
+						}
+					},
+					{
 						"authorization.openfga.api.token": {
 							"longdesc": "",
 							"scope": "global",
@@ -5735,6 +5775,15 @@
 							"longdesc": "",
 							"scope": "global",
 							"shortdesc": "ID of the OpenFGA permission store",
+							"type": "string"
+						}
+					},
+					{
+						"authorization.openfga.tls.identifier": {
+							"defaultdesc": "`name`",
+							"longdesc": "When a TLS client is authorized by OpenFGA, this selects the certificate\nattribute used as the OpenFGA user: `fingerprint` or `name`.",
+							"scope": "global",
+							"shortdesc": "Certificate attribute used as the OpenFGA user for TLS clients",
 							"type": "string"
 						}
 					},

--- a/internal/server/request/const.go
+++ b/internal/server/request/const.go
@@ -20,6 +20,9 @@ const (
 	// CtxProtocol is the protocol field in request context.
 	CtxProtocol CtxKey = "protocol"
 
+	// CtxUnixIsRoot reports whether the request was made by the root user over the local unix socket.
+	CtxUnixIsRoot CtxKey = "unix_is_root"
+
 	// CtxForwardedAddress is the forwarded address field in request context.
 	CtxForwardedAddress CtxKey = "forwarded_address"
 

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -557,6 +557,7 @@ var APIExtensions = []string{
 	"gpu_native_context",
 	"instance_port_forward",
 	"unix_block_limits",
+	"authorization_client_routing",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/openfga.sh
+++ b/test/suites/openfga.sh
@@ -25,9 +25,10 @@ test_openfga() {
     OPENFGA_STORE_ID="$(fga store create --name "test" | jq -r '.store.id')"
 
     # Configure OpenFGA in Incus.
-    incus config set authorization.openfga.api.url "$(fga_address)"
-    incus config set authorization.openfga.api.token "$(fga_token)"
-    incus config set authorization.openfga.store.id "${OPENFGA_STORE_ID}"
+    incus config set "authorization.openfga.api.url=$(fga_address)"
+    incus config set "authorization.openfga.api.token=$(fga_token)"
+    incus config set "authorization.openfga.store.id=${OPENFGA_STORE_ID}"
+    incus config set "authorization.client.oidc=openfga"
 
     # Wait for initial connection to OpenFGA.
     sleep 1s


### PR DESCRIPTION
This PR adds the ability to define multiple authorizers for different authentication methods. A specific authorizer can be set per method using these keys:
```
authorization.client.default: deny
authorization.client.unix: scriptlet
authorization.client.tls: allow
authorization.client.tls-restricted: openfga
authorization.client.oidc: openfga
```

In addition, two new authorizers were added: `allow` and `deny`, which effectively allow and deny all requests respectively.
For the case of OpenFGA mediating TLS clients, a new configuration key `authorization.openfga.tls.identifier` was added to decide whether to mediate access based on the TLS fingerprint or the certificate's name.

Closes: #3488