### PR TITLE
incusd: Fix authorization for inherited storage volumes

### DIFF
--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -366,7 +366,7 @@ func allowPermission(objectType auth.ObjectType, entitlement auth.Entitlement, m
 			}
 
 			if objectType == auth.ObjectTypeStorageVolume {
-				dbVolType, err := storagePools.VolumeTypeNameToDBType(muxVars[1])
+				dbVolType, err := storagePools.VolumeTypeNameToDBType(r.PathValue(muxVars[1]))
 				if err != nil {
 					return projectName
 				}

--- a/test/suites/openfga.sh
+++ b/test/suites/openfga.sh
@@ -78,6 +78,7 @@ test_openfga() {
     user_is_not_server_operator
     user_is_not_project_admin
     user_is_project_operator
+    user_can_view_inherited_storage_volume
 
     # Create an instance for testing the "instance -> user" relation.
     incus launch testimage user-foo
@@ -201,6 +202,26 @@ user_is_project_operator() {
     incus launch testimage oidc-openfga:operator-foo
     INC_LOCAL='' incus_remote exec oidc-openfga:operator-foo -- echo "bar"
     incus delete oidc-openfga:operator-foo --force
+}
+
+user_can_view_inherited_storage_volume() {
+    project_name="openfga-inherited-volume"
+    pool_name="$(incus storage list oidc-openfga: -f csv | cut -d, -f1)"
+    volume_name="openfga-inherited-volume"
+
+    incus project create "${project_name}" -c features.storage.volumes=false
+    fga tuple write --store-id "${OPENFGA_STORE_ID}" user:user1 operator "project:${project_name}"
+    incus storage volume create "oidc-openfga:${pool_name}" "${volume_name}"
+
+    fga tuple delete --store-id "${OPENFGA_STORE_ID}" user:user1 operator project:default
+    fga tuple write --store-id "${OPENFGA_STORE_ID}" user:user1 viewer project:default
+    incus storage volume show "oidc-openfga:${pool_name}" "${volume_name}" --project "${project_name}"
+    fga tuple delete --store-id "${OPENFGA_STORE_ID}" user:user1 viewer project:default
+    fga tuple write --store-id "${OPENFGA_STORE_ID}" user:user1 operator project:default
+
+    incus storage volume delete "oidc-openfga:${pool_name}" "${volume_name}"
+    fga tuple delete --store-id "${OPENFGA_STORE_ID}" user:user1 operator "project:${project_name}"
+    incus project delete "${project_name}"
 }
 
 user_is_not_project_operator() {


### PR DESCRIPTION
This fixes authorization for inherited custom storage volumes in projects with `features.storage.volumes=false`.

## Expected behavior

If a project has `features.storage.volumes=false`, custom storage volumes are shared from the default project. Authorization should therefore use the effective storage project.

For example, a user who is an operator of their own project and a viewer of the default project should be able to view a custom volume inherited from the default project.

## Actual behavior

The authorization path attempted to resolve the effective storage project, but passed the route variable name `type` instead of its value from the request path.

The volume type conversion therefore failed and authorization fell back to the requested project rather than the effective storage project.

As a result, access to inherited custom volumes could be denied even when the user had the required permissions on both projects.

## Changes

- `cmd/incusd/daemon.go`
  - Read the storage volume type from the request path.
  - Resolve authorization against the effective storage project.

- `test/suites/openfga.sh`
  - Add OpenFGA coverage for viewing an inherited custom storage volume.
  - Cover a user who is an operator of the requesting project and a viewer of the effective storage project.