### PR TITLE
incusd/instance/lxc: Keep OCI VOLUME paths persistent instead of tmpfs

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2588,6 +2588,14 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 			lxcMounts = append(lxcMounts, filepath.Clean(fmt.Sprintf("/%s", fields[1])))
 		}
 
+		// OCI VOLUME paths, tracked through the org.opencontainers.image.volumes annotation (PR #678).
+		ociVolumes := make(map[string]bool)
+		for _, vol := range strings.Split(config.Annotations["org.opencontainers.image.volumes"], ",") {
+			if vol != "" {
+				ociVolumes[filepath.Clean(vol)] = true
+			}
+		}
+
 		// Configure mounts.
 		for _, mount := range config.Mounts {
 			// We only support simple tmpfs at this stage.
@@ -2597,6 +2605,11 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 
 			// Skip all our own mounts.
 			if slices.Contains(lxcMounts, filepath.Clean(mount.Destination)) {
+				continue
+			}
+
+			// Skip OCI VOLUME paths so they stay persistent (mount.Source == "none" is a fallback for umoci pre PR #678).
+			if ociVolumes[filepath.Clean(mount.Destination)] || mount.Source == "none" {
 				continue
 			}
 


### PR DESCRIPTION
Paths declared as VOLUME in an OCI/Docker image config were being converted to ephemeral tmpfs mounts, silently discarding their contents on every instance restart. Our instances already have their own persistent storage, so skip those mounts instead and leave the path as a normal part of the instance rootfs.

Identified via the org.opencontainers.image.volumes annotation ([opencontainers/umoci#678](https://github.com/opencontainers/umoci/pull/678)), falling back to the source == "none" heuristic for older umoci versions that don't set it.

This has been in umoci since v0.0.0-rc2 (2016) so `VOLUMES` in Dockerfiles have been "tmpfs" since then.