### PR TITLE
shared/ask, cmd/incus: fix password prompt loop on Windows

### DIFF
--- a/cmd/incus/main.go
+++ b/cmd/incus/main.go
@@ -543,7 +543,7 @@ func (c *cmdGlobal) preRun(cmd *cobra.Command, _ []string) error {
 	// Setup password helper
 	if termios.IsTerminal(getStdinFd()) {
 		c.conf.PromptPassword = func(filename string) (string, error) {
-			return c.asker.AskPasswordOnce(fmt.Sprintf(i18n.G("Password for %s: "), filename)), nil
+			return c.asker.AskPasswordOnce(fmt.Sprintf(i18n.G("Password for %s: "), filename))
 		}
 	}
 

--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -882,7 +882,7 @@ func (c *cmdRemoteGetClientCertificate) run(cmd *cobra.Command, args []string) e
 			}
 
 			// Get a password.
-			password := c.global.asker.AskPasswordOnce(fmt.Sprintf(i18n.G("Password for %s: "), targetFile))
+			password, err := c.global.asker.AskPasswordOnce(fmt.Sprintf(i18n.G("Password for %s: "), targetFile))
 			if err != nil {
 				return err
 			}

--- a/shared/ask/ask.go
+++ b/shared/ask/ask.go
@@ -114,24 +114,30 @@ func (a *Asker) AskString(question string, defaultAnswer string, validate func(s
 }
 
 // AskPassword asks the user to enter a password.
-func (a *Asker) AskPassword(question string) string {
+func (a *Asker) AskPassword(question string) (string, error) {
 	for {
 		fmt.Print(question)
 
-		pwd, _ := term.ReadPassword(0)
+		pwd, err := term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", err
+		}
 		fmt.Println("")
 		inFirst := string(pwd)
 		inFirst = strings.TrimSuffix(inFirst, "\n")
 
 		fmt.Print("Again: ")
-		pwd, _ = term.ReadPassword(0)
+		pwd, err = term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", err
+		}
 		fmt.Println("")
 		inSecond := string(pwd)
 		inSecond = strings.TrimSuffix(inSecond, "\n")
 
 		// refuse empty password or if password inputs do not match
 		if len(inFirst) > 0 && inFirst == inSecond {
-			return inFirst
+			return inFirst, nil
 		}
 
 		invalidInput()
@@ -141,16 +147,19 @@ func (a *Asker) AskPassword(question string) string {
 // AskPasswordOnce asks the user to enter a password.
 //
 // It's the same as AskPassword, but it won't ask to enter it again.
-func (a *Asker) AskPasswordOnce(question string) string {
+func (a *Asker) AskPasswordOnce(question string) (string, error) {
 	for {
 		fmt.Print(question)
-		pwd, _ := term.ReadPassword(0)
+		pwd, err := term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", err
+		}
 		fmt.Println("")
 
 		// refuse empty password
 		spwd := string(pwd)
 		if len(spwd) > 0 {
-			return spwd
+			return spwd, nil
 		}
 
 		invalidInput()


### PR DESCRIPTION
## Fixes
Fixes #3699.

## Summary
Fixes an infinite password prompt loop on Windows when running commands such as:

```sh
incus remote get-client-certificate <file> -f pfx
```

The issue was caused by using a hardcoded file descriptor (`0`) with `term.ReadPassword()` and ignoring the returned error, causing repeated prompt failures.

## Changes
- Use `int(os.Stdin.Fd())` instead of `0` with `term.ReadPassword()`.
- Make `AskPassword` and `AskPasswordOnce` return and propagate errors.
- Update `cmd/incus` to handle the new return signature.

## Verification
- Built successfully.
- Unit tests passed for `cmd/incus` and `shared/ask`.