### PR TITLE
storage/ceph: Ignore detached devices during RBD sysfs scan

### DIFF
--- a/internal/server/storage/drivers/driver_ceph_utils.go
+++ b/internal/server/storage/drivers/driver_ceph_utils.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
 
 	"github.com/lxc/incus/v7/internal/linux"
 	"github.com/lxc/incus/v7/internal/server/db"
@@ -1213,8 +1214,9 @@ func (d *ceph) getRBDMappedDevPath(vol Volume, mapIfMissing bool) (bool, string,
 		// Get the pool for the RBD device.
 		devPoolName, err := os.ReadFile(fmt.Sprintf("/sys/devices/rbd/%s/pool", fName))
 		if err != nil {
-			// Skip if no pool file.
-			if errors.Is(err, fs.ErrNotExist) {
+			// A concurrent unmap can remove the device, or make its attributes return ENODEV,
+			// between the directory listing and this read.
+			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, unix.ENODEV) {
 				continue
 			}
 
@@ -1229,8 +1231,7 @@ func (d *ceph) getRBDMappedDevPath(vol Volume, mapIfMissing bool) (bool, string,
 		// Get the volume name for the RBD device.
 		devName, err := os.ReadFile(fmt.Sprintf("/sys/devices/rbd/%s/name", fName))
 		if err != nil {
-			// Skip if no name file.
-			if errors.Is(err, fs.ErrNotExist) {
+			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, unix.ENODEV) {
 				continue
 			}
 
@@ -1249,8 +1250,14 @@ func (d *ceph) getRBDMappedDevPath(vol Volume, mapIfMissing bool) (bool, string,
 
 		// Get the snapshot name for the RBD device (if exists).
 		devSnap, err := os.ReadFile(fmt.Sprintf("/sys/devices/rbd/%s/current_snap", fName))
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return false, "", err
+		if err != nil {
+			if errors.Is(err, unix.ENODEV) {
+				continue
+			}
+
+			if !errors.Is(err, fs.ErrNotExist) {
+				return false, "", err
+			}
 		}
 
 		devSnapName := strings.TrimSpace(string(devSnap))


### PR DESCRIPTION
An RBD device can be unmapped after `/sys/devices/rbd` is listed but before its attributes are read. In addition to ENOENT, sysfs returns ENODEV for attributes of a half-removed device.

Treat ENODEV as a vanished scan entry for the pool, name and snapshot attributes, while continuing to return permission and other I/O errors. This prevents an unrelated concurrent unmap from aborting mapped-device discovery.

The storage drivers package tests and `go vet` pass on Linux.
