### PR TITLE
Fix event ordering

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -3,10 +3,14 @@ package incus
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 
 	"github.com/lxc/incus/v7/shared/api"
 )
+
+// eventQueueSize is how many events may be pending handling before an ordered listener is dropped.
+const eventQueueSize = 1000
 
 // The EventListener struct is used to interact with an Incus event stream.
 type EventListener struct {
@@ -19,12 +23,84 @@ type EventListener struct {
 	projectName string
 	targets     []*EventTarget
 	targetsLock sync.Mutex
+
+	// queue is only set when ordered delivery was requested.
+	queue chan api.Event
 }
 
 // The EventTarget struct is returned to the caller of AddHandler and used in RemoveHandler.
 type EventTarget struct {
 	function func(api.Event)
 	types    []string
+}
+
+// SetOrdered makes the listener call its handlers one event at a time and in order (must be called before AddHandler).
+func (e *EventListener) SetOrdered() {
+	e.targetsLock.Lock()
+	defer e.targetsLock.Unlock()
+
+	if e.queue != nil {
+		return
+	}
+
+	e.queue = make(chan api.Event, eventQueueSize)
+
+	go e.dispatch()
+}
+
+// dispatch delivers queued events to the handlers, one event at a time.
+func (e *EventListener) dispatch() {
+	for {
+		var event api.Event
+
+		select {
+		case <-e.ctx.Done():
+			return
+		case event = <-e.queue:
+		}
+
+		e.targetsLock.Lock()
+		targets := slices.Clone(e.targets)
+		e.targetsLock.Unlock()
+
+		for _, target := range targets {
+			if target.types != nil && !slices.Contains(target.types, event.Type) {
+				continue
+			}
+
+			target.function(event)
+		}
+	}
+}
+
+// send passes an event on to the handlers of this listener.
+func (e *EventListener) send(event api.Event) {
+	e.targetsLock.Lock()
+	defer e.targetsLock.Unlock()
+
+	if e.ctx.Err() != nil {
+		return
+	}
+
+	if e.queue == nil {
+		for _, target := range e.targets {
+			if target.types != nil && !slices.Contains(target.types, event.Type) {
+				continue
+			}
+
+			go target.function(event)
+		}
+
+		return
+	}
+
+	select {
+	case e.queue <- event:
+	default:
+		// Dropping events would leave the handler with a silently incomplete view.
+		e.err = errors.New("Event handlers are too far behind")
+		e.ctxCancel()
+	}
 }
 
 // AddHandler adds a function to be called whenever an event is received.
@@ -78,10 +154,6 @@ func (e *EventListener) Disconnect() {
 	e.r.eventListenersLock.Lock()
 	defer e.r.eventListenersLock.Unlock()
 
-	if e.ctx.Err() != nil {
-		return
-	}
-
 	// Locate and remove it from the global list
 	for i, listener := range e.r.eventListeners[e.projectName] {
 		if listener == e {
@@ -90,6 +162,10 @@ func (e *EventListener) Disconnect() {
 			e.r.eventListeners[e.projectName] = e.r.eventListeners[e.projectName][:len(e.r.eventListeners[e.projectName])-1]
 			break
 		}
+	}
+
+	if e.ctx.Err() != nil {
+		return
 	}
 
 	// Turn off the handler

--- a/client/incus_events.go
+++ b/client/incus_events.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/url"
-	"slices"
 	"strings"
 	"time"
 
@@ -158,16 +157,7 @@ func (r *ProtocolIncus) getEvents(allProjects bool, eventTypes []string) (*Event
 			// Send the message to all handlers
 			r.eventListenersLock.Lock()
 			for _, listener := range r.eventListeners[listener.projectName] {
-				listener.targetsLock.Lock()
-				for _, target := range listener.targets {
-					if target.types != nil && !slices.Contains(target.types, event.Type) {
-						continue
-					}
-
-					go target.function(event)
-				}
-
-				listener.targetsLock.Unlock()
+				listener.send(event)
 			}
 
 			r.eventListenersLock.Unlock()

--- a/cmd/incusd/api_project.go
+++ b/cmd/incusd/api_project.go
@@ -624,10 +624,15 @@ func projectPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
+	err = projectChange(r.Context(), s, project, req)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	requestor := request.CreateRequestor(r)
 	s.Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, requestor, nil))
 
-	return projectChange(r.Context(), s, project, req)
+	return response.EmptySyncResponse
 }
 
 // swagger:operation PATCH /1.0/projects/{name} projects project_patch
@@ -749,14 +754,19 @@ func projectPatch(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
+	err = projectChange(r.Context(), s, project, req)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	requestor := request.CreateRequestor(r)
 	s.Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, requestor, nil))
 
-	return projectChange(r.Context(), s, project, req)
+	return response.EmptySyncResponse
 }
 
 // Common logic between PUT and PATCH.
-func projectChange(ctx context.Context, s *state.State, project *api.Project, req api.ProjectPut) response.Response {
+func projectChange(ctx context.Context, s *state.State, project *api.Project, req api.ProjectPut) error {
 	// Make a list of config keys that have changed.
 	configChanged := []string{}
 	for key := range project.Config {
@@ -784,7 +794,7 @@ func projectChange(ctx context.Context, s *state.State, project *api.Project, re
 	// Quick checks.
 	if len(featuresChanged) > 0 {
 		if project.Name == api.ProjectDefaultName {
-			return response.BadRequest(errors.New("You can't change the features of the default project"))
+			return api.StatusErrorf(http.StatusBadRequest, "You can't change the features of the default project")
 		}
 
 		// Consider the project empty if it is only used by the default profile.
@@ -796,13 +806,13 @@ func projectChange(ctx context.Context, s *state.State, project *api.Project, re
 				// If feature is currently enabled, and it is being changed in the request, it
 				// must be being disabled. So prevent it on non-empty projects.
 				if util.IsTrue(project.Config[featureChanged]) {
-					return response.BadRequest(fmt.Errorf("Project feature %q cannot be disabled on non-empty projects", featureChanged))
+					return api.StatusErrorf(http.StatusBadRequest, "Project feature %q cannot be disabled on non-empty projects", featureChanged)
 				}
 
 				// If feature is currently disabled, and it is being changed in the request, it
 				// must be being enabled. So check if feature can be enabled on non-empty projects.
 				if util.IsFalse(project.Config[featureChanged]) && !cluster.ProjectFeatures[featureChanged].CanEnableNonEmpty {
-					return response.BadRequest(fmt.Errorf("Project feature %q cannot be enabled on non-empty projects", featureChanged))
+					return api.StatusErrorf(http.StatusBadRequest, "Project feature %q cannot be enabled on non-empty projects", featureChanged)
 				}
 			}
 		}
@@ -811,7 +821,7 @@ func projectChange(ctx context.Context, s *state.State, project *api.Project, re
 	// Validate the configuration.
 	err := projectValidateConfig(s, req.Config)
 	if err != nil {
-		return response.BadRequest(err)
+		return api.StatusErrorf(http.StatusBadRequest, "%v", err)
 	}
 
 	// Update the database entry.
@@ -851,10 +861,10 @@ func projectChange(ctx context.Context, s *state.State, project *api.Project, re
 		return nil
 	})
 	if err != nil {
-		return response.SmartError(err)
+		return err
 	}
 
-	return response.EmptySyncResponse
+	return nil
 }
 
 // swagger:operation POST /1.0/projects/{name} projects project_post

--- a/doc/events.md
+++ b/doc/events.md
@@ -13,6 +13,18 @@ Incus Currently supports three event types.
 - `operation`: Shows all ongoing operations from creation to completion (including updates to their state and progress metadata).
 - `lifecycle`: Shows an audit trail for specific actions occurring over Incus.
 
+## Event ordering
+
+Events are delivered to each listener in the order that Incus generated them.
+
+A listener that cannot keep up with the stream is disconnected rather than having events silently skipped. After
+reconnecting, anything being tracked from the event stream should be re-fetched, as the events that occurred while
+disconnected are not resent.
+
+When using the Go client, handlers registered through `AddHandler` are called concurrently and may therefore observe
+events out of order. Calling `SetOrdered` on the listener before adding any handler makes them run one event at a time
+and in order instead.
+
 ## Event structure
 
 ### Example

--- a/internal/server/events/common.go
+++ b/internal/server/events/common.go
@@ -2,12 +2,16 @@ package events
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/lxc/incus/v7/shared/api"
 	"github.com/lxc/incus/v7/shared/cancel"
 	"github.com/lxc/incus/v7/shared/logger"
 )
+
+// eventQueueSize is how many events may be pending delivery to a listener before it gets dropped.
+const eventQueueSize = 1000
 
 // EventHandler called when the connection receives an event from the client.
 type EventHandler func(event api.Event)
@@ -28,13 +32,42 @@ type listenerCommon struct {
 	id           string
 	lock         sync.Mutex
 	recvFunc     EventHandler
+	writeQueue   chan api.Event
 }
 
 func (e *listenerCommon) start() {
 	logger.Debug("Event listener server handler started", logger.Ctx{"id": e.id, "local": e.LocalAddr(), "remote": e.RemoteAddr()})
 
+	go e.writer()
+
 	e.Reader(e.done.Context, e.recvFunc)
 	e.Close()
+}
+
+// enqueue queues an event for delivery, failing if the listener is too far behind.
+func (e *listenerCommon) enqueue(event api.Event) error {
+	select {
+	case e.writeQueue <- event:
+		return nil
+	default:
+		return errors.New("Event queue is full")
+	}
+}
+
+// writer delivers queued events one at a time so listeners see them in the order they were generated.
+func (e *listenerCommon) writer() {
+	for {
+		select {
+		case <-e.done.Done():
+			return
+		case event := <-e.writeQueue:
+			err := e.WriteJSON(event)
+			if err != nil {
+				e.Close()
+				return
+			}
+		}
+	}
 }
 
 // IsClosed returns true if the listener is closed.

--- a/internal/server/events/dev_incus_events.go
+++ b/internal/server/events/dev_incus_events.go
@@ -41,6 +41,7 @@ func (s *DevIncusServer) AddListener(instanceID int, connection EventListenerCon
 			messageTypes:            messageTypes,
 			done:                    cancel.New(context.Background()),
 			id:                      uuid.New().String(),
+			writeQueue:              make(chan api.Event, eventQueueSize),
 		},
 		instanceID: instanceID,
 	}
@@ -79,6 +80,12 @@ func (s *DevIncusServer) broadcast(instanceID int, event api.Event) error {
 	s.lock.Lock()
 	listeners := s.listeners
 	for _, listener := range listeners {
+		// Drop listeners that are already gone.
+		if listener.IsClosed() {
+			delete(s.listeners, listener.id)
+			continue
+		}
+
 		if !slices.Contains(listener.messageTypes, event.Type) {
 			continue
 		}
@@ -87,27 +94,12 @@ func (s *DevIncusServer) broadcast(instanceID int, event api.Event) error {
 			continue
 		}
 
-		go func(listener *DevIncusListener, event api.Event) {
-			// Check that the listener still exists
-			if listener == nil {
-				return
-			}
-
-			// Make sure we're not done already
-			if listener.IsClosed() {
-				return
-			}
-
-			err := listener.WriteJSON(event)
-			if err != nil {
-				// Remove the listener from the list
-				s.lock.Lock()
-				delete(s.listeners, listener.id)
-				s.lock.Unlock()
-
-				listener.Close()
-			}
-		}(listener, event)
+		// Queue the event so a slow listener doesn't hold up the others or lose ordering.
+		err := listener.enqueue(event)
+		if err != nil {
+			delete(s.listeners, listener.id)
+			listener.Close()
+		}
 	}
 
 	s.lock.Unlock()

--- a/internal/server/events/events.go
+++ b/internal/server/events/events.go
@@ -85,6 +85,7 @@ func (s *Server) AddListener(projectName string, allProjects bool, projectPermis
 			done:                    cancel.New(context.Background()),
 			id:                      uuid.New().String(),
 			recvFunc:                recvFunc,
+			writeQueue:              make(chan api.Event, eventQueueSize),
 		},
 
 		allProjects:           allProjects,
@@ -173,6 +174,12 @@ func (s *Server) broadcast(event api.Event, eventSource EventSource) error {
 
 	listeners := s.listeners
 	for _, listener := range listeners {
+		// Drop listeners that are already gone.
+		if listener.IsClosed() {
+			delete(s.listeners, listener.id)
+			continue
+		}
+
 		// If the event is project specific, check if the listener is requesting events from that project.
 		if event.Project != "" && !listener.allProjects && event.Project != listener.projectName {
 			continue
@@ -196,31 +203,12 @@ func (s *Server) broadcast(event api.Event, eventSource EventSource) error {
 			continue
 		}
 
-		go func(listener *Listener, event api.Event) {
-			// Check that the listener still exists
-			if listener == nil {
-				return
-			}
-
-			// Make sure we're not done already
-			if listener.IsClosed() {
-				// Remove the listener from the list
-				s.lock.Lock()
-				delete(s.listeners, listener.id)
-				s.lock.Unlock()
-				return
-			}
-
-			err := listener.WriteJSON(event)
-			if err != nil {
-				// Remove the listener from the list
-				s.lock.Lock()
-				delete(s.listeners, listener.id)
-				s.lock.Unlock()
-
-				listener.Close()
-			}
-		}(listener, event)
+		// Queue the event so a slow listener doesn't hold up the others or lose ordering.
+		err := listener.enqueue(event)
+		if err != nil {
+			delete(s.listeners, listener.id)
+			listener.Close()
+		}
 	}
 
 	s.lock.Unlock()


### PR DESCRIPTION
Every event was written to each listener in its own go routine, so events
raced each other and arrived in whatever order the scheduler picked.
Anything reconstructing state from the event stream ends up wrong — the
symptom that found this was `project-updated` arriving before
`project-created`.

The Go client did the same thing when calling handlers, so ordering there
is opt-in via `SetOrdered()` rather than changing behavior under existing
consumers.

Also fixes `project-updated` being sent before `projectChange` applied the
update, which meant it fired even when the update was rejected.
