### PR TITLE
incusd/instance/lxc: Use project-qualified CRIU restore name

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -7327,7 +7327,7 @@ func (d *lxc) migrate(args *instance.CriuMigrationArgs) error {
 		_, migrateErr = subprocess.RunCommand(
 			d.state.OS.ExecPath,
 			"forkmigrate",
-			d.name,
+			project.Instance(d.Project().Name, d.Name()),
 			d.state.OS.LxcPath,
 			configPath,
 			finalStateDir,


### PR DESCRIPTION
CRIU restore passed the unqualified instance name to forkmigrate even though liblxc containers use project-qualified names. This fixes stateful restore for instances outside the default project. Tested with: go test ./internal/server/instance/drivers