### PR TITLE
incusd/firewall: Restrict wildcard proxy NAT to local addresses

### DIFF
--- a/internal/server/firewall/drivers/drivers_nftables.go
+++ b/internal/server/firewall/drivers/drivers_nftables.go
@@ -486,6 +486,14 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 		listenAddressStr = forward.ListenAddress.String()
 	}
 
+	// Only used for wildcard listen addresses, where no address match constrains the family.
+	nfProto := "ipv4"
+	loopbackNet := "127.0.0.0/8"
+	if ipFamily == "ip6" {
+		nfProto = "ipv6"
+		loopbackNet = "::1/128"
+	}
+
 	targetAddressStr := forward.TargetAddress.String()
 
 	// Generate slices of rules to add.
@@ -517,6 +525,8 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 
 		dnatRules = append(dnatRules, map[string]any{
 			"ipFamily":      ipFamily,
+			"nfProto":       nfProto,
+			"loopbackNet":   loopbackNet,
 			"protocol":      forward.Protocol,
 			"listenAddress": listenAddressStr,
 			"listenPorts":   portRangeStr(listenPortRange, "-"),

--- a/internal/server/firewall/drivers/drivers_nftables_templates.go
+++ b/internal/server/firewall/drivers/drivers_nftables_templates.go
@@ -103,14 +103,14 @@ table {{.family}} {{.namespace}} {
 	chain {{.chainPrefix}}prert{{.chainSeparator}}{{.label}} {
 		type nat hook prerouting priority -100; policy accept;
 		{{ range .dnatRules }}
-		{{ if .listenAddress }}{{.ipFamily}} daddr {{.listenAddress}} {{ end }}{{ if .protocol }}{{.protocol}} dport {{.listenPorts}}{{ end }} dnat {{.ipFamily}} to {{.targetDest}}
+		{{ if .listenAddress }}{{.ipFamily}} daddr {{.listenAddress}} {{ else }}meta nfproto {{.nfProto}} fib daddr type local {{ end }}{{ if .protocol }}{{.protocol}} dport {{.listenPorts}}{{ end }} dnat {{.ipFamily}} to {{.targetDest}}
 		{{ end }}
 	}
 
 	chain {{.chainPrefix}}out{{.chainSeparator}}{{.label}} {
 		type nat hook output priority -100; policy accept;
 		{{ range .dnatRules }}
-		{{ if .listenAddress }}{{.ipFamily}} daddr {{.listenAddress}} {{ end }}{{ if .protocol }}{{.protocol}} dport {{.listenPorts}}{{ end }} dnat {{.ipFamily}} to {{.targetDest}}
+		{{ if .listenAddress }}{{.ipFamily}} daddr {{.listenAddress}} {{ else }}meta nfproto {{.nfProto}} {{.ipFamily}} daddr != {{.loopbackNet}} fib daddr type local {{ end }}{{ if .protocol }}{{.protocol}} dport {{.listenPorts}}{{ end }} dnat {{.ipFamily}} to {{.targetDest}}
 		{{ end }}
 	}
 

--- a/test/suites/container_devices_proxy.sh
+++ b/test/suites/container_devices_proxy.sh
@@ -208,10 +208,19 @@ container_devices_proxy_tcp() {
 
     incus config device remove nattest validNAT
 
-    # Wildcard listen address (no destination address match in the generated rules).
+    # Wildcard listen address (only host-local destination addresses are matched).
     incus config device add nattest validNAT proxy listen="tcp:0.0.0.0:1234" connect="tcp:${v4_addr}:1234" bind=host nat=true
-    [ "$(nft -nn list chain inet incus prert.nattest.validNAT | grep -c "tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
-    [ "$(nft -nn list chain inet incus prert.nattest.validNAT | grep -c "daddr")" -eq 0 ]
+    [ "$(nft -nn list chain inet incus prert.nattest.validNAT | grep -c "meta nfproto .* fib daddr type .* tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+    [ "$(nft -nn list chain inet incus out.nattest.validNAT | grep -c "ip daddr != 127.0.0.0/8 fib daddr type .* tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+
+    incus config device remove nattest validNAT
+    ! nft -nn list chain inet incus prert.nattest.validNAT || false
+    ! nft -nn list chain inet incus out.nattest.validNAT || false
+
+    # Wildcard IPv6 listen address.
+    incus config device add nattest validNAT proxy listen="tcp:[::]:1234" connect="tcp:[${v6_addr}]:1234" bind=host nat=true
+    [ "$(nft -nn list chain inet incus prert.nattest.validNAT | grep -c "meta nfproto .* fib daddr type .* tcp dport 1234 dnat ip6 to \[${v6_addr}\]:1234")" -eq 1 ]
+    [ "$(nft -nn list chain inet incus out.nattest.validNAT | grep -c "ip6 daddr != ::1.*fib daddr type .* tcp dport 1234 dnat ip6 to \[${v6_addr}\]:1234")" -eq 1 ]
 
     incus config device remove nattest validNAT
     ! nft -nn list chain inet incus prert.nattest.validNAT || false


### PR DESCRIPTION
A proxy device with a wildcard listen address (0.0.0.0 or ::) generated DNAT rules with no destination match at all, in both the nat prerouting and nat output hooks, so every packet with a matching destination port was redirected to the instance regardless of where it was headed. With br_netfilter loaded, which proxy NAT requires, that included traffic between containers on the same bridge and outbound traffic from both instances and the host.

Match "fib daddr type local" instead, so a wildcard listen address means any of the host's own addresses rather than any address at all. The output hook also excludes the loopback prefix; prerouting needs no such exclusion, as the output hook initializes the conntrack DST binding first for loopback flows. Add a "meta nfproto" match too, as without a destination address nothing constrained the rules to the DNAT target's address family.

Fixes: dcf2c22dd ("incusd/firewall: Allow wildcard listen address in proxy NAT")