### PR TITLE
More speed for compression/decompression with pigz

### DIFF
--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -1,7 +1,6 @@
 package incus
 
 import (
-	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -17,7 +16,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/klauspost/pgzip"
+
 	"github.com/lxc/incus/v7/shared/api"
+	"github.com/lxc/incus/v7/shared/archive"
 	"github.com/lxc/incus/v7/shared/ioprogress"
 	"github.com/lxc/incus/v7/shared/logger"
 	"github.com/lxc/incus/v7/shared/osarch"
@@ -248,7 +250,12 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 		}
 	}
 
-	compressWrite := gzip.NewWriter(pipeWrite)
+	compressWrite := pgzip.NewWriter(pipeWrite)
+	err = compressWrite.SetConcurrency(1<<20, archive.CompressionThreads())
+	if err != nil {
+		return nil, err
+	}
+
 	metadataProcess := subprocess.NewProcessWithFds("tar", []string{"-cf", "-", "-C", filepath.Join(ociPath, "image"), "config.json", "metadata.yaml"}, nil, compressWrite, os.Stderr)
 	err = metadataProcess.Start(ctx)
 	if err != nil {
@@ -257,8 +264,8 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 
 	go func() {
 		_, _ = metadataProcess.Wait(ctx)
-		compressWrite.Close()
-		pipeWrite.Close()
+		_ = compressWrite.Close()
+		_ = pipeWrite.Close()
 	}()
 
 	size, err := util.SafeCopy(req.MetaFile, pipeRead)
@@ -284,7 +291,12 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 		}
 	}
 
-	compressWrite = gzip.NewWriter(pipeWrite)
+	compressWrite = pgzip.NewWriter(pipeWrite)
+	err = compressWrite.SetConcurrency(1<<20, archive.CompressionThreads())
+	if err != nil {
+		return nil, err
+	}
+
 	rootfsProcess := subprocess.NewProcessWithFds("tar", []string{"-cf", "-", "-C", filepath.Join(ociPath, "image", "rootfs"), "."}, nil, compressWrite, nil)
 	err = rootfsProcess.Start(ctx)
 	if err != nil {
@@ -293,8 +305,8 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 
 	go func() {
 		_, _ = rootfsProcess.Wait(ctx)
-		compressWrite.Close()
-		pipeWrite.Close()
+		_ = compressWrite.Close()
+		_ = pipeWrite.Close()
 	}()
 
 	size, err = util.SafeCopy(req.RootfsFile, pipeRead)

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -133,7 +133,12 @@ var imagePublishLock sync.Mutex
 var imageTaskMu sync.Mutex
 
 func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
-	reproducible := []string{"gzip"}
+	// Compressors with reproducible output and the flags needed for it.
+	reproducible := map[string][]string{
+		"gzip": {"-n"},
+		"pigz": {"-n", "-m"},
+	}
+
 	var cmd *exec.Cmd
 
 	// Parse the command.
@@ -183,8 +188,9 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 			args = append(args, fields[1:]...)
 		}
 
-		if slices.Contains(reproducible, fields[0]) {
-			args = append(args, "-n")
+		flags, ok := reproducible[fields[0]]
+		if ok {
+			args = append(args, flags...)
 		}
 
 		cmd := exec.Command(fields[0], args...)

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -188,6 +188,15 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 			args = append(args, fields[1:]...)
 		}
 
+		// Prefer pigz over gzip when available.
+		if fields[0] == "gzip" {
+			_, err := exec.LookPath("pigz")
+			if err == nil {
+				fields[0] = "pigz"
+				args = append(args, "-p", strconv.Itoa(archive.CompressionThreads()))
+			}
+		}
+
 		flags, ok := reproducible[fields[0]]
 		if ok {
 			args = append(args, flags...)

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/jaypipes/pcidb v1.1.1
 	github.com/jochenvg/go-udev v0.0.0-20240801134859-b65ed646224b
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/klauspost/pgzip v1.2.6
 	github.com/lxc/go-lxc v0.0.0-20260316180011-3af4ce000ed7
 	github.com/lxc/incus-os/incus-osd v0.0.0-20260625162138-012573a860bd
 	github.com/mattn/go-colorable v0.1.15
@@ -127,7 +128,6 @@ require (
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/k-sone/critbitgo v1.4.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
-	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3,7 +3,6 @@ package drivers
 import (
 	"bufio"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -35,6 +34,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/kballard/go-shellquote"
+	"github.com/klauspost/pgzip"
 	"github.com/mdlayher/vsock"
 	"github.com/pkg/sftp"
 	"go.yaml.in/yaml/v4"
@@ -82,6 +82,7 @@ import (
 	"github.com/lxc/incus/v7/internal/version"
 	"github.com/lxc/incus/v7/shared/api"
 	agentAPI "github.com/lxc/incus/v7/shared/api/agent"
+	"github.com/lxc/incus/v7/shared/archive"
 	"github.com/lxc/incus/v7/shared/ioprogress"
 	"github.com/lxc/incus/v7/shared/logger"
 	"github.com/lxc/incus/v7/shared/osarch"
@@ -1158,7 +1159,7 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 
 		defer logger.WarnOnError(stateFile.Close, "Failed to close state file")
 
-		uncompressedState, err := gzip.NewReader(stateFile)
+		uncompressedState, err := pgzip.NewReaderN(stateFile, 1<<20, archive.CompressionThreads())
 		if err != nil {
 			return fmt.Errorf("Failed opening state gzip reader: %w", err)
 		}
@@ -1226,7 +1227,12 @@ func (d *qemu) saveState(monitor *qmp.Monitor) error {
 
 	defer logger.WarnOnError(stateFile.Close, "Failed to close state file")
 
-	compressedState, err := gzip.NewWriterLevel(stateFile, gzip.BestSpeed)
+	compressedState, err := pgzip.NewWriterLevel(stateFile, pgzip.BestSpeed)
+	if err != nil {
+		return err
+	}
+
+	err = compressedState.SetConcurrency(1<<20, archive.CompressionThreads())
 	if err != nil {
 		return err
 	}

--- a/shared/archive/compression.go
+++ b/shared/archive/compression.go
@@ -1,0 +1,21 @@
+package archive
+
+import (
+	"runtime"
+)
+
+// CompressionThreads returns the optimal number of threads for parallel (de)compression.
+// The value is kept low to avoid load spikes affecting the running instances.
+func CompressionThreads() int {
+	cpus := runtime.NumCPU()
+
+	if cpus >= 16 {
+		return 4
+	}
+
+	if cpus >= 4 {
+		return 2
+	}
+
+	return 1
+}

--- a/shared/archive/detect.go
+++ b/shared/archive/detect.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
+	"strconv"
 
 	"github.com/lxc/incus/v7/shared/logger"
 )
@@ -43,6 +45,12 @@ func DetectCompressionFile(f io.Reader) ([]string, string, []string, error) {
 	case n >= 2 && bytes.Equal(header[0:2], []byte{'B', 'Z'}):
 		return []string{"-jxf"}, ".tar.bz2", []string{"bzip2", "-d"}, nil
 	case n >= 2 && bytes.Equal(header[0:2], []byte{0x1f, 0x8b}):
+		// Prefer pigz when available.
+		_, err := exec.LookPath("pigz")
+		if err == nil {
+			return []string{"-Ipigz", "-xf"}, ".tar.gz", []string{"pigz", "-d", "-p", strconv.Itoa(CompressionThreads())}, nil
+		}
+
 		return []string{"-zxf"}, ".tar.gz", []string{"gzip", "-d"}, nil
 	case n >= 5 && (bytes.Equal(header[1:5], []byte{'7', 'z', 'X', 'Z'}) && header[0] == 0xFD):
 		return []string{"-Jxf"}, ".tar.xz", []string{"xz", "-d"}, nil

--- a/test/godeps.list
+++ b/test/godeps.list
@@ -1,7 +1,9 @@
 github.com/apex/log
 github.com/gorilla/websocket
+github.com/klauspost/pgzip
 github.com/lxc/incus/v7/client
 github.com/lxc/incus/v7/shared/api
+github.com/lxc/incus/v7/shared/archive
 github.com/lxc/incus/v7/shared/cancel
 github.com/lxc/incus/v7/shared/ioprogress
 github.com/lxc/incus/v7/shared/logger


### PR DESCRIPTION
Switch gzip usage to klauspost/pgzip (parallel gzip) in the client,
incusd response rendering, and the qemu driver's state
save/restore path for faster compression.

Prefer the external `pigz` binary for tar.gz decompression when
available, and treat its output as reproducible the same as gzip's
when publishing images.