### PR TITLE
device: Add I/O limits for unix-block devices

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3279,3 +3279,9 @@ is controlled by the new `port-forward` agent feature.
 
 A matching `incus port-forward` command is added to the client, providing
 a local TCP listener which forwards every connection to the instance.
+
+## `unix_block_limits`
+
+This adds the `limits.read` and `limits.write` configuration keys to
+`unix-block` devices. These behave similarly to their `disk` device
+equivalents, accepting either a byte/s value or an IOPS value.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1803,6 +1803,18 @@ The custom policy routing table ID to add IPv6 static routes to (in addition to 
 
 ```
 
+```{config:option} limits.read devices-unix-char-block
+:shortdesc: "I/O limit in byte/s or IOPS for read operations"
+:type: "string"
+
+```
+
+```{config:option} limits.write devices-unix-char-block
+:shortdesc: "I/O limit in byte/s or IOPS for write operations"
+:type: "string"
+
+```
+
 ```{config:option} major devices-unix-char-block
 :default: "device on host"
 :shortdesc: "Device major number"

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -1364,7 +1364,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 	var diskLimits *deviceConfig.DiskLimits
 	if d.config["limits.read"] != "" || d.config["limits.write"] != "" || d.config["limits.max"] != "" {
 		// Parse the limits into usable values.
-		readBps, readIops, writeBps, writeIops, err := d.parseLimit(d.config)
+		readBps, readIops, writeBps, writeIops, err := diskParseLimits(d.config)
 		if err != nil {
 			return nil, err
 		}
@@ -1889,7 +1889,7 @@ func (d *disk) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 
 		if d.inst.Type() == instancetype.VM {
 			// Parse the limits into usable values (zero when unset, which clears any existing throttle).
-			readBps, readIops, writeBps, writeIops, err := d.parseLimit(d.config)
+			readBps, readIops, writeBps, writeIops, err := diskParseLimits(d.config)
 			if err != nil {
 				return err
 			}
@@ -2830,7 +2830,7 @@ func (d *disk) getDiskLimits() (map[string]diskBlockLimit, error) {
 		}
 
 		// Parse the user input
-		readBps, readIops, writeBps, writeIops, err := d.parseLimit(dev)
+		readBps, readIops, writeBps, writeIops, err := diskParseLimits(dev)
 		if err != nil {
 			return nil, err
 		}
@@ -2942,8 +2942,8 @@ func (d *disk) getDiskLimits() (map[string]diskBlockLimit, error) {
 	return result, nil
 }
 
-// parseLimit parses the disk configuration for its I/O limits and returns the I/O bytes/iops limits.
-func (d *disk) parseLimit(dev deviceConfig.Device) (int64, int64, int64, int64, error) {
+// diskParseLimits parses a device configuration for its I/O limits and returns the I/O bytes/iops limits.
+func diskParseLimits(dev deviceConfig.Device) (int64, int64, int64, int64, error) {
 	readSpeed := dev["limits.read"]
 	writeSpeed := dev["limits.write"]
 

--- a/internal/server/device/unix_block_limits.go
+++ b/internal/server/device/unix_block_limits.go
@@ -1,0 +1,121 @@
+package device
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/lxc/incus/v7/internal/linux"
+	"github.com/lxc/incus/v7/internal/server/cgroup"
+	deviceConfig "github.com/lxc/incus/v7/internal/server/device/config"
+)
+
+func unixBlockLimitsEnabled(config deviceConfig.Device) bool {
+	return config["type"] == "unix-block" && (config["limits.read"] != "" || config["limits.write"] != "")
+}
+
+func unixBlockDevicePath(devicesPath string, deviceName string, config deviceConfig.Device) string {
+	prefix := deviceJoinPath("unix", deviceName)
+	destPath := strings.TrimPrefix(unixDeviceDestPath(config), "/")
+	name := linux.PathNameEncode(deviceJoinPath(prefix, destPath))
+	return filepath.Join(devicesPath, name)
+}
+
+func unixBlockLimitValidate(config deviceConfig.Device) error {
+	if !unixBlockLimitsEnabled(config) {
+		return nil
+	}
+
+	readBps, readIops, writeBps, writeIops, err := diskParseLimits(config)
+	if err != nil {
+		return fmt.Errorf("Invalid I/O limit: %w", err)
+	}
+
+	if (config["limits.read"] != "" && readBps <= 0 && readIops <= 0) || (config["limits.write"] != "" && writeBps <= 0 && writeIops <= 0) {
+		return errors.New("I/O limits must be greater than zero")
+	}
+
+	return nil
+}
+
+func unixBlockLimitApply(runConf *deviceConfig.RunConfig, devicePath string, config deviceConfig.Device) error {
+	if !unixBlockLimitsEnabled(config) {
+		return nil
+	}
+
+	if !cgroup.Supports(cgroup.IO) {
+		return errors.New("Cannot apply block device limits as IO cgroup controller is missing")
+	}
+
+	dType, major, minor, err := unixDeviceAttributes(devicePath)
+	if err != nil {
+		return fmt.Errorf("Failed getting block device attributes for I/O limits: %w", err)
+	}
+
+	if dType != "b" {
+		return errors.New("I/O limits require a block device")
+	}
+
+	readBps, readIops, writeBps, writeIops, err := diskParseLimits(config)
+	if err != nil {
+		return err
+	}
+
+	cg, err := cgroup.New(&cgroupWriter{runConf})
+	if err != nil {
+		return err
+	}
+
+	block := fmt.Sprintf("%d:%d", major, minor)
+	limits := []struct {
+		direction string
+		unit      string
+		value     int64
+	}{
+		{"read", "bps", readBps},
+		{"read", "iops", readIops},
+		{"write", "bps", writeBps},
+		{"write", "iops", writeIops},
+	}
+
+	for _, limit := range limits {
+		if limit.value <= 0 {
+			continue
+		}
+
+		err = cg.SetBlkioLimit(block, limit.direction, limit.unit, limit.value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func unixBlockLimitClear(runConf *deviceConfig.RunConfig, devicePath string, config deviceConfig.Device) error {
+	if !unixBlockLimitsEnabled(config) {
+		return nil
+	}
+
+	dType, major, minor, err := unixDeviceAttributes(devicePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("Failed getting block device attributes to clear I/O limits: %w", err)
+	}
+
+	if dType != "b" {
+		return nil
+	}
+
+	runConf.CGroups = append(runConf.CGroups, deviceConfig.RunConfigItem{
+		Key:   "io.max",
+		Value: fmt.Sprintf("%d:%d rbps=max riops=max wbps=max wiops=max", major, minor),
+	})
+
+	return nil
+}

--- a/internal/server/device/unix_common.go
+++ b/internal/server/device/unix_common.go
@@ -110,6 +110,20 @@ func (d *unixCommon) validateConfig(instConf instance.ConfigReader, partialValid
 		//  shortdesc: Whether this device is required to start the instance
 		"required": validate.Optional(validate.IsBool),
 
+		// gendoc:generate(entity=devices, group=unix-char-block, key=limits.read)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: I/O limit in byte/s or IOPS for read operations
+		"limits.read": validate.IsAny,
+
+		// gendoc:generate(entity=devices, group=unix-char-block, key=limits.write)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: I/O limit in byte/s or IOPS for write operations
+		"limits.write": validate.IsAny,
+
 		// gendoc:generate(entity=devices, group=unix-char-block, key=uid)
 		//
 		// ---
@@ -126,6 +140,15 @@ func (d *unixCommon) validateConfig(instConf instance.ConfigReader, partialValid
 
 	if d.config["source"] == "" && d.config["path"] == "" {
 		return errors.New("Unix device entry is missing the required \"source\" or \"path\" property")
+	}
+
+	if d.config["type"] != "unix-block" && (d.config["limits.read"] != "" || d.config["limits.write"] != "") {
+		return errors.New("I/O limits are only supported for unix-block devices")
+	}
+
+	err = unixBlockLimitValidate(d.config)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -188,13 +211,23 @@ func (d *unixCommon) Register() error {
 				return nil, err
 			}
 
+			err = unixBlockLimitApply(&runConf, devPath, devConfig)
+			if err != nil {
+				return nil, err
+			}
+
 		case "remove":
 			// Skip if host side instance device file doesn't exist.
 			if !util.PathExists(devPath) {
 				return nil, nil
 			}
 
-			err := unixDeviceRemove(devicesPath, "unix", deviceName, relativeDestPath, &runConf)
+			err := unixBlockLimitClear(&runConf, devPath, devConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			err = unixDeviceRemove(devicesPath, "unix", deviceName, relativeDestPath, &runConf)
 			if err != nil {
 				return nil, err
 			}
@@ -230,6 +263,7 @@ func (d *unixCommon) Start() (*deviceConfig.RunConfig, error) {
 	srcPath := unixDeviceSourcePath(d.config)
 
 	// If device file already exists on system, proceed to add it whether its required or not.
+	created := false
 	dType, _, _, err := unixDeviceAttributes(srcPath)
 	if err == nil {
 		// Ensure device type matches what the device config is expecting.
@@ -241,6 +275,8 @@ func (d *unixCommon) Start() (*deviceConfig.RunConfig, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		created = true
 	} else {
 		// If the device file doesn't exist on the system, but major & minor numbers have
 		// been provided in the config then we can go ahead and create the device anyway.
@@ -249,9 +285,18 @@ func (d *unixCommon) Start() (*deviceConfig.RunConfig, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			created = true
 		} else if d.isRequired() {
 			// If the file is missing and the device is required then we cannot proceed.
 			return nil, errors.New("The required device path doesn't exist and the major and minor settings are not specified")
+		}
+	}
+
+	if created {
+		err = unixBlockLimitApply(&runConf, unixBlockDevicePath(d.inst.DevicesPath(), d.name, d.config), d.config)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -268,6 +313,11 @@ func (d *unixCommon) Stop() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
+	}
+
+	err = unixBlockLimitClear(&runConf, unixBlockDevicePath(d.inst.DevicesPath(), d.name, d.config), d.config)
+	if err != nil {
+		return nil, err
 	}
 
 	err = unixDeviceRemove(d.inst.DevicesPath(), "unix", d.name, "", &runConf)

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -2042,6 +2042,20 @@
 						}
 					},
 					{
+						"limits.read": {
+							"longdesc": "",
+							"shortdesc": "I/O limit in byte/s or IOPS for read operations",
+							"type": "string"
+						}
+					},
+					{
+						"limits.write": {
+							"longdesc": "",
+							"shortdesc": "I/O limit in byte/s or IOPS for write operations",
+							"type": "string"
+						}
+					},
+					{
 						"major": {
 							"default": "device on host",
 							"longdesc": "",

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -556,6 +556,7 @@ var APIExtensions = []string{
 	"network_allocations_network",
 	"gpu_native_context",
 	"instance_port_forward",
+	"unix_block_limits",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
## Summary

- add `limits.read` and `limits.write` to `unix-block` devices
- reuse Incus' existing cgroup I/O enforcement path
- apply limits during normal/API device start and optional-device add events
- clear limits when a device is detached while the instance keeps running
- advertise support through `unix_block_limits`

## Lifecycle details

A Cinder-style API attach to a running container executes `Start()`. A `required=false` device whose source appears later executes the registered Unix-device add callback. Both paths resolve the Incus-managed host device node and queue limits for its major:minor. The remove callback and `Stop()` clear `io.max` before removing the node, preventing a later device that reuses the same major:minor from inheriting stale limits.

The implementation is isolated in `unix_block_limits.go`; it does not change the existing disk limit parser and stores no volatile device state.

## Validation

- `go test ./internal/server/device ./internal/version`
- complete `incusd` build
- required/API-attached RBD device: 10 MB/s read and 5 MB/s write limits matched direct-I/O measurements
- delayed `required=false` loop device: limits appeared when the host node was created and disappeared with the container device when the host node was removed