### PR TITLE
instance: Derive process start time from proc stat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/pires/go-proxyproto v0.15.0
 	github.com/pkg/sftp v1.13.11
 	github.com/pkg/xattr v0.4.12
+	github.com/prometheus/procfs v0.21.1
 	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
@@ -153,7 +154,6 @@ require (
 	github.com/prometheus/client_golang v1.24.1 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
-	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/rootless-containers/proto/go-proto v0.0.0-20260207013450-f6ee952d53d9 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -15,10 +15,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/procfs"
 
 	internalInstance "github.com/lxc/incus/v7/internal/instance"
 	"github.com/lxc/incus/v7/internal/server/backup"
@@ -1678,17 +1678,23 @@ func (d *common) processStartedAt(pid int) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("Invalid PID %d", pid)
 	}
 
-	file, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	proc, err := procfs.NewProc(pid)
 	if err != nil {
 		return time.Time{}, err
 	}
 
-	linuxInfo, ok := file.Sys().(*syscall.Stat_t)
-	if !ok {
-		return time.Time{}, errors.New("Bad stat type")
+	stat, err := proc.Stat()
+	if err != nil {
+		return time.Time{}, err
 	}
 
-	return time.Unix(int64(linuxInfo.Ctim.Sec), int64(linuxInfo.Ctim.Nsec)), nil
+	startedAt, err := stat.StartTime()
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	seconds, fraction := math.Modf(startedAt)
+	return time.Unix(int64(seconds), int64(fraction*float64(time.Second))), nil
 }
 
 // ETag returns the instance configuration ETag data for pre-condition validation.


### PR DESCRIPTION
## Summary

Use the process start ticks from /proc/<pid>/stat instead of the procfs directory inode ctime for instance started_at and incus_boot_time_seconds.

The procfs inode can be re-instantiated while the process remains alive. After an Incus daemon replacement and LXC re-attachment, this caused started_at to move forward even though the container init PID was unchanged.

## Validation

Reproduced with an Incus daemon running under Podman while a system container remained alive:

- init PID remained 4019322`n- started_at changed from 2026-08-10T16:24:09Z to 2026-08-10T16:24:37Z after daemon replacement
- root RBD mount and both network interfaces remained active

Prometheus procfs is already an indirect Incus dependency and parses process names in /proc/<pid>/stat safely.