### PR TITLE
Allow concurrent instance creation from one image

### DIFF
--- a/cmd/incusd/daemon_images.go
+++ b/cmd/incusd/daemon_images.go
@@ -52,13 +52,22 @@ type imageDownloadArgs struct {
 	SourceProjectName string
 }
 
-// imageOperationLock acquires a lock for operating on an image and returns the unlock function.
+// imageOperationLock acquires an exclusive lock for creating, replacing, or deleting an image.
 func imageOperationLock(ctx context.Context, fingerprint string) (locking.UnlockFunc, error) {
 	l := logger.AddContext(logger.Ctx{"fingerprint": fingerprint})
 	l.Debug("Acquiring lock for image")
 	defer l.Debug("Lock acquired for image")
 
-	return locking.Lock(ctx, fmt.Sprintf("ImageOperation_%s", fingerprint))
+	return locking.RWLock(ctx, fmt.Sprintf("ImageOperation_%s", fingerprint))
+}
+
+// imageOperationLockShared acquires a shared lock for consuming an image.
+func imageOperationLockShared(ctx context.Context, fingerprint string) (locking.UnlockFunc, error) {
+	l := logger.AddContext(logger.Ctx{"fingerprint": fingerprint})
+	l.Debug("Acquiring shared lock for image")
+	defer l.Debug("Shared lock acquired for image")
+
+	return locking.RLock(ctx, fmt.Sprintf("ImageOperation_%s", fingerprint))
 }
 
 // imageDownload resolves the image fingerprint and if not in the database, downloads it.

--- a/cmd/incusd/instance.go
+++ b/cmd/incusd/instance.go
@@ -185,9 +185,9 @@ func instanceCreateFromImage(ctx context.Context, s *state.State, img *api.Image
 		return fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}
 
-	// Lock this operation to ensure that concurrent image operations don't conflict.
-	// Other operations will wait for this one to finish.
-	unlock, err := imageOperationLock(ctx, img.Fingerprint)
+	// Keep the image stable while creating the instance, while allowing other creations from the
+	// same image to proceed concurrently.
+	unlock, err := imageOperationLockShared(ctx, img.Fingerprint)
 	if err != nil {
 		return err
 	}

--- a/internal/server/locking/lock.go
+++ b/internal/server/locking/lock.go
@@ -38,6 +38,113 @@ func Lock(ctx context.Context, lockName string) (UnlockFunc, error) {
 	}
 }
 
+type rwState struct {
+	readers        int
+	writer         bool
+	writersWaiting int
+	waitCh         chan struct{}
+}
+
+var rwLocks = map[string]*rwState{}
+var rwLocksMutex sync.Mutex
+
+func (s *rwState) broadcast() {
+	close(s.waitCh)
+	s.waitCh = make(chan struct{})
+}
+
+func getRWLock(lockName string) *rwState {
+	state, ok := rwLocks[lockName]
+	if !ok {
+		state = &rwState{waitCh: make(chan struct{})}
+		rwLocks[lockName] = state
+	}
+
+	return state
+}
+
+func releaseRWLock(lockName string, state *rwState) {
+	current, ok := rwLocks[lockName]
+	if ok && current == state && state.readers == 0 && !state.writer && state.writersWaiting == 0 {
+		delete(rwLocks, lockName)
+	}
+}
+
+func rwUnlock(lockName string, state *rwState, release func(*rwState)) UnlockFunc {
+	var once sync.Once
+
+	return func() {
+		once.Do(func() {
+			rwLocksMutex.Lock()
+			release(state)
+			state.broadcast()
+			releaseRWLock(lockName, state)
+			rwLocksMutex.Unlock()
+		})
+	}
+}
+
+// RWLock acquires an exclusive named read-write lock.
+// Writers are prioritized over new readers so a continuous stream of readers cannot starve a writer.
+func RWLock(ctx context.Context, lockName string) (UnlockFunc, error) {
+	rwLocksMutex.Lock()
+
+	for {
+		state := getRWLock(lockName)
+		if state.readers == 0 && !state.writer {
+			state.writer = true
+			rwLocksMutex.Unlock()
+
+			return rwUnlock(lockName, state, func(state *rwState) { state.writer = false }), nil
+		}
+
+		state.writersWaiting++
+		waitCh := state.waitCh
+		rwLocksMutex.Unlock()
+
+		select {
+		case <-waitCh:
+		case <-ctx.Done():
+			rwLocksMutex.Lock()
+			state.writersWaiting--
+			state.broadcast()
+			releaseRWLock(lockName, state)
+			rwLocksMutex.Unlock()
+
+			return nil, fmt.Errorf("Failed to obtain lock %q: %w", lockName, ctx.Err())
+		}
+
+		rwLocksMutex.Lock()
+		state.writersWaiting--
+	}
+}
+
+// RLock acquires a shared named read-write lock.
+func RLock(ctx context.Context, lockName string) (UnlockFunc, error) {
+	rwLocksMutex.Lock()
+
+	for {
+		state := getRWLock(lockName)
+		if !state.writer && state.writersWaiting == 0 {
+			state.readers++
+			rwLocksMutex.Unlock()
+
+			return rwUnlock(lockName, state, func(state *rwState) { state.readers-- }), nil
+		}
+
+		waitCh := state.waitCh
+		rwLocksMutex.Unlock()
+
+		select {
+		case <-waitCh:
+		case <-ctx.Done():
+			return nil, fmt.Errorf("Failed to obtain lock %q: %w", lockName, ctx.Err())
+		}
+
+		rwLocksMutex.Lock()
+	}
+}
+
 // TryLock creates a named lock for activities that require exclusive access.
 // It does not block if the lock is already held.
 // If the lock is acquired successfully, it returns an unlock function that

--- a/internal/server/locking/lock.go
+++ b/internal/server/locking/lock.go
@@ -45,8 +45,10 @@ type rwState struct {
 	waitCh         chan struct{}
 }
 
-var rwLocks = map[string]*rwState{}
-var rwLocksMutex sync.Mutex
+var (
+	rwLocks      = map[string]*rwState{}
+	rwLocksMutex sync.Mutex
+)
 
 func (s *rwState) broadcast() {
 	close(s.waitCh)

--- a/internal/server/locking/lock_test.go
+++ b/internal/server/locking/lock_test.go
@@ -1,0 +1,90 @@
+package locking
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRWLockAllowsConcurrentReaders(t *testing.T) {
+	unlockFirst, err := RLock(t.Context(), t.Name())
+	require.NoError(t, err)
+	defer unlockFirst()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	unlockSecond, err := RLock(ctx, t.Name())
+	require.NoError(t, err)
+	unlockSecond()
+}
+
+func TestRWLockExcludesReadersAndHonorsCancellation(t *testing.T) {
+	unlockWriter, err := RWLock(t.Context(), t.Name())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+
+	unlockReader, err := RLock(ctx, t.Name())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, unlockReader)
+
+	unlockWriter()
+	unlockWriter() // Unlock functions are idempotent.
+
+	unlockReader, err = RLock(t.Context(), t.Name())
+	require.NoError(t, err)
+	unlockReader()
+}
+
+func TestRWLockPrioritizesWaitingWriter(t *testing.T) {
+	lockName := t.Name()
+	unlockFirstReader, err := RLock(t.Context(), lockName)
+	require.NoError(t, err)
+
+	writerAcquired := make(chan UnlockFunc, 1)
+	go func() {
+		unlock, err := RWLock(t.Context(), lockName)
+		if err == nil {
+			writerAcquired <- unlock
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		rwLocksMutex.Lock()
+		defer rwLocksMutex.Unlock()
+
+		return rwLocks[lockName] != nil && rwLocks[lockName].writersWaiting == 1
+	}, time.Second, time.Millisecond)
+
+	readerAcquired := make(chan UnlockFunc, 1)
+	go func() {
+		unlock, err := RLock(t.Context(), lockName)
+		if err == nil {
+			readerAcquired <- unlock
+		}
+	}()
+
+	unlockFirstReader()
+
+	var unlockWriter UnlockFunc
+	select {
+	case unlockWriter = <-writerAcquired:
+	case <-readerAcquired:
+		t.Fatal("Reader acquired the lock ahead of a waiting writer")
+	case <-time.After(time.Second):
+		t.Fatal("Writer did not acquire the lock")
+	}
+
+	unlockWriter()
+
+	select {
+	case unlockReader := <-readerAcquired:
+		unlockReader()
+	case <-time.After(time.Second):
+		t.Fatal("Reader did not acquire the lock after the writer released it")
+	}
+}

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -2078,6 +2078,15 @@ func (b *backend) CreateInstanceFromImage(inst instance.Instance, fingerprint st
 			return err
 		}
 
+		// Keep the cached image volume stable while copying from it. EnsureImage can call
+		// DeleteImage, so this lock must be acquired only after EnsureImage returns.
+		unlockImage, err := locking.RLock(context.TODO(), drivers.OperationLockName("UseImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
+		if err != nil {
+			return err
+		}
+
+		defer unlockImage()
+
 		// Try and load existing volume config on this storage pool so we can compare filesystems if needed.
 		imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)
 		if err != nil {
@@ -4513,6 +4522,15 @@ func (b *backend) DeleteImage(fingerprint string, op *operations.Operation) erro
 	}
 
 	defer unlock()
+
+	// Wait for operations copying from the cached image volume and prevent new copies until
+	// the deletion has completed.
+	unlockImage, err := locking.RWLock(context.TODO(), drivers.OperationLockName("UseImage", b.name, drivers.VolumeTypeImage, "", fingerprint))
+	if err != nil {
+		return err
+	}
+
+	defer unlockImage()
 
 	// Load the storage volume in order to get the volume config which is needed for some drivers.
 	imgDBVol, err := VolumeDBGet(b, api.ProjectDefaultName, fingerprint, drivers.VolumeTypeImage)


### PR DESCRIPTION
Instance creation currently takes an exclusive per-image lock for the full storage copy. Independent creations from the same already-present image are serialized even though they only read the image and cached image volume.

Add context-aware, writer-prioritized named read-write locks. Image consumers take shared locks, while image download/replacement/deletion and cached-volume deletion remain exclusive. The storage layer separately protects the cached image volume so expiry or regeneration cannot remove it while a copy is in progress.

The locking tests pass with the race detector. The locking, storage and incusd package tests and `go vet` pass on Linux.
