### PR TITLE
Fix SFTP connections

### DIFF
--- a/cmd/incus-agent/sftp.go
+++ b/cmd/incus-agent/sftp.go
@@ -71,7 +71,7 @@ func (r *sftpServe) Render(w http.ResponseWriter) error {
 	}
 
 	// Start sftp server.
-	server, err := sftp.NewServer(conn, sftp.WithAllocator(), sftp.WithServerWorkingDirectory(osBaseWorkingDirectory))
+	server, err := sftp.NewServer(conn, sftp.WithAllocator(), sftp.WithServerWorkingDirectory(osBaseWorkingDirectory), sftp.WithMaxTxPacket(128*1024))
 	if err != nil {
 		return nil
 	}

--- a/cmd/incusd/main_forkfile.go
+++ b/cmd/incusd/main_forkfile.go
@@ -237,7 +237,7 @@ func (c *cmdForkfile) run(_ *cobra.Command, args []string) error {
 			mu.Unlock()
 
 			// Spawn the server.
-			server, err := sftp.NewServer(conn, sftp.WithAllocator())
+			server, err := sftp.NewServer(conn, sftp.WithAllocator(), sftp.WithMaxTxPacket(128*1024))
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
Wait a full minute instead of 10s for sFTP connections and Align the buffer/package size used by the client and server (cmd/incusd, incus-agent) for sFTP transfers.

The first fixes slow clients in overloaded tests, the second WOULD fix `io.Copy()` breaking at ~800 MiB of a transfer.

Related: https://github.com/pkg/sftp/issues/658