### PR TITLE
Sync filesystem instead of freezing it before snapshots

### DIFF
--- a/internal/server/storage/drivers/driver_linstor_volumes.go
+++ b/internal/server/storage/drivers/driver_linstor_volumes.go
@@ -859,14 +859,12 @@ func (d *linstor) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation)
 	sourcePath := GetVolumeMountPath(d.name, snapVol.volType, parentName)
 
 	if linux.IsMountPoint(sourcePath) {
-		// Attempt to sync and freeze filesystem, but do not error if not able to freeze (as filesystem
-		// could still be busy), as LINSTOR does not have any notion of the filesystem and therefore can't
-		// guarantee the consistently of the filesystem on a snapshot. This is costly but tries to ensure
-		// that all cached data has been committed to the underlying DRBD device. If we don't then the
-		// LINSTOR snapshot can be inconsistent or, in the worst case, empty.
-		unfreezeFS, err := d.filesystemFreeze(sourcePath)
-		if err == nil {
-			defer logger.WarnOnError(unfreezeFS, "Failed to unfreeze filesystem")
+		// The filesystem is deliberately not frozen. A userspace freeze held across a LINSTOR
+		// snapshot leaves the DRBD device frozen even once the filesystem has been thawed, so the
+		// volume can never be mounted again ("Can't mount, blockdev is frozen").
+		err := linux.SyncFS(sourcePath)
+		if err != nil {
+			d.logger.Warn("Failed syncing filesystem before snapshot", logger.Ctx{"path": sourcePath, "err": err})
 		}
 	}
 


### PR DESCRIPTION
### Summary
Snapshotting a LINSTOR volume whose filesystem is mounted leaves the DRBD device permanently unmountable.
The kernel logs: `drbd1001: Can't mount, blockdev is frozen`.
The trigger is `CreateVolumeSnapshot` freezing the filesystem with `fsfreeze` and holding that freeze across the LINSTOR snapshot.

### Reproducer
```
root@server11:~# incus launch images:debian/13 c1 --storage linstor --target server11
Launching c1
root@server11:~# incus storage volume create linstor d1
Storage volume d1 created
root@server11:~# incus storage volume attach linstor d1 c1 d1 /mnt/d1
root@server11:~# incus storage volume snapshot create linstor d1 snap0
root@server11:~# incus storage volume snapshot delete linstor d1 snap0
Storage volume snapshot snap0 deleted from d1
root@server11:~# incus stop c1
root@server11:~# incus start c1
Error: Failed to start device "d1": Failed mounting volume: Failed mounting custom storage volume "d1" on storage pool "linstor": Failed to mount "/dev/drbd1002" on "/var/lib/incus/storage-pools/linstor/custom/default_d1" using "ext4": device or resource busy
Try `incus info --show-log c1` for more info
```

### Fix
Sync the filesystem rather than freezing it. This is a workaround. Bug also reported to LINSTOR: https://github.com/LINBIT/linstor-server/issues/525