### PR TITLE
Fix bug in s3 bucket authorization

### DIFF
--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -413,7 +413,46 @@ func allowPermission(objectType auth.ObjectType, entitlement auth.Entitlement, m
 			return nodes[0].Name
 		}
 
-		objectName, err := auth.ObjectFromRequest(r, objectType, expandProject, expandFingerprint, expandVolumeLocation, muxVars...)
+		// Expansion function for bucket location.
+		expandBucketLocation := func(projectName string, poolName string, bucketName string) string {
+			// The location field is only relevant in clusters.
+			if !d.serverClustered {
+				return ""
+			}
+
+			var (
+				poolID int64
+				nodes  []db.NodeInfo
+			)
+
+			err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+				var err error
+
+				poolID, err = tx.GetStoragePoolID(ctx, poolName)
+				if err != nil {
+					return err
+				}
+
+				nodes, err = tx.GetStorageBucketNodes(ctx, poolID, projectName, bucketName)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+			if err != nil {
+				return ""
+			}
+
+			// Buckets should only ever exist on a single member.
+			if len(nodes) != 1 {
+				return ""
+			}
+
+			return nodes[0].Name
+		}
+
+		objectName, err := auth.ObjectFromRequest(r, objectType, expandProject, expandFingerprint, expandVolumeLocation, expandBucketLocation, muxVars...)
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Failed to create authentication object: %w", err))
 		}

--- a/internal/server/auth/authorization_objects.go
+++ b/internal/server/auth/authorization_objects.go
@@ -168,7 +168,7 @@ func NewObject(objectType ObjectType, projectName string, identifierElements ...
 // Mux vars must be provided in the order that they are found in the endpoint path. If the object
 // requires a project name, this is taken from the project query parameter unless the URL begins
 // with /1.0/projects.
-func ObjectFromRequest(r *http.Request, objectType ObjectType, expandProject func(string) string, expandFingerprint func(string, string) string, expandVolumeLocation func(string, string, string, string) string, muxVars ...string) (Object, error) {
+func ObjectFromRequest(r *http.Request, objectType ObjectType, expandProject func(string) string, expandFingerprint func(string, string) string, expandVolumeLocation func(string, string, string, string) string, expandBucketLocation func(string, string, string) string, muxVars ...string) (Object, error) {
 	// Shortcut for server objects which don't require any arguments.
 	if objectType == ObjectTypeServer {
 		return ObjectServer(), nil
@@ -198,6 +198,12 @@ func ObjectFromRequest(r *http.Request, objectType ObjectType, expandProject fun
 				muxValue = location
 			} else if objectType == ObjectTypeStorageVolume {
 				muxValue = expandVolumeLocation(projectName, r.PathValue("poolName"), r.PathValue("type"), r.PathValue("volumeName"))
+			} else if objectType == ObjectTypeStorageBucket {
+		        muxValue = expandBucketLocation(
+				    projectName,
+				    r.PathValue("poolName"),
+				    r.PathValue("bucketName"),
+		        )
 			}
 
 			if muxValue == "" {


### PR DESCRIPTION
When using local s3 buckets (eg btrfs) in clustered mode of incus, bucket permissions are create with the location.
When performing actions that require can_view or can_edit the request for the authorization has no location and fails.
This results in that you can generate buckets but without ability to use, show or edit them.
The fix is oriented at the workaround with volumes for code consistency.
For fairness I don´t test the fix and I get a little bit help from AI.

Signed-off-by: Ramona Beermann <ra-beer@berryit.de>
