### PR TITLE
Use proxy ARP rather than NAT rules for OVN l2proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ GOPATH ?= $(shell $(GO) env GOPATH)
 CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
 SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
-OVN_MINVER=23.03.0
-OVS_MINVER=2.15.0
+OVN_MINVER=24.03.0
+OVS_MINVER=3.3.0
 
 ifneq "$(wildcard vendor)" ""
 	RAFT_PATH=$(CURDIR)/vendor/raft

--- a/cmd/incusd/patches.go
+++ b/cmd/incusd/patches.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -104,6 +105,7 @@ var patches = []patch{
 	{name: "storage_lvmcluster_qcow2_overhead", stage: patchPostDaemonStorage, run: patchGenericStorage},
 	{name: "authorization_openfga_config_keys", stage: patchPreDaemonStorage, run: patchAuthorizationOpenFGAConfigKeys},
 	{name: "authorization_client_routes_from_driver", stage: patchPreDaemonStorage, run: patchAuthorizationClientRoutesFromDriver},
+	{name: "network_ovn_l2proxy_arp_proxy", stage: patchPostDaemonStorage, run: patchGenericNetwork(patchNetworkOVNL2ProxyARPProxy)},
 }
 
 type patchRun func(name string, d *Daemon) error
@@ -1927,6 +1929,165 @@ func patchAuthorizationClientRoutesFromDriver(_ string, d *Daemon) error {
 
 		return nil
 	})
+}
+
+// patchNetworkOVNL2ProxyARPProxy converts the DNAT_AND_SNAT rules used to publish addresses on OVN
+// uplink networks with l2proxy ingress mode into arp_proxy entries on the external switch router port.
+func patchNetworkOVNL2ProxyARPProxy(_ string, d *Daemon) error {
+	s := d.State()
+
+	// Only apply patch on leader.
+	var err error
+	var localConfig *node.Config
+	isLeader := false
+
+	err = d.db.Node.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.NodeTx) error {
+		localConfig, err = node.ConfigLoad(ctx, tx)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	leaderAddress, err := s.Cluster.LeaderAddress()
+	if err != nil {
+		// If we're not clustered, we're the leader.
+		if !errors.Is(err, cluster.ErrNodeIsNotClustered) {
+			return err
+		}
+
+		isLeader = true
+	} else if localConfig.ClusterAddress() == leaderAddress {
+		isLeader = true
+	}
+
+	if !isLeader {
+		return nil
+	}
+
+	// Get all networks.
+	var networks map[string]map[int64]api.Network
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		networks, err = tx.GetCreatedNetworks(ctx)
+
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	for projectName, projectNetworks := range networks {
+		for networkID, netInfo := range projectNetworks {
+			if netInfo.Type != "ovn" {
+				continue
+			}
+
+			// Check that OVN is available.
+			ovnnb, _, err := s.OVN()
+			if err != nil {
+				logger.Errorf("Failed to connect to OVN: %v", err)
+				return errRetryNextTime
+			}
+
+			networkPrefix := acl.OVNNetworkPrefix(networkID)
+			routerName := ovn.OVNRouter(fmt.Sprintf("%s-lr", networkPrefix))
+			extSwitchRouterPortName := ovn.OVNSwitchPort(fmt.Sprintf("%s-ls-ext-lsp-router", networkPrefix))
+
+			// Get the identity DNAT_AND_SNAT rules used to publish addresses on the uplink.
+			natRules, err := ovnnb.GetLogicalRouterNATs(context.TODO(), routerName)
+			if err != nil {
+				if errors.Is(err, ovn.ErrNotFound) {
+					continue // Skip networks that don't exist on the OVN side.
+				}
+
+				return fmt.Errorf("Failed getting NAT rules for network %q in project %q: %w", netInfo.Name, projectName, err)
+			}
+
+			var identityIPs []net.IP
+			for _, natRule := range natRules {
+				if natRule.Type != "dnat_and_snat" || natRule.ExternalIP != natRule.LogicalIP {
+					continue
+				}
+
+				ip := net.ParseIP(natRule.ExternalIP)
+				if ip == nil {
+					continue
+				}
+
+				identityIPs = append(identityIPs, ip)
+			}
+
+			if len(identityIPs) == 0 {
+				continue
+			}
+
+			// Get the list of active instance ports.
+			activePorts, err := ovnnb.GetLogicalSwitchActivePorts(context.TODO(), acl.OVNIntSwitchName(networkID))
+			if err != nil {
+				return fmt.Errorf("Failed getting active ports for network %q in project %q: %w", netInfo.Name, projectName, err)
+			}
+
+			// Get the external routes of active NICs so their per-IP rules can be converted to subnets.
+			var routeIPNets []*net.IPNet
+			err = network.UsedByInstanceDevices(s, projectName, netInfo.Name, netInfo.Type, func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error {
+				instancePortName := ovn.OVNSwitchPort(fmt.Sprintf("%s-instance-%s-%s", networkPrefix, inst.Config["volatile.uuid"], nicName))
+				_, found := activePorts[instancePortName]
+				if !found {
+					return nil // Skip NICs that aren't started.
+				}
+
+				for _, key := range []string{"ipv4.routes.external", "ipv6.routes.external"} {
+					for _, routeStr := range util.SplitNTrimSpace(nicConfig[key], ",", -1, true) {
+						_, routeIPNet, err := net.ParseCIDR(routeStr)
+						if err != nil {
+							continue
+						}
+
+						routeIPNets = append(routeIPNets, routeIPNet)
+					}
+				}
+
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			// Build the proxy ARP/NDP entries.
+			var addIPNets []net.IPNet
+			for _, routeIPNet := range routeIPNets {
+				addIPNets = append(addIPNets, *routeIPNet)
+			}
+
+			for _, ip := range identityIPs {
+				covered := false
+				for _, routeIPNet := range routeIPNets {
+					if routeIPNet.Contains(ip) {
+						covered = true
+						break
+					}
+				}
+
+				if !covered {
+					addIPNets = append(addIPNets, network.IPToNet(ip))
+				}
+			}
+
+			// Add the proxy ARP/NDP entries before removing the NAT rules to avoid an advertisement gap.
+			err = ovnnb.UpdateLogicalSwitchPortARPProxy(context.TODO(), extSwitchRouterPortName, addIPNets, nil)
+			if err != nil {
+				return fmt.Errorf("Failed adding proxy ARP/NDP entries for network %q in project %q: %w", netInfo.Name, projectName, err)
+			}
+
+			err = ovnnb.DeleteLogicalRouterNAT(context.TODO(), routerName, "dnat_and_snat", false, identityIPs...)
+			if err != nil {
+				return fmt.Errorf("Failed deleting NAT rules for network %q in project %q: %w", netInfo.Name, projectName, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // Patches end here

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -56,8 +56,8 @@ Minimum versions for network related tooling:
 
 When using Incus with OVN networks, the minimum versions of OVS and OVN are:
 
-* `openvswitch`: 2.15.0
-* `ovn`: 23.03.0
+* `openvswitch`: 3.3.0
+* `ovn`: 24.03.0
 
 ## Storage
 

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -5025,6 +5025,9 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		}
 	}
 
+	// Addresses to advertise on the uplink network using proxy ARP/NDP.
+	var arpProxyIPNets []net.IPNet
+
 	// Publish NIC's IPs on uplink network if NAT is disabled and using l2proxy ingress mode on uplink.
 	if n.config["network"] != "none" && slices.Contains([]string{"l2proxy", ""}, opts.UplinkConfig["ovn.ingress_mode"]) {
 		for _, k := range []string{"ipv4.nat", "ipv6.nat"} {
@@ -5045,14 +5048,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 				continue // No qualifying target IP from DNS records.
 			}
 
-			err = n.ovnnb.CreateLogicalRouterNAT(context.TODO(), n.getRouterName(), "dnat_and_snat", nil, ipAddress, ipAddress, true, true)
-			if err != nil {
-				return "", nil, err
-			}
-
-			reverter.Add(func() {
-				_ = n.ovnnb.DeleteLogicalRouterNAT(context.TODO(), n.getRouterName(), "dnat_and_snat", false, ipAddress)
-			})
+			arpProxyIPNets = append(arpProxyIPNets, IPToNet(ipAddress))
 		}
 	}
 
@@ -5104,28 +5100,23 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			Port:    n.getRouterIntPortName(),
 		})
 
-		// When using l2proxy ingress mode on uplink, in order to advertise the external route to the
-		// uplink network using proxy ARP/NDP we need to add a stateless dnat_and_snat rule (as to my
-		// knowledge this is the only way to get the OVN router to respond to ARP/NDP requests for IPs that
-		// it doesn't actually have). However we have to add each IP in the external route individually as
-		// DNAT doesn't support whole subnets.
+		// When using l2proxy ingress mode on uplink, advertise the external route on the uplink
+		// network using proxy ARP/NDP.
 		if n.config["network"] != "none" && slices.Contains([]string{"l2proxy", ""}, opts.UplinkConfig["ovn.ingress_mode"]) {
-			err = SubnetIterate(externalRoute, func(ip net.IP) error {
-				err = n.ovnnb.CreateLogicalRouterNAT(context.TODO(), n.getRouterName(), "dnat_and_snat", nil, ip, ip, true, true)
-				if err != nil {
-					return err
-				}
-
-				reverter.Add(func() {
-					_ = n.ovnnb.DeleteLogicalRouterNAT(context.TODO(), n.getRouterName(), "dnat_and_snat", false, ip)
-				})
-
-				return nil
-			})
-			if err != nil {
-				return "", nil, err
-			}
+			arpProxyIPNets = append(arpProxyIPNets, *externalRoute)
 		}
+	}
+
+	// Advertise the addresses on the uplink network through the external switch's router port.
+	if len(arpProxyIPNets) > 0 {
+		err = n.ovnnb.UpdateLogicalSwitchPortARPProxy(context.TODO(), n.getExtSwitchRouterPortName(), arpProxyIPNets, nil)
+		if err != nil {
+			return "", nil, err
+		}
+
+		reverter.Add(func() {
+			_ = n.ovnnb.UpdateLogicalSwitchPortARPProxy(context.TODO(), n.getExtSwitchRouterPortName(), nil, arpProxyIPNets)
+		})
 	}
 
 	if len(routes) > 0 {
@@ -5532,7 +5523,7 @@ func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort networkOVN.OVNSwitchPort
 	}
 
 	var removeRoutes []net.IPNet
-	var removeNATIPs []net.IP
+	var removeARPProxyIPNets []net.IPNet
 
 	if len(dnsIPs) > 0 {
 		// When using l3only mode the instance port's IPs are added as static routes to the router.
@@ -5541,8 +5532,10 @@ func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort networkOVN.OVNSwitchPort
 			removeRoutes = append(removeRoutes, IPToNet(dnsIP))
 		}
 
-		// Delete any associated external IP DNAT rules for the DNS IPs.
-		removeNATIPs = append(removeNATIPs, dnsIPs...)
+		// Delete any associated proxy ARP/NDP entries for the DNS IPs.
+		for _, dnsIP := range dnsIPs {
+			removeARPProxyIPNets = append(removeARPProxyIPNets, IPToNet(dnsIP))
+		}
 	}
 
 	// Delete internal routes.
@@ -5556,16 +5549,9 @@ func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort networkOVN.OVNSwitchPort
 	for _, externalRoute := range externalRoutes {
 		removeRoutes = append(removeRoutes, *externalRoute)
 
-		// Remove the DNAT rules when using l2proxy ingress mode on uplink.
+		// Remove the proxy ARP/NDP entries when using l2proxy ingress mode on uplink.
 		if uplink != nil && slices.Contains([]string{"l2proxy", ""}, uplink.Config["ovn.ingress_mode"]) {
-			err = SubnetIterate(externalRoute, func(ip net.IP) error {
-				removeNATIPs = append(removeNATIPs, ip)
-
-				return nil
-			})
-			if err != nil {
-				return err
-			}
+			removeARPProxyIPNets = append(removeARPProxyIPNets, *externalRoute)
 		}
 	}
 
@@ -5597,9 +5583,9 @@ func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort networkOVN.OVNSwitchPort
 		}
 	}
 
-	if len(removeNATIPs) > 0 {
-		err = n.ovnnb.DeleteLogicalRouterNAT(context.TODO(), n.getRouterName(), "dnat_and_snat", false, removeNATIPs...)
-		if err != nil {
+	if uplink != nil && len(removeARPProxyIPNets) > 0 {
+		err = n.ovnnb.UpdateLogicalSwitchPortARPProxy(context.TODO(), n.getExtSwitchRouterPortName(), nil, removeARPProxyIPNets)
+		if err != nil && !errors.Is(err, networkOVN.ErrNotFound) {
 			return err
 		}
 	}
@@ -5962,7 +5948,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 		break // Only run setup once per notification (all changes will be applied).
 	}
 
-	// Add or remove the instance NIC l2proxy DNAT_AND_SNAT rules if uplink's ovn.ingress_mode has changed.
+	// Add or remove the instance NIC l2proxy advertisements if uplink's ovn.ingress_mode has changed.
 	if slices.Contains(changedKeys, "ovn.ingress_mode") {
 		n.logger.Debug("Applying ingress mode changes from uplink network to instance NICs", logger.Ctx{"uplink": uplinkName})
 
@@ -5974,7 +5960,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 			}
 
 			// Find all instance NICs that use this network, and re-add the logical OVN instance port.
-			// This will restore the l2proxy DNAT_AND_SNAT rules.
+			// This will restore the l2proxy proxy ARP/NDP entries.
 			err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
 					// Get the instance's effective network project name.
@@ -6008,7 +5994,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 							devConfig["hwaddr"] = inst.Config[fmt.Sprintf("volatile.%s.hwaddr", devName)]
 						}
 
-						// Re-add logical switch port to apply the l2proxy DNAT_AND_SNAT rules.
+						// Re-add logical switch port to apply the l2proxy proxy ARP/NDP entries.
 						n.logger.Debug("Re-adding instance OVN NIC port to apply ingress mode changes", logger.Ctx{"project": inst.Project, "instance": inst.Name, "device": devName})
 						_, _, err = n.InstanceDevicePortStart(&OVNInstanceNICSetupOpts{
 							InstanceUUID: instanceUUID,
@@ -6030,11 +6016,11 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 				return fmt.Errorf("Failed adding instance NIC ingress mode l2proxy rules: %w", err)
 			}
 		} else {
-			// Remove all DNAT_AND_SNAT rules if not using l2proxy ingress mode, as currently we only
-			// use DNAT_AND_SNAT rules for this feature so it is safe to do.
-			err := n.ovnnb.DeleteLogicalRouterNAT(context.TODO(), n.getRouterName(), "dnat_and_snat", true)
+			// Remove all proxy ARP/NDP entries if not using l2proxy ingress mode, as currently we
+			// only use them for this feature so it is safe to do.
+			err := n.ovnnb.ClearLogicalSwitchPortARPProxy(context.TODO(), n.getExtSwitchRouterPortName())
 			if err != nil {
-				return fmt.Errorf("Failed deleting instance NIC ingress mode l2proxy rules: %w", err)
+				return fmt.Errorf("Failed clearing instance NIC ingress mode l2proxy entries: %w", err)
 			}
 		}
 	}

--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -2582,6 +2582,114 @@ func (o *NB) UpdateLogicalSwitchPortLinkRouter(ctx context.Context, switchPortNa
 	return nil
 }
 
+// UpdateLogicalSwitchPortARPProxy adds and removes entries from a logical switch port's arp_proxy option.
+func (o *NB) UpdateLogicalSwitchPortARPProxy(ctx context.Context, switchPortName OVNSwitchPort, addIPNets []net.IPNet, removeIPNets []net.IPNet) error {
+	// Get the logical switch port.
+	lsp := ovnNB.LogicalSwitchPort{
+		Name: string(switchPortName),
+	}
+
+	err := o.get(ctx, &lsp)
+	if err != nil {
+		return err
+	}
+
+	// Get the current entries.
+	entries := strings.Fields(lsp.Options["arp_proxy"])
+
+	// Apply the requested changes.
+	for _, ipNet := range removeIPNets {
+		entry := ipNet.String()
+		entries = slices.DeleteFunc(entries, func(e string) bool { return e == entry })
+	}
+
+	for _, ipNet := range addIPNets {
+		entry := ipNet.String()
+		if !slices.Contains(entries, entry) {
+			entries = append(entries, entry)
+		}
+	}
+
+	slices.Sort(entries)
+
+	// Check if anything changed.
+	newValue := strings.Join(entries, " ")
+	if newValue == lsp.Options["arp_proxy"] {
+		return nil
+	}
+
+	// Update the fields.
+	if lsp.Options == nil {
+		lsp.Options = map[string]string{}
+	}
+
+	if newValue != "" {
+		lsp.Options["arp_proxy"] = newValue
+	} else {
+		delete(lsp.Options, "arp_proxy")
+	}
+
+	// Update the record.
+	operations, err := o.client.Where(&lsp).Update(&lsp)
+	if err != nil {
+		return err
+	}
+
+	// Apply the changes.
+	resp, err := o.client.Transact(ctx, operations...)
+	if err != nil {
+		return err
+	}
+
+	_, err = ovsdb.CheckOperationResults(resp, operations)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ClearLogicalSwitchPortARPProxy removes the arp_proxy option from a logical switch port.
+func (o *NB) ClearLogicalSwitchPortARPProxy(ctx context.Context, switchPortName OVNSwitchPort) error {
+	// Get the logical switch port.
+	lsp := ovnNB.LogicalSwitchPort{
+		Name: string(switchPortName),
+	}
+
+	err := o.get(ctx, &lsp)
+	if err != nil {
+		return err
+	}
+
+	// Check if there's anything to clear.
+	_, found := lsp.Options["arp_proxy"]
+	if !found {
+		return nil
+	}
+
+	// Update the fields.
+	delete(lsp.Options, "arp_proxy")
+
+	// Update the record.
+	operations, err := o.client.Where(&lsp).Update(&lsp)
+	if err != nil {
+		return err
+	}
+
+	// Apply the changes.
+	resp, err := o.client.Transact(ctx, operations...)
+	if err != nil {
+		return err
+	}
+
+	_, err = ovsdb.CheckOperationResults(resp, operations)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // UpdateLogicalSwitchPortLinkProviderNetwork links a logical switch port to a provider network.
 func (o *NB) UpdateLogicalSwitchPortLinkProviderNetwork(ctx context.Context, switchPortName OVNSwitchPort, extNetworkName string) error {
 	// Get the logical switch port.

--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -321,6 +321,32 @@ func (o *NB) GetLogicalRouter(ctx context.Context, routerName OVNRouter) (*ovnNB
 	return logicalRouter, nil
 }
 
+// GetLogicalRouterNATs returns the NAT rules of a logical router.
+func (o *NB) GetLogicalRouterNATs(ctx context.Context, routerName OVNRouter) ([]ovnNB.NAT, error) {
+	// Get the logical router.
+	logicalRouter, err := o.GetLogicalRouter(ctx, routerName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the NAT rules.
+	natRules := make([]ovnNB.NAT, 0, len(logicalRouter.Nat))
+	for _, natUUID := range logicalRouter.Nat {
+		natRule := ovnNB.NAT{
+			UUID: natUUID,
+		}
+
+		err = o.get(ctx, &natRule)
+		if err != nil {
+			return nil, err
+		}
+
+		natRules = append(natRules, natRule)
+	}
+
+	return natRules, nil
+}
+
 // CreateLogicalRouterNAT adds an SNAT or DNAT rule to a logical router to translate packets from intNet to extIP.
 func (o *NB) CreateLogicalRouterNAT(ctx context.Context, routerName OVNRouter, natType string, intNet *net.IPNet, extIP net.IP, intIP net.IP, stateless bool, mayExist bool) error {
 	// Prepare the addresses.

--- a/internal/server/network/ovn/schema/ovn-ic-nb/ic_nb_global.go
+++ b/internal/server/network/ovn/schema/ovn-ic-nb/ic_nb_global.go
@@ -10,6 +10,8 @@ type ICNBGlobal struct {
 	UUID        string            `ovsdb:"_uuid"`
 	Connections []string          `ovsdb:"connections"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	NbIcCfg     int               `ovsdb:"nb_ic_cfg"`
 	Options     map[string]string `ovsdb:"options"`
+	SbIcCfg     int               `ovsdb:"sb_ic_cfg"`
 	SSL         *string           `ovsdb:"ssl"`
 }

--- a/internal/server/network/ovn/schema/ovn-ic-nb/model.go
+++ b/internal/server/network/ovn/schema/ovn-ic-nb/model.go
@@ -22,7 +22,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_IC_Northbound",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "tables": {
     "Connection": {
       "columns": {
@@ -120,6 +120,9 @@ var schema = `{
             "max": "unlimited"
           }
         },
+        "nb_ic_cfg": {
+          "type": "integer"
+        },
         "options": {
           "type": {
             "key": {
@@ -131,6 +134,9 @@ var schema = `{
             "min": 0,
             "max": "unlimited"
           }
+        },
+        "sb_ic_cfg": {
+          "type": "integer"
         },
         "ssl": {
           "type": {

--- a/internal/server/network/ovn/schema/ovn-ic-sb/availability_zone.go
+++ b/internal/server/network/ovn/schema/ovn-ic-sb/availability_zone.go
@@ -7,6 +7,7 @@ const AvailabilityZoneTable = "Availability_Zone"
 
 // AvailabilityZone defines an object in Availability_Zone table
 type AvailabilityZone struct {
-	UUID string `ovsdb:"_uuid"`
-	Name string `ovsdb:"name"`
+	UUID    string `ovsdb:"_uuid"`
+	Name    string `ovsdb:"name"`
+	NbIcCfg int    `ovsdb:"nb_ic_cfg"`
 }

--- a/internal/server/network/ovn/schema/ovn-ic-sb/ic_sb_global.go
+++ b/internal/server/network/ovn/schema/ovn-ic-sb/ic_sb_global.go
@@ -10,6 +10,7 @@ type ICSBGlobal struct {
 	UUID        string            `ovsdb:"_uuid"`
 	Connections []string          `ovsdb:"connections"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	NbIcCfg     int               `ovsdb:"nb_ic_cfg"`
 	Options     map[string]string `ovsdb:"options"`
 	SSL         *string           `ovsdb:"ssl"`
 }

--- a/internal/server/network/ovn/schema/ovn-ic-sb/model.go
+++ b/internal/server/network/ovn/schema/ovn-ic-sb/model.go
@@ -27,12 +27,15 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_IC_Southbound",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "tables": {
     "Availability_Zone": {
       "columns": {
         "name": {
           "type": "string"
+        },
+        "nb_ic_cfg": {
+          "type": "integer"
         }
       },
       "indexes": [
@@ -260,6 +263,9 @@ var schema = `{
             "min": 0,
             "max": "unlimited"
           }
+        },
+        "nb_ic_cfg": {
+          "type": "integer"
         },
         "options": {
           "type": {

--- a/internal/server/network/ovn/schema/ovn-nb/acl.go
+++ b/internal/server/network/ovn/schema/ovn-nb/acl.go
@@ -17,6 +17,7 @@ var (
 	ACLActionAllowStateless ACLAction    = "allow-stateless"
 	ACLActionDrop           ACLAction    = "drop"
 	ACLActionReject         ACLAction    = "reject"
+	ACLActionPass           ACLAction    = "pass"
 	ACLDirectionFromLport   ACLDirection = "from-lport"
 	ACLDirectionToLport     ACLDirection = "to-lport"
 	ACLSeverityAlert        ACLSeverity  = "alert"
@@ -29,7 +30,7 @@ var (
 // ACL defines an object in ACL table
 type ACL struct {
 	UUID        string            `ovsdb:"_uuid"`
-	Action      ACLAction         `ovsdb:"action" validate:"oneof='allow' 'allow-related' 'allow-stateless' 'drop' 'reject'"`
+	Action      ACLAction         `ovsdb:"action" validate:"oneof='allow' 'allow-related' 'allow-stateless' 'drop' 'reject' 'pass'"`
 	Direction   ACLDirection      `ovsdb:"direction" validate:"oneof='from-lport' 'to-lport'"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Label       int               `ovsdb:"label" validate:"min=0,max=4294967295"`
@@ -40,4 +41,5 @@ type ACL struct {
 	Options     map[string]string `ovsdb:"options"`
 	Priority    int               `ovsdb:"priority" validate:"min=0,max=32767"`
 	Severity    *ACLSeverity      `ovsdb:"severity" validate:"omitempty,oneof='alert' 'warning' 'notice' 'info' 'debug'"`
+	Tier        int               `ovsdb:"tier" validate:"min=0,max=3"`
 }

--- a/internal/server/network/ovn/schema/ovn-nb/dns.go
+++ b/internal/server/network/ovn/schema/ovn-nb/dns.go
@@ -9,5 +9,6 @@ const DNSTable = "DNS"
 type DNS struct {
 	UUID        string            `ovsdb:"_uuid"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	Options     map[string]string `ovsdb:"options"`
 	Records     map[string]string `ovsdb:"records"`
 }

--- a/internal/server/network/ovn/schema/ovn-nb/logical_router_policy.go
+++ b/internal/server/network/ovn/schema/ovn-nb/logical_router_policy.go
@@ -19,6 +19,7 @@ var (
 type LogicalRouterPolicy struct {
 	UUID        string                    `ovsdb:"_uuid"`
 	Action      LogicalRouterPolicyAction `ovsdb:"action" validate:"oneof='allow' 'drop' 'reroute'"`
+	BFDSessions []string                  `ovsdb:"bfd_sessions"`
 	ExternalIDs map[string]string         `ovsdb:"external_ids"`
 	Match       string                    `ovsdb:"match"`
 	Nexthop     *string                   `ovsdb:"nexthop"`

--- a/internal/server/network/ovn/schema/ovn-nb/logical_router_port.go
+++ b/internal/server/network/ovn/schema/ovn-nb/logical_router_port.go
@@ -19,4 +19,5 @@ type LogicalRouterPort struct {
 	Networks       []string          `ovsdb:"networks" validate:"min=1"`
 	Options        map[string]string `ovsdb:"options"`
 	Peer           *string           `ovsdb:"peer"`
+	Status         map[string]string `ovsdb:"status"`
 }

--- a/internal/server/network/ovn/schema/ovn-nb/mirror.go
+++ b/internal/server/network/ovn/schema/ovn-nb/mirror.go
@@ -13,17 +13,19 @@ type (
 var (
 	MirrorFilterFromLport MirrorFilter = "from-lport"
 	MirrorFilterToLport   MirrorFilter = "to-lport"
+	MirrorFilterBoth      MirrorFilter = "both"
 	MirrorTypeGre         MirrorType   = "gre"
 	MirrorTypeErspan      MirrorType   = "erspan"
+	MirrorTypeLocal       MirrorType   = "local"
 )
 
 // Mirror defines an object in Mirror table
 type Mirror struct {
 	UUID        string            `ovsdb:"_uuid"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
-	Filter      MirrorFilter      `ovsdb:"filter" validate:"oneof='from-lport' 'to-lport'"`
+	Filter      MirrorFilter      `ovsdb:"filter" validate:"oneof='from-lport' 'to-lport' 'both'"`
 	Index       int               `ovsdb:"index"`
 	Name        string            `ovsdb:"name"`
 	Sink        string            `ovsdb:"sink"`
-	Type        MirrorType        `ovsdb:"type" validate:"oneof='gre' 'erspan'"`
+	Type        MirrorType        `ovsdb:"type" validate:"oneof='gre' 'erspan' 'local'"`
 }

--- a/internal/server/network/ovn/schema/ovn-nb/model.go
+++ b/internal/server/network/ovn/schema/ovn-nb/model.go
@@ -48,7 +48,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Northbound",
-  "version": "7.0.0",
+  "version": "7.3.0",
   "tables": {
     "ACL": {
       "columns": {
@@ -63,7 +63,8 @@ var schema = `{
                   "allow-related",
                   "allow-stateless",
                   "drop",
-                  "reject"
+                  "reject",
+                  "pass"
                 ]
               ]
             }
@@ -168,6 +169,15 @@ var schema = `{
             },
             "min": 0,
             "max": 1
+          }
+        },
+        "tier": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 0,
+              "maxInteger": 3
+            }
           }
         }
       }
@@ -475,6 +485,18 @@ var schema = `{
     "DNS": {
       "columns": {
         "external_ids": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
+        "options": {
           "type": {
             "key": {
               "type": "string"
@@ -943,6 +965,17 @@ var schema = `{
             }
           }
         },
+        "bfd_sessions": {
+          "type": {
+            "key": {
+              "type": "uuid",
+              "refTable": "BFD",
+              "refType": "weak"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
         "external_ids": {
           "type": {
             "key": {
@@ -1099,6 +1132,18 @@ var schema = `{
             },
             "min": 0,
             "max": 1
+          }
+        },
+        "status": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
           }
         }
       },
@@ -1582,7 +1627,8 @@ var schema = `{
                 "set",
                 [
                   "from-lport",
-                  "to-lport"
+                  "to-lport",
+                  "both"
                 ]
               ]
             }
@@ -1605,7 +1651,8 @@ var schema = `{
                 "set",
                 [
                   "gre",
-                  "erspan"
+                  "erspan",
+                  "local"
                 ]
               ]
             }
@@ -1848,12 +1895,18 @@ var schema = `{
           "type": {
             "key": {
               "type": "string",
-              "enum": "dscp"
+              "enum": [
+                "set",
+                [
+                  "dscp",
+                  "mark"
+                ]
+              ]
             },
             "value": {
               "type": "integer",
               "minInteger": 0,
-              "maxInteger": 63
+              "maxInteger": 4294967295
             },
             "min": 0,
             "max": "unlimited"

--- a/internal/server/network/ovn/schema/ovn-nb/qos.go
+++ b/internal/server/network/ovn/schema/ovn-nb/qos.go
@@ -13,6 +13,7 @@ type (
 
 var (
 	QoSActionDSCP         QoSAction    = "dscp"
+	QoSActionMark         QoSAction    = "mark"
 	QoSBandwidthRate      QoSBandwidth = "rate"
 	QoSBandwidthBurst     QoSBandwidth = "burst"
 	QoSDirectionFromLport QoSDirection = "from-lport"
@@ -22,7 +23,7 @@ var (
 // QoS defines an object in QoS table
 type QoS struct {
 	UUID        string            `ovsdb:"_uuid"`
-	Action      map[string]int    `ovsdb:"action" validate:"dive,keys,oneof='dscp',endkeys,min=0,max=63"`
+	Action      map[string]int    `ovsdb:"action" validate:"dive,keys,oneof='dscp' 'mark',endkeys,min=0,max=4294967295"`
 	Bandwidth   map[string]int    `ovsdb:"bandwidth" validate:"dive,keys,oneof='rate' 'burst',endkeys,min=1,max=4294967295"`
 	Direction   QoSDirection      `ovsdb:"direction" validate:"oneof='from-lport' 'to-lport'"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`

--- a/internal/server/network/ovn/schema/ovn-sb/bfd.go
+++ b/internal/server/network/ovn/schema/ovn-sb/bfd.go
@@ -19,6 +19,7 @@ var (
 // BFD defines an object in BFD table
 type BFD struct {
 	UUID        string            `ovsdb:"_uuid"`
+	ChassisName string            `ovsdb:"chassis_name"`
 	DetectMult  int               `ovsdb:"detect_mult"`
 	Disc        int               `ovsdb:"disc"`
 	DstIP       string            `ovsdb:"dst_ip"`

--- a/internal/server/network/ovn/schema/ovn-sb/dhcpv6_options.go
+++ b/internal/server/network/ovn/schema/ovn-sb/dhcpv6_options.go
@@ -10,9 +10,10 @@ type (
 )
 
 var (
-	DHCPv6OptionsTypeIpv6 DHCPv6OptionsType = "ipv6"
-	DHCPv6OptionsTypeStr  DHCPv6OptionsType = "str"
-	DHCPv6OptionsTypeMAC  DHCPv6OptionsType = "mac"
+	DHCPv6OptionsTypeIpv6   DHCPv6OptionsType = "ipv6"
+	DHCPv6OptionsTypeStr    DHCPv6OptionsType = "str"
+	DHCPv6OptionsTypeMAC    DHCPv6OptionsType = "mac"
+	DHCPv6OptionsTypeDomain DHCPv6OptionsType = "domain"
 )
 
 // DHCPv6Options defines an object in DHCPv6_Options table
@@ -20,5 +21,5 @@ type DHCPv6Options struct {
 	UUID string            `ovsdb:"_uuid"`
 	Code int               `ovsdb:"code" validate:"min=0,max=254"`
 	Name string            `ovsdb:"name"`
-	Type DHCPv6OptionsType `ovsdb:"type" validate:"oneof='ipv6' 'str' 'mac'"`
+	Type DHCPv6OptionsType `ovsdb:"type" validate:"oneof='ipv6' 'str' 'mac' 'domain'"`
 }

--- a/internal/server/network/ovn/schema/ovn-sb/dns.go
+++ b/internal/server/network/ovn/schema/ovn-sb/dns.go
@@ -10,5 +10,6 @@ type DNS struct {
 	UUID        string            `ovsdb:"_uuid"`
 	Datapaths   []string          `ovsdb:"datapaths" validate:"min=1"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	Options     map[string]string `ovsdb:"options"`
 	Records     map[string]string `ovsdb:"records"`
 }

--- a/internal/server/network/ovn/schema/ovn-sb/fdb.go
+++ b/internal/server/network/ovn/schema/ovn-sb/fdb.go
@@ -7,8 +7,9 @@ const FDBTable = "FDB"
 
 // FDB defines an object in FDB table
 type FDB struct {
-	UUID    string `ovsdb:"_uuid"`
-	DpKey   int    `ovsdb:"dp_key" validate:"min=1,max=16777215"`
-	MAC     string `ovsdb:"mac"`
-	PortKey int    `ovsdb:"port_key" validate:"min=1,max=16777215"`
+	UUID      string `ovsdb:"_uuid"`
+	DpKey     int    `ovsdb:"dp_key" validate:"min=1,max=16777215"`
+	MAC       string `ovsdb:"mac"`
+	PortKey   int    `ovsdb:"port_key" validate:"min=1,max=16777215"`
+	Timestamp int    `ovsdb:"timestamp"`
 }

--- a/internal/server/network/ovn/schema/ovn-sb/igmp_group.go
+++ b/internal/server/network/ovn/schema/ovn-sb/igmp_group.go
@@ -7,9 +7,10 @@ const IGMPGroupTable = "IGMP_Group"
 
 // IGMPGroup defines an object in IGMP_Group table
 type IGMPGroup struct {
-	UUID     string   `ovsdb:"_uuid"`
-	Address  string   `ovsdb:"address"`
-	Chassis  *string  `ovsdb:"chassis"`
-	Datapath *string  `ovsdb:"datapath"`
-	Ports    []string `ovsdb:"ports"`
+	UUID        string   `ovsdb:"_uuid"`
+	Address     string   `ovsdb:"address"`
+	Chassis     *string  `ovsdb:"chassis"`
+	ChassisName string   `ovsdb:"chassis_name"`
+	Datapath    *string  `ovsdb:"datapath"`
+	Ports       []string `ovsdb:"ports"`
 }

--- a/internal/server/network/ovn/schema/ovn-sb/load_balancer.go
+++ b/internal/server/network/ovn/schema/ovn-sb/load_balancer.go
@@ -17,12 +17,14 @@ var (
 
 // LoadBalancer defines an object in Load_Balancer table
 type LoadBalancer struct {
-	UUID          string                `ovsdb:"_uuid"`
-	DatapathGroup *string               `ovsdb:"datapath_group"`
-	Datapaths     []string              `ovsdb:"datapaths"`
-	ExternalIDs   map[string]string     `ovsdb:"external_ids"`
-	Name          string                `ovsdb:"name"`
-	Options       map[string]string     `ovsdb:"options"`
-	Protocol      *LoadBalancerProtocol `ovsdb:"protocol" validate:"omitempty,oneof='tcp' 'udp' 'sctp'"`
-	Vips          map[string]string     `ovsdb:"vips"`
+	UUID            string                `ovsdb:"_uuid"`
+	DatapathGroup   *string               `ovsdb:"datapath_group"`
+	Datapaths       []string              `ovsdb:"datapaths"`
+	ExternalIDs     map[string]string     `ovsdb:"external_ids"`
+	LrDatapathGroup *string               `ovsdb:"lr_datapath_group"`
+	LsDatapathGroup *string               `ovsdb:"ls_datapath_group"`
+	Name            string                `ovsdb:"name"`
+	Options         map[string]string     `ovsdb:"options"`
+	Protocol        *LoadBalancerProtocol `ovsdb:"protocol" validate:"omitempty,oneof='tcp' 'udp' 'sctp'"`
+	Vips            map[string]string     `ovsdb:"vips"`
 }

--- a/internal/server/network/ovn/schema/ovn-sb/mirror.go
+++ b/internal/server/network/ovn/schema/ovn-sb/mirror.go
@@ -13,17 +13,19 @@ type (
 var (
 	MirrorFilterFromLport MirrorFilter = "from-lport"
 	MirrorFilterToLport   MirrorFilter = "to-lport"
+	MirrorFilterBoth      MirrorFilter = "both"
 	MirrorTypeGre         MirrorType   = "gre"
 	MirrorTypeErspan      MirrorType   = "erspan"
+	MirrorTypeLocal       MirrorType   = "local"
 )
 
 // Mirror defines an object in Mirror table
 type Mirror struct {
 	UUID        string            `ovsdb:"_uuid"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
-	Filter      MirrorFilter      `ovsdb:"filter" validate:"oneof='from-lport' 'to-lport'"`
+	Filter      MirrorFilter      `ovsdb:"filter" validate:"oneof='from-lport' 'to-lport' 'both'"`
 	Index       int               `ovsdb:"index"`
 	Name        string            `ovsdb:"name"`
 	Sink        string            `ovsdb:"sink"`
-	Type        MirrorType        `ovsdb:"type" validate:"oneof='gre' 'erspan'"`
+	Type        MirrorType        `ovsdb:"type" validate:"oneof='gre' 'erspan' 'local'"`
 }

--- a/internal/server/network/ovn/schema/ovn-sb/model.go
+++ b/internal/server/network/ovn/schema/ovn-sb/model.go
@@ -52,7 +52,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Southbound",
-  "version": "20.27.0",
+  "version": "20.33.0",
   "tables": {
     "Address_Set": {
       "columns": {
@@ -78,6 +78,9 @@ var schema = `{
     },
     "BFD": {
       "columns": {
+        "chassis_name": {
+          "type": "string"
+        },
         "detect_mult": {
           "type": "integer"
         },
@@ -472,7 +475,8 @@ var schema = `{
                 [
                   "ipv6",
                   "str",
-                  "mac"
+                  "mac",
+                  "domain"
                 ]
               ]
             }
@@ -494,6 +498,18 @@ var schema = `{
           }
         },
         "external_ids": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
+        "options": {
           "type": {
             "key": {
               "type": "string"
@@ -625,6 +641,9 @@ var schema = `{
               "maxInteger": 16777215
             }
           }
+        },
+        "timestamp": {
+          "type": "integer"
         }
       },
       "indexes": [
@@ -790,6 +809,9 @@ var schema = `{
             "max": 1
           }
         },
+        "chassis_name": {
+          "type": "string"
+        },
         "datapath": {
           "type": {
             "key": {
@@ -939,6 +961,26 @@ var schema = `{
             },
             "min": 0,
             "max": "unlimited"
+          }
+        },
+        "lr_datapath_group": {
+          "type": {
+            "key": {
+              "type": "uuid",
+              "refTable": "Logical_DP_Group"
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
+        "ls_datapath_group": {
+          "type": {
+            "key": {
+              "type": "uuid",
+              "refTable": "Logical_DP_Group"
+            },
+            "min": 0,
+            "max": 1
           }
         },
         "name": {
@@ -1220,7 +1262,8 @@ var schema = `{
                 "set",
                 [
                   "from-lport",
-                  "to-lport"
+                  "to-lport",
+                  "both"
                 ]
               ]
             }
@@ -1243,7 +1286,8 @@ var schema = `{
                 "set",
                 [
                   "gre",
-                  "erspan"
+                  "erspan",
+                  "local"
                 ]
               ]
             }
@@ -1692,6 +1736,9 @@ var schema = `{
     },
     "Service_Monitor": {
       "columns": {
+        "chassis_name": {
+          "type": "string"
+        },
         "external_ids": {
           "type": {
             "key": {

--- a/internal/server/network/ovn/schema/ovn-sb/service_monitor.go
+++ b/internal/server/network/ovn/schema/ovn-sb/service_monitor.go
@@ -21,6 +21,7 @@ var (
 // ServiceMonitor defines an object in Service_Monitor table
 type ServiceMonitor struct {
 	UUID        string                  `ovsdb:"_uuid"`
+	ChassisName string                  `ovsdb:"chassis_name"`
 	ExternalIDs map[string]string       `ovsdb:"external_ids"`
 	IP          string                  `ovsdb:"ip"`
 	LogicalPort string                  `ovsdb:"logical_port"`

--- a/internal/server/network/ovs/schema/ovs/ct_zone.go
+++ b/internal/server/network/ovs/schema/ovs/ct_zone.go
@@ -9,5 +9,6 @@ const CTZoneTable = "CT_Zone"
 type CTZone struct {
 	UUID          string            `ovsdb:"_uuid"`
 	ExternalIDs   map[string]string `ovsdb:"external_ids"`
+	Limit         *int              `ovsdb:"limit" validate:"omitempty,min=0,max=4294967295"`
 	TimeoutPolicy *string           `ovsdb:"timeout_policy"`
 }

--- a/internal/server/network/ovs/schema/ovs/datapath.go
+++ b/internal/server/network/ovs/schema/ovs/datapath.go
@@ -7,9 +7,10 @@ const DatapathTable = "Datapath"
 
 // Datapath defines an object in Datapath table
 type Datapath struct {
-	UUID            string            `ovsdb:"_uuid"`
-	Capabilities    map[string]string `ovsdb:"capabilities"`
-	CTZones         map[int]string    `ovsdb:"ct_zones" validate:"dive,keys,min=0,max=65535"`
-	DatapathVersion string            `ovsdb:"datapath_version"`
-	ExternalIDs     map[string]string `ovsdb:"external_ids"`
+	UUID               string            `ovsdb:"_uuid"`
+	Capabilities       map[string]string `ovsdb:"capabilities"`
+	CTZoneDefaultLimit *int              `ovsdb:"ct_zone_default_limit" validate:"omitempty,min=0,max=4294967295"`
+	CTZones            map[int]string    `ovsdb:"ct_zones" validate:"dive,keys,min=0,max=65535"`
+	DatapathVersion    string            `ovsdb:"datapath_version"`
+	ExternalIDs        map[string]string `ovsdb:"external_ids"`
 }

--- a/internal/server/network/ovs/schema/ovs/interface.go
+++ b/internal/server/network/ovs/schema/ovs/interface.go
@@ -25,38 +25,40 @@ var (
 
 // Interface defines an object in Interface table
 type Interface struct {
-	UUID                 string                     `ovsdb:"_uuid"`
-	AdminState           *InterfaceAdminState       `ovsdb:"admin_state" validate:"omitempty,oneof='up' 'down'"`
-	BFD                  map[string]string          `ovsdb:"bfd"`
-	BFDStatus            map[string]string          `ovsdb:"bfd_status"`
-	CFMFault             *bool                      `ovsdb:"cfm_fault"`
-	CFMFaultStatus       []string                   `ovsdb:"cfm_fault_status"`
-	CFMFlapCount         *int                       `ovsdb:"cfm_flap_count"`
-	CFMHealth            *int                       `ovsdb:"cfm_health" validate:"omitempty,min=0,max=100"`
-	CFMMpid              *int                       `ovsdb:"cfm_mpid"`
-	CFMRemoteMpids       []int                      `ovsdb:"cfm_remote_mpids"`
-	CFMRemoteOpstate     *InterfaceCFMRemoteOpstate `ovsdb:"cfm_remote_opstate" validate:"omitempty,oneof='up' 'down'"`
-	Duplex               *InterfaceDuplex           `ovsdb:"duplex" validate:"omitempty,oneof='half' 'full'"`
-	Error                *string                    `ovsdb:"error"`
-	ExternalIDs          map[string]string          `ovsdb:"external_ids"`
-	Ifindex              *int                       `ovsdb:"ifindex" validate:"omitempty,min=0,max=4294967295"`
-	IngressPolicingBurst int                        `ovsdb:"ingress_policing_burst" validate:"min=0"`
-	IngressPolicingRate  int                        `ovsdb:"ingress_policing_rate" validate:"min=0"`
-	LACPCurrent          *bool                      `ovsdb:"lacp_current"`
-	LinkResets           *int                       `ovsdb:"link_resets"`
-	LinkSpeed            *int                       `ovsdb:"link_speed"`
-	LinkState            *InterfaceLinkState        `ovsdb:"link_state" validate:"omitempty,oneof='up' 'down'"`
-	LLDP                 map[string]string          `ovsdb:"lldp"`
-	MAC                  *string                    `ovsdb:"mac"`
-	MACInUse             *string                    `ovsdb:"mac_in_use"`
-	MTU                  *int                       `ovsdb:"mtu"`
-	MTURequest           *int                       `ovsdb:"mtu_request" validate:"omitempty,min=1"`
-	Name                 string                     `ovsdb:"name"`
-	Ofport               *int                       `ovsdb:"ofport"`
-	OfportRequest        *int                       `ovsdb:"ofport_request" validate:"omitempty,min=1,max=65279"`
-	Options              map[string]string          `ovsdb:"options"`
-	OtherConfig          map[string]string          `ovsdb:"other_config"`
-	Statistics           map[string]int             `ovsdb:"statistics"`
-	Status               map[string]string          `ovsdb:"status"`
-	Type                 string                     `ovsdb:"type"`
+	UUID                      string                     `ovsdb:"_uuid"`
+	AdminState                *InterfaceAdminState       `ovsdb:"admin_state" validate:"omitempty,oneof='up' 'down'"`
+	BFD                       map[string]string          `ovsdb:"bfd"`
+	BFDStatus                 map[string]string          `ovsdb:"bfd_status"`
+	CFMFault                  *bool                      `ovsdb:"cfm_fault"`
+	CFMFaultStatus            []string                   `ovsdb:"cfm_fault_status"`
+	CFMFlapCount              *int                       `ovsdb:"cfm_flap_count"`
+	CFMHealth                 *int                       `ovsdb:"cfm_health" validate:"omitempty,min=0,max=100"`
+	CFMMpid                   *int                       `ovsdb:"cfm_mpid"`
+	CFMRemoteMpids            []int                      `ovsdb:"cfm_remote_mpids"`
+	CFMRemoteOpstate          *InterfaceCFMRemoteOpstate `ovsdb:"cfm_remote_opstate" validate:"omitempty,oneof='up' 'down'"`
+	Duplex                    *InterfaceDuplex           `ovsdb:"duplex" validate:"omitempty,oneof='half' 'full'"`
+	Error                     *string                    `ovsdb:"error"`
+	ExternalIDs               map[string]string          `ovsdb:"external_ids"`
+	Ifindex                   *int                       `ovsdb:"ifindex" validate:"omitempty,min=0,max=4294967295"`
+	IngressPolicingBurst      int                        `ovsdb:"ingress_policing_burst" validate:"min=0"`
+	IngressPolicingKpktsBurst int                        `ovsdb:"ingress_policing_kpkts_burst" validate:"min=0"`
+	IngressPolicingKpktsRate  int                        `ovsdb:"ingress_policing_kpkts_rate" validate:"min=0"`
+	IngressPolicingRate       int                        `ovsdb:"ingress_policing_rate" validate:"min=0"`
+	LACPCurrent               *bool                      `ovsdb:"lacp_current"`
+	LinkResets                *int                       `ovsdb:"link_resets"`
+	LinkSpeed                 *int                       `ovsdb:"link_speed"`
+	LinkState                 *InterfaceLinkState        `ovsdb:"link_state" validate:"omitempty,oneof='up' 'down'"`
+	LLDP                      map[string]string          `ovsdb:"lldp"`
+	MAC                       *string                    `ovsdb:"mac"`
+	MACInUse                  *string                    `ovsdb:"mac_in_use"`
+	MTU                       *int                       `ovsdb:"mtu"`
+	MTURequest                *int                       `ovsdb:"mtu_request" validate:"omitempty,min=1"`
+	Name                      string                     `ovsdb:"name"`
+	Ofport                    *int                       `ovsdb:"ofport"`
+	OfportRequest             *int                       `ovsdb:"ofport_request" validate:"omitempty,min=1,max=65279"`
+	Options                   map[string]string          `ovsdb:"options"`
+	OtherConfig               map[string]string          `ovsdb:"other_config"`
+	Statistics                map[string]int             `ovsdb:"statistics"`
+	Status                    map[string]string          `ovsdb:"status"`
+	Type                      string                     `ovsdb:"type"`
 }

--- a/internal/server/network/ovs/schema/ovs/ipfix.go
+++ b/internal/server/network/ovs/schema/ovs/ipfix.go
@@ -15,5 +15,7 @@ type IPFIX struct {
 	ObsPointID         *int              `ovsdb:"obs_point_id" validate:"omitempty,min=0,max=4294967295"`
 	OtherConfig        map[string]string `ovsdb:"other_config"`
 	Sampling           *int              `ovsdb:"sampling" validate:"omitempty,min=1,max=4294967295"`
+	StatsInterval      *int              `ovsdb:"stats_interval" validate:"omitempty,min=1,max=3600"`
 	Targets            []string          `ovsdb:"targets"`
+	TemplateInterval   *int              `ovsdb:"template_interval" validate:"omitempty,min=1,max=3600"`
 }

--- a/internal/server/network/ovs/schema/ovs/model.go
+++ b/internal/server/network/ovs/schema/ovs/model.go
@@ -37,7 +37,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "Open_vSwitch",
-  "version": "8.2.0",
+  "version": "8.5.0",
   "tables": {
     "AutoAttach": {
       "columns": {
@@ -350,6 +350,17 @@ var schema = `{
             "max": "unlimited"
           }
         },
+        "limit": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 0,
+              "maxInteger": 4294967295
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
         "timeout_policy": {
           "type": {
             "key": {
@@ -558,6 +569,17 @@ var schema = `{
             },
             "min": 0,
             "max": "unlimited"
+          }
+        },
+        "ct_zone_default_limit": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 0,
+              "maxInteger": 4294967295
+            },
+            "min": 0,
+            "max": 1
           }
         },
         "ct_zones": {
@@ -796,6 +818,17 @@ var schema = `{
             "max": 1
           }
         },
+        "stats_interval": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 1,
+              "maxInteger": 3600
+            },
+            "min": 0,
+            "max": 1
+          }
+        },
         "targets": {
           "type": {
             "key": {
@@ -803,6 +836,17 @@ var schema = `{
             },
             "min": 0,
             "max": "unlimited"
+          }
+        },
+        "template_interval": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 1,
+              "maxInteger": 3600
+            },
+            "min": 0,
+            "max": 1
           }
         }
       }
@@ -848,7 +892,8 @@ var schema = `{
             },
             "min": 0,
             "max": "unlimited"
-          }
+          },
+          "ephemeral": true
         },
         "cfm_fault": {
           "type": {
@@ -978,6 +1023,22 @@ var schema = `{
           "ephemeral": true
         },
         "ingress_policing_burst": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 0
+            }
+          }
+        },
+        "ingress_policing_kpkts_burst": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 0
+            }
+          }
+        },
+        "ingress_policing_kpkts_rate": {
           "type": {
             "key": {
               "type": "integer",

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -220,25 +220,18 @@ test_network_ovn_basic() {
     incus init "${instanceImage}" u1 --project testovn -s "${poolName}"
     incus config device add u1 eth0 nic network=ovn-virtual-network name=eth0 --project testovn
 
-    # Record NAT rules count before u1 started.
-    natRulesBefore=$(ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | wc -l)
-
     incus start u1 --project testovn
 
-    # Test external IPs allocated and published using dnat.
+    # Test external IPs allocated and published using ARP proxy.
     sleep 5
     U1_EXT_IPV4="$(incus list u1 --project testovn -c4 --format=csv | cut -d' ' -f1)"
     U1_EXT_IPV6="$(incus list u1 --project testovn -c6 --format=csv | cut -d' ' -f1)"
-    ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | grep "${U1_EXT_IPV4},${U1_EXT_IPV4},dnat_and_snat"
-    ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | grep "${U1_EXT_IPV6},${U1_EXT_IPV6},dnat_and_snat"
+    ovn-nbctl --bare --format=csv --column=options find logical_switch_port | grep -F "${U1_EXT_IPV4}/32"
+    ovn-nbctl --bare --format=csv --column=options find logical_switch_port | grep -F "${U1_EXT_IPV6}/128"
     incus stop -f u1 --project testovn
 
-    # Check NAT rules got cleaned up.
-    natRulesAfter=$(ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | wc -l)
-    if [ "$natRulesBefore" -ne "$natRulesAfter" ]; then
-        echo "NAT rules left over. Started with ${natRulesBefore} now have ${natRulesAfter}"
-        false
-    fi
+    # Check ARP proxy entries got cleaned up.
+    ovn-nbctl --bare --format=csv --column=options find logical_switch_port | grep -cF arp_proxy | grep -xF 0
 
     # Test external IPs routed to OVN NIC.
     incus network set ovn-virtual-network --project testovn \
@@ -275,14 +268,9 @@ test_network_ovn_basic() {
     incus network unset dummy ipv4.routes.anycast --project default
     incus network unset dummy ipv6.routes.anycast --project default
 
-    # Check DNAT_AND_SNAT rules get added when starting instance port with external routes.
+    # Check ARP proxy entries get added when starting instance port with external routes.
     incus start u1 --project testovn
-    ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat
-    ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | grep "198.51.100.0,198.51.100.0,dnat_and_snat"
-    ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | grep "198.51.100.63,198.51.100.63,dnat_and_snat"
-    ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | grep "2001:db8:1:2::,2001:db8:1:2::,dnat_and_snat"
-    ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | grep "2001:db8:1:2::3f,2001:db8:1:2::3f,dnat_and_snat"
-    ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | wc -l | grep -xF 132
+    ovn-nbctl --bare --format=csv --column=options find logical_switch_port | grep -F "arp_proxy=198.51.100.0/26 2001:db8:1:2::/122"
 
     # Add internal static route to instance NIC.
     incus config device set u1 eth0 ipv4.routes=203.0.113.1/32 ipv6.routes=2001:db8:2:2::1/128 --project testovn
@@ -309,44 +297,33 @@ test_network_ovn_basic() {
     incus network unset ovn-virtual-network --project testovn ipv6.dhcp
     incus start u1 --project testovn
 
-    # Check DNAT_AND_SNAT NAT rules get removed when switching to routed ingress mode.
-    natRulesBeforeRouted=$(ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | wc -l)
+    # Check ARP proxy entries get removed when switching to routed ingress mode.
     incus network set dummy ovn.ingress_mode=routed
-    natRulesAfterRouted=$(ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | wc -l)
-    if [ "$natRulesAfterRouted" -ne "4" ]; then
-        echo "NAT rules left over after switching to routed ingress mode. Expecting 4. Started with ${natRulesBeforeRouted} now have ${natRulesAfterRouted}"
-        false
-    fi
+    ovn-nbctl --bare --format=csv --column=options find logical_switch_port | grep -cF arp_proxy | grep -xF 0
 
-    # Check DNAT_AND_SNAT rules are re-added when switching to l2proxy ingress mode.
+    # Check ARP proxy entries are re-added when switching to l2proxy ingress mode.
     incus network unset dummy ovn.ingress_mode
-    natRulesAfterL2proxy=$(ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | wc -l)
-    if [ "$natRulesBeforeRouted" -ne "$natRulesAfterL2proxy" ]; then
-        echo "NAT rules not restored after switching to l2proxy ingress mode. Started with ${natRulesBeforeRouted} now have ${natRulesAfterL2proxy}"
-        false
-    fi
+    ovn-nbctl --bare --format=csv --column=options find logical_switch_port | grep -F "arp_proxy=198.51.100.0/26 2001:db8:1:2::/122"
 
     incus stop -f u1 --project testovn
 
-    # Check NAT rules got cleaned up.
-    natRulesAfter=$(ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | wc -l)
-    if [ "$natRulesBefore" -ne "$natRulesAfter" ]; then
-        echo "NAT rules left over. Started with ${natRulesBefore} now have ${natRulesAfter}"
-        false
-    fi
+    # Check ARP proxy entries got cleaned up.
+    ovn-nbctl --bare --format=csv --column=options find logical_switch_port | grep -cF arp_proxy | grep -xF 0
 
-    # Check routed ingress mode allows larger subnets and doesn't add DNAT rules.
+    # Check routed ingress mode allows larger subnets and doesn't add ARP proxy entries.
     incus network set dummy ovn.ingress_mode=routed
     incus config device set u1 eth0 ipv4.routes.external=198.51.100.0/24 --project testovn
     incus config device set u1 eth0 ipv6.routes.external=2001:db8:1:2::/64 --project testovn
     incus start u1 --project testovn
 
-    # Check no NAT rules got added.
+    # Check no NAT rules or ARP proxy entries got added.
     natRulesAfter=$(ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | wc -l)
     if [ "$natRulesBefore" -ne "$natRulesAfter" ]; then
         echo "NAT rules got added in routed ingress mode. Started with ${natRulesBefore} now have ${natRulesAfter}"
         false
     fi
+
+    ovn-nbctl --bare --format=csv --column=options find logical_switch_port | grep -cF arp_proxy | grep -xF 0
 
     incus delete -f u1 --project testovn
     incus network unset dummy ovn.ingress_mode


### PR DESCRIPTION
This makes use of OVN's native ARP proxy feature to replace the rather hackish and buggy l2proxy mechanism. Bump minimum OVS/OVN to get a supported version.