### PR TITLE
Fix instance copy for non-block volumes

### DIFF
--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -2234,7 +2234,7 @@ func (b *backend) CreateInstanceFromMigration(inst instance.Instance, conn io.Re
 		}
 	}
 
-	if b.driver.Info().TargetFormat == drivers.BlockVolumeTypeQcow2 && (!b.driver.Info().Remote || args.ClusterMoveSourceName == "" || args.StoragePool != "") {
+	if b.driver.Info().TargetFormat == drivers.BlockVolumeTypeQcow2 && inst.Type() == instancetype.VM && (!b.driver.Info().Remote || args.ClusterMoveSourceName == "" || args.StoragePool != "") {
 		err = b.qcow2CreateVolumeFromMigration(vol, inst.Project().Name, conn, args, &preFiller, op)
 		if err != nil {
 			return err
@@ -5564,7 +5564,7 @@ func (b *backend) CreateCustomVolumeFromMigration(projectName string, conn io.Re
 		}
 	}
 
-	if b.driver.Info().TargetFormat == drivers.BlockVolumeTypeQcow2 && (!b.driver.Info().Remote || args.ClusterMoveSourceName == "" || args.StoragePool != "") {
+	if b.driver.Info().TargetFormat == drivers.BlockVolumeTypeQcow2 && vol.ContentType() == drivers.ContentTypeBlock && (!b.driver.Info().Remote || args.ClusterMoveSourceName == "" || args.StoragePool != "") {
 		err = b.qcow2CreateVolumeFromMigration(vol, projectName, conn, args, nil, op)
 		if err != nil {
 			return err


### PR DESCRIPTION
Copying a container to shared LVM cluster storage failed on the target with errors such as:

    incus cp c1 c2 --storage shared
    Error: Error transferring instance data: Failed migration on target:
    Failed creating instance on target: Volume is not attached to running instance

and, when a dependent disk was involved:

    incus cp c1 c2 --storage shared
    Error: Error transferring instance data: Failed migration on target:
    Failed creating instance on target: Volume is attached to a container

The root cause was that the qcow2 code path was being invoked for volumes that should not use it. For lvmcluster storage, qcow2 handling should only apply to block devices, container root volumes were incorrectly routed through the same qcow2 path, which caused failures during creation on the target.
This change restricts the qcow2 path to block devices, so container on lvmcluster storage are created through the correct code path.
