### PR TITLE
Preserve client state across derived clients

### DIFF
--- a/client/incus.go
+++ b/client/incus.go
@@ -523,9 +523,26 @@ func (r *ProtocolIncus) websocket(path string) (*websocket.Conn, error) {
 
 // WithContext returns a client that will add context.Context.
 func (r *ProtocolIncus) WithContext(ctx context.Context) InstanceServer {
-	rr := r
-	rr.ctx = ctx
-	return rr
+	return &ProtocolIncus{
+		ctx:                  ctx,
+		ctxConnected:         r.ctxConnected,
+		ctxConnectedCancel:   r.ctxConnectedCancel,
+		server:               r.server,
+		http:                 r.http,
+		httpCertificate:      r.httpCertificate,
+		httpBaseURL:          r.httpBaseURL,
+		httpProtocol:         r.httpProtocol,
+		httpUserAgent:        r.httpUserAgent,
+		httpUnixPath:         r.httpUnixPath,
+		requireAuthenticated: r.requireAuthenticated,
+		clusterTarget:        r.clusterTarget,
+		project:              r.project,
+		eventConns:           make(map[string]*websocket.Conn),
+		eventListeners:       make(map[string][]*EventListener),
+		skipEvents:           r.skipEvents,
+		oidcClient:           r.oidcClient,
+		tempPath:             r.tempPath,
+	}
 }
 
 // getUnderlyingHTTPTransport returns the *http.Transport used by the http client. If the http

--- a/client/incus_server.go
+++ b/client/incus_server.go
@@ -121,6 +121,7 @@ func (r *ProtocolIncus) UseProject(name string) InstanceServer {
 		eventListeners:       make(map[string][]*EventListener), // New project specific listeners.
 		skipEvents:           r.skipEvents,
 		oidcClient:           r.oidcClient,
+		tempPath:             r.tempPath,
 	}
 }
 
@@ -146,6 +147,7 @@ func (r *ProtocolIncus) UseTarget(name string) InstanceServer {
 		skipEvents:           r.skipEvents,
 		oidcClient:           r.oidcClient,
 		clusterTarget:        name,
+		tempPath:             r.tempPath,
 	}
 }
 


### PR DESCRIPTION
`WithContext` now returns a copy of the `ProtocolIncus` client rather than mutating
the receiver, so you can hand a client a different context (timeout/deadline) without
affecting the original.

The second commit fixes the same class of bug in the two pre-existing copy methods:
`UseProject` and `UseTarget` were rebuilding the struct field-by-field and silently
dropping `tempPath`, so project- or target-scoped clients fell back to `os.TempDir()`
instead of the `ConnectionArgs.TempPath` the caller asked for.
