### PR TITLE
lxc: Make incremental memory migration opt-in

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -6015,6 +6015,13 @@ func getCRIULogErrors(imagesDir string, method string) (string, error) {
 
 // Check if CRIU supports pre-dumping and number of pre-dump iterations.
 func (d *lxc) migrationSendCheckForPreDumpSupport() (bool, int) {
+	config := d.ExpandedConfig()
+
+	// Incremental memory migration is opt-in, matching the documented default and avoiding an unnecessary CRIU probe.
+	if !util.IsTrue(config["migration.incremental.memory"]) {
+		return false, 0
+	}
+
 	// Check if this architecture/kernel/criu combination supports pre-copy dirty memory tracking feature.
 	_, err := subprocess.RunCommand("criu", "check", "--feature", "mem_dirty_track")
 	if err != nil {
@@ -6023,23 +6030,12 @@ func (d *lxc) migrationSendCheckForPreDumpSupport() (bool, int) {
 		return false, 0
 	}
 
-	// CRIU says it can actually do pre-dump. Let's set it to true
-	// unless the user wants something else.
-	usePreDumps := true
-
-	// What does the configuration say about pre-copy
-	tmp := d.ExpandedConfig()["migration.incremental.memory"]
-
-	if tmp != "" {
-		usePreDumps = util.IsTrue(tmp)
-	}
-
 	var maxIterations int
 
 	// migration.incremental.memory.iterations is the value after which the
 	// container will be definitely migrated, even if the remaining number
 	// of memory pages is below the defined threshold.
-	tmp = d.ExpandedConfig()["migration.incremental.memory.iterations"]
+	tmp := config["migration.incremental.memory.iterations"]
 	if tmp != "" {
 		maxIterations, _ = strconv.Atoi(tmp)
 	} else {
@@ -6057,7 +6053,7 @@ func (d *lxc) migrationSendCheckForPreDumpSupport() (bool, int) {
 
 	logger.Debugf("Using maximal %d iterations for pre-dumping", maxIterations)
 
-	return usePreDumps, maxIterations
+	return true, maxIterations
 }
 
 func (d *lxc) migrationSendWriteActionScript(directory string, operation string, secret string, execPath string) error {


### PR DESCRIPTION
The `migration.incremental.memory` configuration is documented with a default of false, but the LXC migration sender currently enables pre-dumps when the key is unset. It also probes the CRIU dirty-memory feature even when the setting is explicitly false.

Treat incremental memory migration as opt-in and only probe CRIU when the expanded configuration is explicitly true. Preserve the existing default iteration count and upper bound.

The driver package tests and `go vet` pass on Linux.
