### PR TITLE
Add storage note about loop devices on COW fs

### DIFF
--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -62,9 +62,19 @@ This option is supported for the `btrfs` driver, the `lvm` driver, the `zfs` dri
 
 Incus can create a loop file on your main drive and have the selected storage driver use that.
 This method is functionally similar to using a disk or partition, but it uses a large file on your main drive instead.
-This means that every write must go through the storage driver and your main drive's file system, which leads to decreased performance.
 
 The loop files reside in `/var/lib/incus/disks/`.
+
+```{note}
+Every write must go through the storage driver and your main drive's
+file system, which leads to decreased performance.
+
+When the host file system is also copy-on-write (`btrfs` or `zfs`),
+every commit inside the loop file has to be committed again by the host
+file system, so synchronous write workloads can issue several times the
+physical writes they would on a dedicated disk or partition. On SSDs,
+this costs endurance, not just throughput.
+```
 
 Loop files usually cannot be shrunk.
 They will grow up to the configured limit, but deleting instances or images will not cause the file to shrink.


### PR DESCRIPTION
I was recently alerted to a read error on one of my NVME drives by SMART. Digging in, I noticed that my 1 TB disk with 5,843 power-on hours had a *ton* of NAND wear. Worth noting - NVME POH may not be a strict "power on" time of the drive. Mine is a few years old, but only entered Incus service ~2 years ago.

In Grafana, using stats Prometheus scraped from smartctl_exporter, I could see that there was a pattern of heavy writes causing decreased endurance that ended earlier this year (`smatctl_device_percentage_used`):

<img width="1067" height="575" alt="Screenshot 2026-07-21 at 2 34 28 PM" src="https://github.com/user-attachments/assets/bfaf868e-a797-4069-9f1c-cc8dcb0616bb" />

I correlated this date to changes made in my environment and saw that I had moved from nested btrfs to btrfs on a raw partition on 02-14, the exact day the wear stopped.

This was my old layout:

```
Samsung 980  →  nvme1n1p2
  └─ btrfs (root fs, subvol @)        ← snapper snapshotting hourly
      └─ /var/lib/incus/disks/default.img   750 GiB file
          └─ /dev/loop0
              └─ btrfs again          ← the Incus pool
                  └─ container/VM subvolumes
                      └─ guest filesystems
```

And data usage:

| Date | Samsung 980 (root) | WD SN850X | Stack |
|---|---:|---:|---|
| 02-10 | 2.06 TB | — | nested: btrfs pool in a loop file on btrfs root |
| 02-11 | 2.17 TB | — | nested: btrfs pool in a loop file on btrfs root |
| 02-12 | 2.17 TB | — | nested: btrfs pool in a loop file on btrfs root |
| 02-13 | — | — | *exporter gap; Incus pool moved to the raw partition at 01:47* |
| 02-14 | 2.62 TB | — | nested + migration copy |
| 02-15 | 0.01 TB | 0.20 TB | btrfs pool on raw NVMe partition |
| 02-16 | 0.01 TB | 0.28 TB | btrfs pool on raw NVMe partition |

Worth noting my root filesystem was also under hourly snapper snapshots, which pin extents and make the outer COW layer worse. So the multiplier here is nesting plus snapshot retention, not nesting alone.

Added a note to the docs to try and save the next poor soul. It already mentions throughput, but the endurance consequence is not mentioned. With current NAND pricing, this kinda stings.

Nested COW Write Amplification Reference: https://ieeexplore.ieee.org/document/6879362