### PR TITLE
cmd/incus: add --data-file flag for query command

### DIFF
--- a/cmd/incus/query.go
+++ b/cmd/incus/query.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/lxc/incus/v7/internal/i18n"
 	"github.com/lxc/incus/v7/shared/api"
 	cli "github.com/lxc/incus/v7/shared/cmd"
+	"github.com/lxc/incus/v7/shared/logger"
 )
 
 type cmdQuery struct {
@@ -27,6 +29,7 @@ type cmdQuery struct {
 	flagRespRaw  bool
 	flagAction   string
 	flagData     string
+	flagDataFile string
 }
 
 var cmdQueryUsage = u.Usage{u.Placeholder(i18n.G("API path")).Remote()}
@@ -49,6 +52,7 @@ func (c *cmdQuery) command() *cobra.Command {
 	cli.AddBoolFlag(cmd.Flags(), &c.flagRespRaw, "raw", i18n.G("Print the raw response"))
 	cli.AddStringFlag(cmd.Flags(), &c.flagAction, "request|X", "GET", "", i18n.G("Action"))
 	cli.AddStringFlag(cmd.Flags(), &c.flagData, "data|d", "", "", i18n.G("Input data"))
+	cli.AddStringFlag(cmd.Flags(), &c.flagDataFile, "data-file", "", "", i18n.G("Input data file (\"-\" for stdin)"))
 
 	return cmd
 }
@@ -79,6 +83,10 @@ func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 		return errors.New(i18n.G("--project cannot be used with the query command"))
 	}
 
+	if c.flagData != "" && c.flagDataFile != "" {
+		return errors.New(i18n.G("--data cannot be used with --data-file"))
+	}
+
 	if !slices.Contains([]string{"GET", "PUT", "POST", "PATCH", "DELETE"}, c.flagAction) {
 		return fmt.Errorf(i18n.G("Action %q isn't supported by this tool"), c.flagAction)
 	}
@@ -93,6 +101,22 @@ func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 	err = json.Unmarshal([]byte(c.flagData), &data)
 	if err != nil {
 		data = c.flagData
+	}
+
+	var input *os.File
+	if c.flagDataFile != "" {
+		if isStdin(c.flagDataFile) {
+			input = os.Stdin
+		} else {
+			input, err = os.Open(c.flagDataFile)
+			if err != nil {
+				return fmt.Errorf(i18n.G("Failed to open input file %q: %w"), c.flagDataFile, err)
+			}
+
+			defer logger.WarnOnErrorExcept(input.Close, []error{os.ErrClosed}, "Failed to close file")
+		}
+
+		data = input
 	}
 
 	// Perform the query
@@ -121,8 +145,16 @@ func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Setup input.
-		var rs io.ReadSeeker
-		if c.flagData != "" {
+		var rs io.Reader
+		if input != nil {
+			// Rewind the input so that it can be sent again.
+			_, err := input.Seek(0, io.SeekStart)
+			if err != nil {
+				return cleanErr
+			}
+
+			rs = input
+		} else if c.flagData != "" {
 			rs = bytes.NewReader([]byte(c.flagData))
 		}
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:44+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 "
 "<nlincus@users.noreply.hosted.weblate.org>\n"
@@ -754,6 +754,11 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target kann nicht mit Instanzen verwendet werden"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 #, fuzzy
 msgid "--expanded cannot be used with a server"
@@ -793,7 +798,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 #, fuzzy
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -884,7 +889,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -928,12 +933,12 @@ msgstr "Zugriff auf erweiterte Konfiguration"
 msgid "Acknowledge warning"
 msgstr "Warnung gesehen"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 #, fuzzy
 msgid "Action"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Aktion %q wird von diesem Programm nicht unterstützt"
@@ -3596,6 +3601,11 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Akzeptiere Zertifikat"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, fuzzy, c-format
@@ -4542,8 +4552,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -7141,7 +7155,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr "Ein Client Zertifikat ist bereits erstellt worden"
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -7343,7 +7357,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7933,7 +7947,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -10060,7 +10074,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -10948,7 +10962,7 @@ msgstr ""
 "    Automatisches Editieren der Konfiguration eines Projekts mit der "
 "Konfigurationsdatei \"project.yaml\""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/incus/cli/el/>\n"
@@ -489,6 +489,10 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
+#: cmd/incus/query.go:87
+msgid "--data cannot be used with --data-file"
+msgstr ""
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr ""
@@ -522,7 +526,7 @@ msgstr ""
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -608,7 +612,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -649,11 +653,11 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr ""
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
@@ -3042,6 +3046,11 @@ msgstr ""
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, c-format
+msgid "Failed to open input file %q: %w"
+msgstr ""
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -3944,8 +3953,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6420,7 +6433,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr ""
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -6609,7 +6622,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7159,7 +7172,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9130,7 +9143,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -9882,7 +9895,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:45+0000\n"
 "Last-Translator: Kazantsev Mikhail <kazan417@mail.ru>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/incus/cli/es/>\n"
@@ -751,6 +751,11 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr ""
@@ -789,7 +794,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -879,7 +884,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -920,12 +925,12 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 #, fuzzy
 msgid "Action"
 msgstr "condición"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "El filtrado no está soportado aún"
@@ -3411,6 +3416,11 @@ msgstr "Acepta certificado"
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Acepta certificado"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, fuzzy, c-format
@@ -4347,8 +4357,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6894,7 +6908,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr "Certificado del cliente almacenado en el servidor: "
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -7091,7 +7105,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7668,7 +7682,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Creado: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9729,7 +9743,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -10492,7 +10506,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:46+0000\n"
 "Last-Translator: Varlorg <varlorg@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -763,6 +763,11 @@ msgstr "--console ne peut être utilisé avec --all"
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target ne peut pas être utilisé avec des instances"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
@@ -800,7 +805,7 @@ msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
@@ -889,7 +894,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr "chemin d’API"
 
@@ -930,11 +935,11 @@ msgstr "Accéder à la configuration étendue"
 msgid "Acknowledge warning"
 msgstr "Prendre acte d’un avertissement"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr "Action"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "L'action '%q' n'est pas supporté par le serveur"
@@ -3537,6 +3542,11 @@ msgstr "Échec de la mise en écoute des demandes de connexion : %w"
 msgid "Failed to load configuration: %s"
 msgstr "Échec du chargement de la configuration : %s"
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Échec de la fermeture du fichier de certificat du serveur %q : %w"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -4535,9 +4545,13 @@ msgstr ""
 msgid "Infiniband:"
 msgstr "Infiniband :"
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
 msgstr "Données d'entrée"
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
+msgstr ""
 
 #: cmd/incus/low_level.go:1265
 #, fuzzy
@@ -7689,7 +7703,7 @@ msgstr "Afficher l’aide"
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr "Un certificat client est déjà présent"
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr "Afficher la réponse brute"
 
@@ -7887,7 +7901,7 @@ msgstr "Création du conteneur"
 msgid "Pushing %s to %s: %%s"
 msgstr "Envoi de « %s » à « %s » : %%s"
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr "Le chemin de la requête doit commencer par « / »"
 
@@ -8476,7 +8490,7 @@ msgstr "Clef secrète (auto-générée si vide)"
 msgid "Secret key: %s"
 msgstr "Clef secrète : %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr "Envoyer une requête brute au serveur"
 
@@ -10574,7 +10588,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr "Attendre la fin de l’opération"
 
@@ -11420,7 +11434,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:51+0000\n"
 "Last-Translator: Kazantsev Mikhail <kazan417@mail.ru>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -492,6 +492,11 @@ msgstr "--console tidak bisa dipakai dengan --allx"
 msgid "--console only works with a single instance"
 msgstr "--console hanya bekerja dengan satu instansi"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--console tidak bisa dipakai dengan --allx"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded tidak bisa dipakai dengan server"
@@ -526,7 +531,7 @@ msgstr ""
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -615,7 +620,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -656,12 +661,12 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 #, fuzzy
 msgid "Action"
 msgstr "kondisi"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
@@ -3068,6 +3073,11 @@ msgstr ""
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, c-format
+msgid "Failed to open input file %q: %w"
+msgstr ""
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -3972,8 +3982,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6464,7 +6478,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr ""
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -6660,7 +6674,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7213,7 +7227,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9198,7 +9212,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -9958,7 +9972,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2026-08-19 22:43-0400\n"
+        "POT-Creation-Date: 2026-08-20 14:46+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -460,6 +460,10 @@ msgstr  ""
 msgid   "--console only works with a single instance"
 msgstr  ""
 
+#: cmd/incus/query.go:87
+msgid   "--data cannot be used with --data-file"
+msgstr  ""
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
@@ -492,7 +496,7 @@ msgstr  ""
 msgid   "--owner and --type require --all to be set"
 msgstr  ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid   "--project cannot be used with the query command"
 msgstr  ""
 
@@ -574,7 +578,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid   "API path"
 msgstr  ""
 
@@ -615,11 +619,11 @@ msgstr  ""
 msgid   "Acknowledge warning"
 msgstr  ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid   "Action"
 msgstr  ""
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid   "Action %q isn't supported by this tool"
 msgstr  ""
@@ -2820,6 +2824,11 @@ msgstr  ""
 msgid   "Failed to load configuration: %s"
 msgstr  ""
 
+#: cmd/incus/query.go:113
+#, c-format
+msgid   "Failed to open input file %q: %w"
+msgstr  ""
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828 cmd/incus/utils_sftp.go:330
 #, c-format
 msgid   "Failed to open source file %q: %v"
@@ -3672,8 +3681,12 @@ msgstr  ""
 msgid   "Infiniband:"
 msgstr  ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid   "Input data"
+msgstr  ""
+
+#: cmd/incus/query.go:55
+msgid   "Input data file (\"-\" for stdin)"
 msgstr  ""
 
 #: cmd/incus/low_level.go:1265
@@ -6032,7 +6045,7 @@ msgstr  ""
 msgid   "Print or retrieve the client certificate used by this Incus client"
 msgstr  ""
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid   "Print the raw response"
 msgstr  ""
 
@@ -6218,7 +6231,7 @@ msgstr  ""
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid   "Query path must start with /"
 msgstr  ""
 
@@ -6746,7 +6759,7 @@ msgstr  ""
 msgid   "Secret key: %s"
 msgstr  ""
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid   "Send a raw query to the server"
 msgstr  ""
 
@@ -8583,7 +8596,7 @@ msgid   "Wait for the daemon to be ready to process requests\n"
         "  containers."
 msgstr  ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid   "Wait for the operation to complete"
 msgstr  ""
 
@@ -9245,7 +9258,7 @@ msgid   "incus project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid   "incus query -X DELETE --wait /1.0/instances/c1\n"
         "    Delete local instance \"c1\"."
 msgstr  ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:46+0000\n"
 "Last-Translator: Alberto Donato <ack@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -764,6 +764,10 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
+#: cmd/incus/query.go:87
+msgid "--data cannot be used with --data-file"
+msgstr ""
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr ""
@@ -797,7 +801,7 @@ msgstr ""
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -884,7 +888,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -925,11 +929,11 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr ""
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "'%s' non è un tipo di file supportato."
@@ -3403,6 +3407,11 @@ msgstr "Accetta certificato"
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Accetta certificato"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, fuzzy, c-format
@@ -4332,8 +4341,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6880,7 +6893,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -7075,7 +7088,7 @@ msgstr "Creazione del container in corso"
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7651,7 +7664,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9709,7 +9722,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -10472,7 +10485,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:47+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -750,6 +750,11 @@ msgstr "--console と --all は同時に指定できません"
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target はインスタンスでは使えません"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
@@ -787,7 +792,7 @@ msgstr "--no-profiles と --refresh は同時に指定できません"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
@@ -878,7 +883,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr "API パス"
 
@@ -919,12 +924,12 @@ msgstr "拡張した設定を表示する"
 msgid "Acknowledge warning"
 msgstr "警告を確認します"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 #, fuzzy
 msgid "Action"
 msgstr "説明"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "%q はこのツールではサポートされていません"
@@ -3495,6 +3500,11 @@ msgstr "コネクションのリッスンに失敗しました: %w"
 msgid "Failed to load configuration: %s"
 msgstr "設定のロードに失敗しました: %s"
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "ターゲットファイルのオープンに失敗しました %q: %w"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -4480,9 +4490,13 @@ msgstr ""
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
 msgstr "入力するデータ"
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
+msgstr ""
 
 #: cmd/incus/low_level.go:1265
 #, fuzzy
@@ -7846,7 +7860,7 @@ msgstr "ヘルプを表示します"
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr "クライアント証明書がサーバに格納されました:"
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
@@ -8042,7 +8056,7 @@ msgstr "インスタンス内にファイルをコピーします"
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
@@ -8637,7 +8651,7 @@ msgstr "秘密鍵（空白の場合自動生成）"
 msgid "Secret key: %s"
 msgstr "秘密鍵: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 #, fuzzy
 msgid "Send a raw query to the server"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
@@ -10892,7 +10906,7 @@ msgstr ""
 "で\n"
 "  ブロックします。"
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
 
@@ -11935,7 +11949,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 #, fuzzy
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:54+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Georgian <https://hosted.weblate.org/projects/incus/cli/ka/>\n"
@@ -513,6 +513,11 @@ msgstr "--console-ის გამოყენება --all-თან ერ�
 msgid "--console only works with a single instance"
 msgstr "--console მხოლოდ ერთ გაშვებულ ასლთან მუშაობს"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target გაშვებულ ასლებთან ერთად ვერ გამოიყენებთ"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded სერვერთან ერთად ვერ გამოიყენებთ"
@@ -547,7 +552,7 @@ msgstr "--no-profiles -ის და --refresh -ის ერთად გამ
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project -ის გამოყენება მოთხოვნის ბრძანებასთან ერთად შეუძლებელია"
 
@@ -635,7 +640,7 @@ msgstr "ფსევდონიმი"
 msgid "ALIASES"
 msgstr "ფსევდონიმები"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -676,12 +681,12 @@ msgstr "წვდომა გაფართოებულ კონფიგ�
 msgid "Acknowledge warning"
 msgstr "გაფრთხილების დადასტურება"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 #, fuzzy
 msgid "Action"
 msgstr "მდგომარეობა"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "ქმედება %q ამ პროგრამის მიერ მხარდაჭერილი არაა"
@@ -3078,6 +3083,11 @@ msgstr ""
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "sshfs-ის გაშვების შეცდომა: %w"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -3982,9 +3992,13 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
 msgstr "შეყვანილი მონაცემები"
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
+msgstr ""
 
 #: cmd/incus/low_level.go:1265
 #, fuzzy
@@ -6470,7 +6484,7 @@ msgstr "დახმარების გამოტანა"
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr ""
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -6659,7 +6673,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7213,7 +7227,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "საიდუმლო გასაღები: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9201,7 +9215,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -9954,7 +9968,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:50+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -509,6 +509,10 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
+#: cmd/incus/query.go:87
+msgid "--data cannot be used with --data-file"
+msgstr ""
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr ""
@@ -542,7 +546,7 @@ msgstr ""
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -628,7 +632,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -669,11 +673,11 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr ""
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
@@ -3062,6 +3066,11 @@ msgstr ""
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, c-format
+msgid "Failed to open input file %q: %w"
+msgstr ""
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -3965,8 +3974,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6441,7 +6454,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr ""
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -6630,7 +6643,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7180,7 +7193,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9151,7 +9164,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -9903,7 +9916,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:47+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 "
 "<nlincus@users.noreply.hosted.weblate.org>\n"
@@ -770,6 +770,11 @@ msgid "--console only works with a single instance"
 msgstr ""
 "--console werkt alleen als het een enkele instantiatie (instance) betreft"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target kan niet gebruikt worden met: instances"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded kan niet gebruikt worden voor een server"
@@ -806,7 +811,7 @@ msgstr "--no-profiles kan niet gebruikt worden met --refresh"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project kan niet gebruikt worden met de query command"
 
@@ -895,7 +900,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASSEN"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -936,11 +941,11 @@ msgstr "Toegang tot de geëxpandeerde configuratie"
 msgid "Acknowledge warning"
 msgstr "Bevestig de waarschuwing"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr ""
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Actie %q is niet ondersteund door dit programma"
@@ -3387,6 +3392,11 @@ msgstr ""
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Backup aan het maken van instantiatie (instance): %s"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -4290,8 +4300,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6779,7 +6793,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr "Een client certificaat is al aanwezig"
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -6971,7 +6985,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7525,7 +7539,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9536,7 +9550,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -10294,7 +10308,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:50+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/incus/cli/pt/"
@@ -755,6 +755,11 @@ msgstr "--console não pode ser usado com --all"
 msgid "--console only works with a single instance"
 msgstr "-- console só funciona com uma única instância"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target não pode ser usado com instâncias"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded não pode ser usado com um servidor"
@@ -791,7 +796,7 @@ msgstr "--no-profiles não pode ser usado com --refresh"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project não pode ser usado com o comando query"
 
@@ -881,7 +886,7 @@ msgstr "NOME ALTERNATIVO (ALIAS)"
 msgid "ALIASES"
 msgstr "NOMES ALTERNATIVOS"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr "Caminho do API"
 
@@ -922,11 +927,11 @@ msgstr "Acesso à configuração expandida"
 msgid "Acknowledge warning"
 msgstr "Aviso de reconhecimento"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr "Ação"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Acção %q não é suportada por esta ferramenta"
@@ -3522,6 +3527,11 @@ msgstr "Falhou ao escutar por ligação: %w"
 msgid "Failed to load configuration: %s"
 msgstr "Falhou ao carregar configuração: %s"
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Falhou ao abrir ficheiro alvo %q: %w"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -4498,9 +4508,13 @@ msgstr "O Incus não sabe como dissecar %s:%s"
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
 msgstr "Dados de entrada"
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
+msgstr ""
 
 #: cmd/incus/low_level.go:1265
 #, fuzzy
@@ -7765,7 +7779,7 @@ msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr ""
 "Escreve ou recupera o certificado de cliente utilizado por este cliente Incus"
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr "Escreve a resposta crua"
 
@@ -7957,7 +7971,7 @@ msgstr "Envia ficheiros para instâncias"
 msgid "Pushing %s to %s: %%s"
 msgstr "A enviar %s to %s: %%s"
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr "Caminho de consulta tem de começar com /"
 
@@ -8542,7 +8556,7 @@ msgstr "Chave secreta (auto-gerada se vazia)"
 msgid "Secret key: %s"
 msgstr "Chave secreta: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr "Envia uma consulta em cru para o servidor"
 
@@ -10735,7 +10749,7 @@ msgstr ""
 "previamente\n"
 "  arrancados."
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr "Aguarde que a operação complete"
 
@@ -11768,7 +11782,7 @@ msgstr ""
 "incus project edit <project> < project.yaml\n"
 "    Atualiza um projeto usando o conteúdo de project.yaml"
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:48+0000\n"
 "Last-Translator: Kazantsev Mikhail <kazan417@mail.ru>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -744,6 +744,11 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--refresh só pode ser usado com containers"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 #, fuzzy
 msgid "--expanded cannot be used with a server"
@@ -783,7 +788,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 #, fuzzy
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
@@ -877,7 +882,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -919,12 +924,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 #, fuzzy
 msgid "Action"
 msgstr "condição"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -3448,6 +3453,11 @@ msgstr "Aceitar certificado"
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Aceitar certificado"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, fuzzy, c-format
@@ -4385,8 +4395,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6941,7 +6955,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr "Certificado do cliente armazenado no servidor: "
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -7140,7 +7154,7 @@ msgstr "Editar arquivos no container"
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7730,7 +7744,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9818,7 +9832,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -10582,7 +10596,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:48+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/incus/cli/ru/>\n"
@@ -752,6 +752,11 @@ msgstr "--console не может быть использован с --all"
 msgid "--console only works with a single instance"
 msgstr "--console работает только с одним экземпляром"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target не может использоваться с экземплярами"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded не может использоваться с сервером"
@@ -791,7 +796,7 @@ msgstr "--no-profiles не может использоваться с --refresh"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project не может быть использован с командой query"
 
@@ -881,7 +886,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМЫ"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr "путь к API"
 
@@ -922,11 +927,11 @@ msgstr "Расширенная конфигурация"
 msgid "Acknowledge warning"
 msgstr "Принять предупреждение"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr "Действие"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Действие %q не поддерживается этим инструментом"
@@ -3537,6 +3542,11 @@ msgstr "Не удалось запустить принятие соединен
 msgid "Failed to load configuration: %s"
 msgstr "Не удалось загрузить конфигурацию: %s"
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Не удалось открыть целевой файл %q: %w"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -4529,9 +4539,13 @@ msgstr "Incus не умеет разбирать %s:%s"
 msgid "Infiniband:"
 msgstr "информация о Infiniband:"
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
 msgstr "Входные данные"
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
+msgstr ""
 
 #: cmd/incus/low_level.go:1265
 #, fuzzy
@@ -7766,7 +7780,7 @@ msgstr ""
 "Распечатайте или извлеките сертификат клиента, используемый этим клиентом "
 "Incus"
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr "Вывести необработанный ответ"
 
@@ -7958,7 +7972,7 @@ msgstr "Отправка файлов в экземпляры"
 msgid "Pushing %s to %s: %%s"
 msgstr "Отправка %s в %s: %%s"
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr "Путь запроса должен начаться с /"
 
@@ -8546,7 +8560,7 @@ msgstr "Секретный ключ (автогенерация, если пус
 msgid "Secret key: %s"
 msgstr "Секретный ключ: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr "Отправить необработанный запрос на сервер"
 
@@ -10737,7 +10751,7 @@ msgstr ""
 "   станет доступен через свой REST API и не завершит выполнение задач \n"
 "  раннего запуска, таких как перезапуск ранее запущенных контейнеров."
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr "Ожидать завершения операции"
 
@@ -11785,7 +11799,7 @@ msgstr ""
 "incus project edit <project> < project.yaml\n"
 "    Обновить проект, используя содержимое файла project.yaml"
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/incus/cli/sv/>\n"
@@ -751,6 +751,11 @@ msgstr "--console kan inte användas tillsammans med --all"
 msgid "--console only works with a single instance"
 msgstr "--console fungerar endast med en enda instans"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target kan inte användas med instanser"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded kan inte användas med en server"
@@ -785,7 +790,7 @@ msgstr "--no-profiles kan inte användas tillsammans med --refresh"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project kan inte användas med kommandot query"
 
@@ -876,7 +881,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASER"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr "API-sökväg"
 
@@ -917,11 +922,11 @@ msgstr "Öppna den utökade konfigurationen"
 msgid "Acknowledge warning"
 msgstr "Bekräfta varning"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr "Åtgärden"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Åtgärden %q stöds inte av detta verktyg"
@@ -3504,6 +3509,11 @@ msgstr "Misslyckades med att lyssna efter anslutning: %w"
 msgid "Failed to load configuration: %s"
 msgstr "Konfigurationen kunde inte läsas in: %s"
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "Misslyckades att öppna målfil %q: %w"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -4486,9 +4496,13 @@ msgstr ""
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
 msgstr "Inmatningsdata"
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
+msgstr ""
 
 #: cmd/incus/low_level.go:1265
 #, fuzzy
@@ -7687,7 +7701,7 @@ msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr ""
 "Skriv ut eller hämta det klientcertifikat som används av denna Incus-klient"
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr "Skriv ut det råa svaret"
 
@@ -7879,7 +7893,7 @@ msgstr "Skicka filer till instanser"
 msgid "Pushing %s to %s: %%s"
 msgstr "Trycker %s till %s: %%s"
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr "Sökvägen måste börja med /"
 
@@ -8456,7 +8470,7 @@ msgstr "Hemlig nyckel (genereras automatiskt om tom)"
 msgid "Secret key: %s"
 msgstr "Hemlig nyckel: %s"
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr "Skicka en rå fråga till servern"
 
@@ -10624,7 +10638,7 @@ msgstr ""
 "slutfört tidiga startuppgifter, såsom att starta om tidigare startade\n"
 "containrar."
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr "Vänta tills operationen är klar"
 
@@ -11657,7 +11671,7 @@ msgstr ""
 "incus-projekt redigera <projekt> < project.yaml\n"
 "    Uppdatera ett projekt med innehållet i project.yaml"
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/incus/cli/ta/>\n"
@@ -489,6 +489,10 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
+#: cmd/incus/query.go:87
+msgid "--data cannot be used with --data-file"
+msgstr ""
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr ""
@@ -522,7 +526,7 @@ msgstr ""
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr ""
 
@@ -608,7 +612,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -649,11 +653,11 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr ""
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
@@ -3042,6 +3046,11 @@ msgstr ""
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, c-format
+msgid "Failed to open input file %q: %w"
+msgstr ""
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -3944,8 +3953,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6420,7 +6433,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr ""
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -6609,7 +6622,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7159,7 +7172,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9130,7 +9143,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -9882,7 +9895,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:49+0000\n"
 "Last-Translator: meipeter <meipeter114514@outlook.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -749,6 +749,11 @@ msgstr "--console 不能与 --all 一起使用"
 msgid "--console only works with a single instance"
 msgstr "--console 只适用于单个实例"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target 不能与实例一起使用"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded 不能与服务器一起使用"
@@ -784,7 +789,7 @@ msgstr "--no-profiles 不能与 --refresh 一起使用"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project 不能与 query 命令一起使用"
 
@@ -874,7 +879,7 @@ msgstr "别名"
 msgid "ALIASES"
 msgstr "别名"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -915,12 +920,12 @@ msgstr "访问扩展配置"
 msgid "Acknowledge warning"
 msgstr "确认警告"
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 #, fuzzy
 msgid "Action"
 msgstr "描述"
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "此工具不支持操作 %q"
@@ -3447,6 +3452,11 @@ msgstr "监听连接失败：%w"
 msgid "Failed to load configuration: %s"
 msgstr "加载配置失败：%s"
 
+#: cmd/incus/query.go:113
+#, fuzzy, c-format
+msgid "Failed to open input file %q: %w"
+msgstr "关闭服务器证书文件 %q 失败：%w"
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, fuzzy, c-format
@@ -4387,9 +4397,13 @@ msgstr ""
 msgid "Infiniband:"
 msgstr "Infiniband："
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
 msgstr "输入数据"
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
+msgstr ""
 
 #: cmd/incus/low_level.go:1265
 #, fuzzy
@@ -7192,7 +7206,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr "客户端证书已存在"
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -7385,7 +7399,7 @@ msgstr "向实例推送文件"
 msgid "Pushing %s to %s: %%s"
 msgstr "正在向 %[2]s 推送 %[1]s: %%s"
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr "查询路径必须以 / 开头"
 
@@ -7950,7 +7964,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9952,7 +9966,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -10714,7 +10728,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-19 22:43-0400\n"
+"POT-Creation-Date: 2026-08-20 14:46+0000\n"
 "PO-Revision-Date: 2026-08-12 03:51+0000\n"
 "Last-Translator: pesder <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
@@ -491,6 +491,11 @@ msgstr "--console 不能與 --all 一起使用"
 msgid "--console only works with a single instance"
 msgstr "--console 僅適用於單個實體"
 
+#: cmd/incus/query.go:87
+#, fuzzy
+msgid "--data cannot be used with --data-file"
+msgstr "--target 不能與實體一起使用"
+
 #: cmd/incus/config.go:474 cmd/incus/config.go:726
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded 不能與伺服器一起使用"
@@ -526,7 +531,7 @@ msgstr "--no-profiles 不能與 --refresh 一起使用"
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
-#: cmd/incus/query.go:79
+#: cmd/incus/query.go:83
 msgid "--project cannot be used with the query command"
 msgstr "--project 不能與 query 命令一起使用"
 
@@ -614,7 +619,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:35
 msgid "API path"
 msgstr ""
 
@@ -655,11 +660,11 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:50
+#: cmd/incus/query.go:53
 msgid "Action"
 msgstr ""
 
-#: cmd/incus/query.go:83
+#: cmd/incus/query.go:91
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
@@ -3048,6 +3053,11 @@ msgstr ""
 msgid "Failed to load configuration: %s"
 msgstr ""
 
+#: cmd/incus/query.go:113
+#, c-format
+msgid "Failed to open input file %q: %w"
+msgstr ""
+
 #: cmd/incus/file.go:796 cmd/incus/storage_volume_file.go:828
 #: cmd/incus/utils_sftp.go:330
 #, c-format
@@ -3950,8 +3960,12 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:51
+#: cmd/incus/query.go:54
 msgid "Input data"
+msgstr ""
+
+#: cmd/incus/query.go:55
+msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
 #: cmd/incus/low_level.go:1265
@@ -6426,7 +6440,7 @@ msgstr ""
 msgid "Print or retrieve the client certificate used by this Incus client"
 msgstr ""
 
-#: cmd/incus/query.go:49
+#: cmd/incus/query.go:52
 msgid "Print the raw response"
 msgstr ""
 
@@ -6615,7 +6629,7 @@ msgstr ""
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:96
 msgid "Query path must start with /"
 msgstr ""
 
@@ -7165,7 +7179,7 @@ msgstr ""
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:37 cmd/incus/query.go:38
+#: cmd/incus/query.go:40 cmd/incus/query.go:41
 msgid "Send a raw query to the server"
 msgstr ""
 
@@ -9138,7 +9152,7 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:48
+#: cmd/incus/query.go:51
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -9892,7 +9906,7 @@ msgid ""
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:41
+#: cmd/incus/query.go:44
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."


### PR DESCRIPTION
@stgraber One thing to point out: since the file is passed as io.Reader to the client (RawQuery), the content type is set to `application/octet-stream` regardless of the actual payload in the file. I wonder, if additional flags (e.g. `--data-file-json` and `--data-file-binary`) are required here to support more accurate content type headers.