### PR TITLE
lxc: Start live migration action operation before pre-dumps

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -6446,6 +6446,12 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 					return err
 				}
 
+				err = actionScriptOp.Start()
+				if err != nil {
+					_ = os.RemoveAll(checkpointDir)
+					return err
+				}
+
 				err = d.migrationSendWriteActionScript(checkpointDir, actionScriptOp.URL(), actionScriptOpSecret, d.state.OS.ExecPath)
 				if err != nil {
 					_ = os.RemoveAll(checkpointDir)
@@ -6490,12 +6496,6 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 					}
 				} else {
 					d.logger.Debug("The other side does not support pre-copy")
-				}
-
-				err = actionScriptOp.Start()
-				if err != nil {
-					_ = os.RemoveAll(checkpointDir)
-					return err
 				}
 
 				go func() {


### PR DESCRIPTION
The live migration action-script operation is created before the script and CRIU pre-dumps are prepared, but is only started after those steps. A script-write or pre-dump failure therefore returns with the operation permanently Pending.

Start the operation immediately after creation. Its handler already waits for the buffered restore result, and the existing migration error path supplies false, so later setup failures now complete the operation instead of leaking it.

The LXC drivers package tests and `go vet` pass on Linux.
