### PR TITLE
Allow live update of ipv4/ipv6.address.external

### DIFF
--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -79,7 +79,7 @@ func (d *nicOVN) UpdatableFields(oldDevice Type) []string {
 		return []string{}
 	}
 
-	return []string{"security.acls", "limits.ingress", "limits.egress", "limits.max", "limits.priority", "connected"}
+	return []string{"security.acls", "limits.ingress", "limits.egress", "limits.max", "limits.priority", "connected", "ipv4.address.external", "ipv6.address.external"}
 }
 
 // validateConfig checks the supplied config for correctness.
@@ -1159,8 +1159,8 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 		}
 	}
 
-	// Apply any changes needed when assigned ACLs change.
-	if d.config["security.acls"] != oldConfig["security.acls"] {
+	// Apply any changes needed when assigned ACLs or external NAT addresses change.
+	if d.config["security.acls"] != oldConfig["security.acls"] || d.config["ipv4.address.external"] != oldConfig["ipv4.address.external"] || d.config["ipv6.address.external"] != oldConfig["ipv6.address.external"] {
 		// Work out which ACLs have been removed and remove logical port from those groups.
 		oldACLs := util.SplitNTrimSpace(oldConfig["security.acls"], ",", -1, true)
 		newACLs := util.SplitNTrimSpace(d.config["security.acls"], ",", -1, true)

--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -344,7 +344,9 @@ func (o *NB) CreateLogicalRouterNAT(ctx context.Context, routerName OVNRouter, n
 		return err
 	}
 
-	// Check if the rule already exists.
+	// Check if the rule already exists, and collect any stale rules
+	// for the same logical IP so they can be replaced.
+	staleOperations := []ovsdb.Operation{}
 	for _, natUUID := range logicalRouter.Nat {
 		natRule := ovnNB.NAT{
 			UUID: natUUID,
@@ -361,12 +363,32 @@ func (o *NB) CreateLogicalRouterNAT(ctx context.Context, routerName OVNRouter, n
 		}
 
 		// Check if matching our new rule.
-		if natRule.LogicalIP == logicalIP && natRule.ExternalIP == externalIP {
-			if mayExist {
-				return nil
+		if natRule.LogicalIP == logicalIP {
+			if natRule.ExternalIP == externalIP {
+				if mayExist {
+					return nil
+				}
+
+				return ErrExists
 			}
 
-			return ErrExists
+			deleteOps, err := o.client.Where(&natRule).Delete()
+			if err != nil {
+				return err
+			}
+
+			staleOperations = append(staleOperations, deleteOps...)
+
+			deleteOps, err = o.client.Where(logicalRouter).Mutate(logicalRouter, ovsModel.Mutation{
+				Field:   &logicalRouter.Nat,
+				Mutator: ovsdb.MutateOperationDelete,
+				Value:   []string{natRule.UUID},
+			})
+			if err != nil {
+				return err
+			}
+
+			staleOperations = append(staleOperations, deleteOps...)
 		}
 	}
 
@@ -378,7 +400,7 @@ func (o *NB) CreateLogicalRouterNAT(ctx context.Context, routerName OVNRouter, n
 		ExternalIP: externalIP,
 	}
 
-	operations := []ovsdb.Operation{}
+	operations := staleOperations
 
 	createOps, err := o.client.Create(&natRule)
 	if err != nil {


### PR DESCRIPTION
Currently, a change of either `ipv4` or `ipv6.address.external` of an instance's NIC triggers a full re-attach. For these two properties, this action is not strictly needed and limits when they can be applied. As of right now, I was seeing errors when applying a `.external` address when an instance's agent is not fully ready yet.

This fix exempts these two properties in `UpdatableFields` and additionally makes sure stale SNAT rules are replaced correctly when addresses change.