### PR TITLE
incus/console: Escape spaces in SPICE console socket URI

### DIFF
--- a/cmd/incus/console.go
+++ b/cmd/incus/console.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -340,7 +341,12 @@ func (c *cmdConsole) vga(d incus.InstanceServer, name string) error {
 			return err
 		}, "Failed to remove temporary file")
 
-		socket = fmt.Sprintf("spice+unix://%s", path.Name())
+		spiceURL := &url.URL{
+			Scheme: "spice+unix",
+			Path:   path.Name(),
+		}
+
+		socket = spiceURL.String()
 	} else {
 		listener, err = net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {


### PR DESCRIPTION
## Fixes
Fixes https://github.com/lxc/incus/issues/3649
## Rationale / Context
When launching a SPICE VGA console (`incus console --type=vga`), a temporary local UNIX socket is created mirroring the instance's SPICE socket. 

On systems like macOS or configurations where the user's home or application support path contains spaces (for example, `/Users/User Name/Library/Application Support/...`), the raw socket path contains spaces. 
The previous implementation formatted the path using a raw string:
```go
socket = fmt.Sprintf("spice+unix://%s", path.Name())
```
This produced an invalid URI with unescaped spaces (e.g. `spice+unix:///path/to/some folder/socket`). As a result, SPICE clients such as `remote-viewer` or `spicy` failed to parse the URI and aborted.

## Solution
This PR updates the URI generation to use Go's standard library `net/url`:
```go
spiceURL := &url.URL{
    Scheme: "spice+unix",
    Path:   path.Name(),
}
socket = spiceURL.String()
```
This ensures that the socket path is properly percent-encoded/escaped (e.g. converting spaces to `%20`), yielding a valid RFC-compliant URL that SPICE clients can successfully parse.

Additionally, the local variable was named `spiceURL` instead of `u` to prevent shadowing the package import alias `u` (`github.com/lxc/incus/v7/cmd/incus/usage`).

---

## Changes
The following change was made to `cmd/incus/console.go`:

```diff
diff --git a/cmd/incus/console.go b/cmd/incus/console.go
index f20cb2c8e..0105208fa 100644
--- a/cmd/incus/console.go
+++ b/cmd/incus/console.go
@@ -340,7 +340,11 @@ func (c *cmdConsole) vga(d incus.InstanceServer, name string) error {
 			return err
 		}, "Failed to remove temporary file")
 
-		socket = fmt.Sprintf("spice+unix://%s", path.Name())
+		spiceURL := &url.URL{
+			Scheme: "spice+unix",
+			Path:   path.Name(),
+		}
+		socket = spiceURL.String()
 	} else {
 		listener, err = net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
```

---

## Verification & Testing
1. **Unit Tests**:
   Ran `go test -v ./cmd/incus/...` successfully.
2. **Lint/Static Analysis**:
   Ran `golangci-lint run cmd/incus/...` successfully (0 issues found).

