### PR TITLE
Fix volume activation of filesystem snapshots

### DIFF
--- a/internal/server/storage/drivers/driver_lvm_utils.go
+++ b/internal/server/storage/drivers/driver_lvm_utils.go
@@ -567,7 +567,7 @@ func (d *lvm) acquireExclusive(vol Volume) (func(), error) {
 	lvmActivation.Lock()
 	defer lvmActivation.Unlock()
 
-	_, err := subprocess.TryRunCommand("lvchange", "--activate", "ey", "--ignoreactivationskip", volDevPath)
+	_, err := subprocess.TryRunCommand("lvchange", "--activate", "ey", "-y", "--ignoreactivationskip", volDevPath)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to acquire exclusive lock on LVM logical volume %q: %w", volDevPath, err)
 	}

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -1163,7 +1163,10 @@ func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 				return err
 			}
 
-			releaseSnap, _ := d.acquireExclusive(snapVol)
+			releaseSnap, err := d.acquireExclusive(snapVol)
+			if err != nil {
+				return err
+			}
 
 			err = d.renameLogicalVolume(snapVolPath, newSnapVolPath)
 			if err != nil {
@@ -1323,7 +1326,11 @@ func (d *lvm) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 
 			// acquireExclusive is called on the parent volume to obtain a release function
 			// that switches the volume back to shared mode.
-			releaseParent, _ := d.acquireExclusive(parentVol)
+			releaseParent, err := d.acquireExclusive(parentVol)
+			if err != nil {
+				return
+			}
+
 			releaseParent()
 		})
 
@@ -1340,7 +1347,11 @@ func (d *lvm) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		}
 
 		reverter.Add(func() {
-			releaseParent, _ := d.acquireExclusive(parentVol)
+			releaseParent, err := d.acquireExclusive(parentVol)
+			if err != nil {
+				return
+			}
+
 			_ = d.removeLogicalVolume(parentVolPath)
 			releaseParent()
 		})


### PR DESCRIPTION
When acquiring an exclusive lock on a snapshot volume backed by a non-block volume (which still uses LVM snapshots), activating the snapshot also requires activating its parent LV, which triggers an interactive confirmation prompt from `lvchange`. This adds the `-y` flag to the `lvchange` command in `acquireExclusive` to automatically answer the confirmation prompt.
Additionally, this fixes error handling in `acquireExclusive` so that we return early on error instead of proceeding and dereferencing a nil value.