### PR TITLE
lxc: Normalize received CRIU state ownership

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -7213,6 +7213,22 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 			d.logger.Debug("Done receiving final dump rsync")
 
+			// CRIU writes most images as the outer daemon's root user, but some namespace-owned
+			// images retain the source container's shifted IDs. Normalize only those shifted
+			// owners before migrate() applies the target container's idmap to the tree.
+			if len(srcIdmap.Entries) > 0 {
+				err = srcIdmap.UnshiftPath(imagesDir, func(_ string, _ string, _ os.FileInfo, newUID int64, newGID int64) error {
+					if newUID < 0 && newGID < 0 {
+						return errors.New("CRIU state owner is not source-idmapped")
+					}
+
+					return nil
+				})
+				if err != nil {
+					return fmt.Errorf("Failed normalizing CRIU state ownership: %w", err)
+				}
+			}
+
 			// Wait until filesystem transfer is done before starting final state sync and restore.
 			<-fsTransferDone
 


### PR DESCRIPTION
CRIU migration state can contain mixed ownership: most images are created by the outer daemon as root, while namespace-owned files retain the source container's shifted IDs. Applying the target idmap directly to that mixed tree leaves the source-shifted files with incorrect target ownership.

Before restore, unshift only files whose UID or GID belongs to the source idmap. Files created by the outer daemon do not map back into the source namespace and are deliberately left unchanged before the existing target shift is applied.

The LXC drivers package tests and `go vet` pass on Linux.
