### PR TITLE
storage: Bound Ceph RBD unmap operations

### DIFF
--- a/internal/server/storage/drivers/driver_ceph_utils.go
+++ b/internal/server/storage/drivers/driver_ceph_utils.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -242,7 +243,9 @@ func (d *ceph) rbdUnmapVolume(vol Volume, unmapUntilEINVAL bool) error {
 	ourDeactivate := false
 
 again:
-	_, err := subprocess.RunCommand(
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	_, err := subprocess.RunCommandContext(
+		ctx,
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -250,7 +253,12 @@ again:
 		"unmap",
 		rbdVol,
 	)
+	cancel()
 	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("Timed out unmapping RBD volume %q", rbdVol)
+		}
+
 		var runError subprocess.RunError
 		if errors.As(err, &runError) {
 			var exitError *exec.ExitError


### PR DESCRIPTION
The regular \bd unmap\ path can block indefinitely when the kernel side of a mapped RBD device is stuck. Bound the normal unmap call, reject timeout-based recovery for mounted filesystem volumes, and fall back to \bd device unmap --options force\ for detached mapped devices when the regular unmap times out.\n\nA forced RBD unmap can complete asynchronously while open references remain, so this returns once the kernel accepts the removal request instead of looping until EINVAL.\n\nTesting:\n- \go test ./internal/server/storage/drivers\ on Windows: not applicable, Linux/cgo quota package is excluded by build tags.\n- Linux container attempt reached package compilation but the ad-hoc container lacked full Incus CI dependencies, specifically \cowsql.h\. This patch is limited to Ceph helper code and should be covered by upstream CI.