### PR TITLE
incusd/instance/lxc: Clean devices after failed CRIU restore

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -3799,6 +3799,21 @@ func (d *lxc) cleanupDevices(instanceRunning bool, stopHookNetnsPath string) {
 	}
 }
 
+// cleanupFailedMigrationRestore removes devices prepared by startCommon when CRIU restore fails before the stop hooks can run.
+func (d *lxc) cleanupFailedMigrationRestore() {
+	d.cleanupDevices(false, "")
+
+	err := d.removeUnixDevices()
+	if err != nil {
+		d.logger.Error("Failed to remove Unix devices after migration restore failure", logger.Ctx{"err": err})
+	}
+
+	err = d.removeDiskDevices()
+	if err != nil {
+		d.logger.Error("Failed to remove disk devices after migration restore failure", logger.Ctx{"err": err})
+	}
+}
+
 // Freeze functions.
 func (d *lxc) Freeze() error {
 	ctxMap := logger.Ctx{
@@ -7160,6 +7175,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			// here since we know that "final" is the folder for CRIU's final dump.
 			err = d.migrate(&criuMigrationArgs)
 			if err != nil {
+				d.cleanupFailedMigrationRestore()
 				return err
 			}
 


### PR DESCRIPTION
startCommon prepares storage and device resources before CRIU restore. If restore fails before LXC can run its stop hooks, clean the prepared non-network devices and Unix/disk paths before returning the migration failure. Tested with: go test ./internal/server/instance/drivers