### PR TITLE
incusd/seccomp: Report FUSE mount helper failures

### DIFF
--- a/internal/server/seccomp/seccomp.go
+++ b/internal/server/seccomp/seccomp.go
@@ -2207,6 +2207,7 @@ func (srv *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 	}
 
 	if err != nil {
+		ctx["err"] = err
 		ctx["syscall_continue"] = "true"
 		C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))
 		return 0


### PR DESCRIPTION
Report contextual errors from the intercepted FUSE mount helper and retain its stderr in the seccomp debug context. The existing syscall fallback behavior is unchanged. Tested with: go test ./internal/server/seccomp ./cmd/incusd