### PR TITLE
incusd/networks: Fix panic when a network fails to start

### DIFF
--- a/cmd/incusd/networks.go
+++ b/cmd/incusd/networks.go
@@ -1813,7 +1813,8 @@ func networkStartup(s *state.State) error {
 	var initNetworksMu sync.Mutex
 
 	initNetwork := func(n network.Network, priority int) error {
-		err = n.Start()
+		// Use a local error variable as this runs concurrently.
+		err := n.Start()
 		if err != nil {
 			err = fmt.Errorf("Failed starting: %w", err)
 


### PR DESCRIPTION
`initNetwork()` in `networkStartup()` assigned to the function-scoped `err` instead of a local one, so all concurrent network-init goroutines shared it (errgroup limited to `runtime.NumCPU()/2`).

If one network's `Start()` failed while another's succeeded, the successful goroutine could reset the shared `err` to `nil` after the failing goroutine had entered the error branch, making the subsequent `err.Error()` a call on a nil interface:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18]
main.networkStartup.func3.1({0x2b43f60, 0x1277f0d32ee0}, 0x1277f18a53b0)
        cmd/incusd/networks.go:1819
...
main.networkStartup.networkStartup.func5.func7()
        cmd/incusd/networks.go:1918
golang.org/x/sync/errgroup.(*Group).Go.func1()
```

Hit in live cluster on 7.3.0: this caused an incusd restart to fail until timing was "right" at some point. At this point it would result in periodic error messages being logged:

```
level=error msg="Failed initializing network" err="Failed starting: Failed adding OVS chassis \"97071acd-8a52-48ee-a95c-90d1ea798d08\" with priority 13287 to chassis group \"incus-net420\": object not found" network=01a0009f-416b-76d1-ae77-c57af58f0bb3 project=019fb2bf-dfff-72bf-8b46-beae9c8c1a4a
```