### PR TITLE
incusd/device: Fix address set project scope on bridged NIC start

### DIFF
--- a/internal/server/device/nic_bridged.go
+++ b/internal/server/device/nic_bridged.go
@@ -1546,7 +1546,7 @@ func (d *nicBridged) setFilters() (err error) {
 
 		// Ensure address sets for ACL, we state bridge because
 		// this is the table firewall driver will use for this kind of NIC.
-		err = addressSet.FirewallApplyAddressSetsForACLRules(d.state, "bridge", d.inst.Project().Name, aclNames)
+		err = addressSet.FirewallApplyAddressSetsForACLRules(d.state, "bridge", networkProjectName, aclNames)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Problem
On a host using `features.networks=false` with separate tenant projects sharing one network project (the documented multi-tenancy pattern), a bridged NIC device whose effective `security.acls` references a network address set fails to start once the kernel nftables sets backing that address set have been evicted - e.g. after a host reboot:

```
Failed to start device "eth0": Failed adding bridge filter rules ...
Failed apply nftables config: Failed to run: nft -f -: exit status 1
(/dev/stdin:91:35-54: Error: No such file or directory
        oifname "vethXXXXXXXX" ip saddr  @secure-servers_ipv4 ...)
```

## Root cause

`nic_bridged.go`'s device start path already resolves the correct
network project for ACL rules:

```go
networkProjectName, _, err := project.NetworkProject(d.state.DB.Cluster, d.inst.Project().Name)
...
aclRules, err = acl.FirewallACLRules(d.state, d.name, networkProjectName, d.config)
```

but the very next call, meant to ensure the address sets referenced by those ACLs exist before the filter is applied, uses the instance's own project instead of the resolved network project:

```go
err = addressSet.FirewallApplyAddressSetsForACLRules(d.state, "bridge", d.inst.Project().Name, aclNames)
```

`GetAddressSetsForACLs` filters strictly by the given project, so when the instance project differs from the network project this call finds zero address sets, returns no error, and does nothing. The address set never gets refreshed, and the subsequent bridge filter apply fails because the referenced `@<set>_ipv4`/`@<set>_ipv6` kernel sets don't exist.

## Fix

Use `networkProjectName`, matching the line above it.

## Testing

Reproduced on a multi-tenant Alpine/nftables host (`features.networks=false`, separate tenant project sharing the `default` network project). Before the fix: the affected instance failed to start identically after every reboot;
other instances on the same host whose effective ACLs don't reference an address set were unaffected, confirming the address-set dependency as the trigger. After the fix: repeated full host reboots - the instance autostarts cleanly with no manual `refresh-nft` intervention.