### PR TITLE
Allow "none" ipv4.address/ipv6.address for OCI

### DIFF
--- a/cmd/incusd/main_forknet.go
+++ b/cmd/incusd/main_forknet.go
@@ -412,6 +412,15 @@ func (c *cmdForknet) runDHCP(_ *cobra.Command, args []string) error {
 			}
 		}
 
+		// Prevent router advertisements from configuring addresses on interfaces
+		// with a static or disabled IPv6 configuration.
+		if !config.DHCP6 {
+			err := c.disableIPv6Autoconf(iface)
+			if err != nil {
+				l.WithError(err).Warning("Couldn't disable IPv6 address auto-configuration")
+			}
+		}
+
 		// Skip interfaces that are fully statically configured.
 		if !config.DHCP4 && !config.DHCP6 {
 			l.Info("skipping dhcp on statically configured interface")
@@ -1163,6 +1172,23 @@ func (c *cmdForknet) dhcpApplyDNS(l *logrus.Logger) error {
 	}
 
 	return nil
+}
+
+// disableIPv6Autoconf prevents router advertisements from configuring addresses on the interface.
+func (c *cmdForknet) disableIPv6Autoconf(iface string) error {
+	// Don't auto-configure addresses from router advertisements.
+	err := os.WriteFile(filepath.Join("/proc/sys/net/ipv6/conf", iface, "autoconf"), []byte("0"), 0o644)
+	if err != nil {
+		return err
+	}
+
+	// Remove any already auto-configured address.
+	addr := &ip.Addr{
+		DevName: iface,
+		Family:  ip.FamilyV6,
+	}
+
+	return addr.FlushDynamic()
 }
 
 // disableIPv6Gateway prevents router advertisements from providing a default gateway on the interface.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -607,7 +607,7 @@ With VMs, this option supports mounting file system disk devices and paths withi
 
 ```{config:option} ipv4.address devices-nic_bridged
 :managed: "no"
-:shortdesc: "An IPv4 address to assign to the instance through DHCP (can be `none` to restrict all IPv4 traffic when `security.ipv4_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)"
+:shortdesc: "An IPv4 address to assign to the instance through DHCP (can be `none` to disable DHCPv4 inside an OCI container and restrict all IPv4 traffic when `security.ipv4_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)"
 :type: "string"
 
 ```
@@ -635,7 +635,7 @@ With VMs, this option supports mounting file system disk devices and paths withi
 
 ```{config:option} ipv6.address devices-nic_bridged
 :managed: "no"
-:shortdesc: "An IPv6 address to assign to the instance through DHCP (can be `none` to restrict all IPv6 traffic when `security.ipv6_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)"
+:shortdesc: "An IPv6 address to assign to the instance through DHCP (can be `none` to disable DHCPv6 and SLAAC inside an OCI container and restrict all IPv6 traffic when `security.ipv6_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)"
 :type: "string"
 
 ```

--- a/internal/server/device/nic_bridged.go
+++ b/internal/server/device/nic_bridged.go
@@ -169,7 +169,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 		// ---
 		//  type: string
 		//  managed: no
-		//  shortdesc: An IPv4 address to assign to the instance through DHCP (can be `none` to restrict all IPv4 traffic when `security.ipv4_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)
+		//  shortdesc: An IPv4 address to assign to the instance through DHCP (can be `none` to disable DHCPv4 inside an OCI container and restrict all IPv4 traffic when `security.ipv4_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)
 		"ipv4.address",
 
 		// gendoc:generate(entity=devices, group=nic_bridged, key=ipv6.address)
@@ -177,7 +177,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 		// ---
 		//  type: string
 		//  managed: no
-		//  shortdesc: An IPv6 address to assign to the instance through DHCP (can be `none` to restrict all IPv6 traffic when `security.ipv6_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)
+		//  shortdesc: An IPv6 address to assign to the instance through DHCP (can be `none` to disable DHCPv6 and SLAAC inside an OCI container and restrict all IPv6 traffic when `security.ipv6_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)
 		"ipv6.address",
 
 		// gendoc:generate(entity=devices, group=nic_bridged, key=ipv4.gateway)
@@ -364,7 +364,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 
 		netConfig := n.Config()
 
-		if d.config["ipv4.address"] != "" && !strings.Contains(d.config["ipv4.address"], "/") {
+		if !util.IsNoneOrEmpty(d.config["ipv4.address"]) && !strings.Contains(d.config["ipv4.address"], "/") {
 			dhcpv4Subnet := n.DHCPv4Subnet()
 
 			// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs) when
@@ -375,7 +375,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if dhcpv4Subnet != nil && d.config["ipv4.address"] != "none" && !dhcpalloc.DHCPValidIP(dhcpv4Subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
+			if dhcpv4Subnet != nil && !dhcpalloc.DHCPValidIP(dhcpv4Subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], n.Name())
 			}
 
@@ -389,17 +389,13 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 				return fmt.Errorf("Invalid network ipv4.address: %w", err)
 			}
 
-			if d.config["ipv4.address"] == "none" && util.IsFalseOrEmpty(d.config["security.ipv4_filtering"]) {
-				return errors.New("Cannot have ipv4.address as none unless using security.ipv4_filtering")
-			}
-
 			// IP should not be the same as the parent managed network address.
 			if ipAddr.Equal(net.ParseIP(d.config["ipv4.address"])) {
 				return fmt.Errorf("IP address %q is assigned to parent managed network device %q", d.config["ipv4.address"], d.config["parent"])
 			}
 		}
 
-		if d.config["ipv6.address"] != "" && !strings.Contains(d.config["ipv6.address"], "/") {
+		if !util.IsNoneOrEmpty(d.config["ipv6.address"]) && !strings.Contains(d.config["ipv6.address"], "/") {
 			dhcpv6Subnet := n.DHCPv6Subnet()
 
 			// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs) when
@@ -410,7 +406,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if dhcpv6Subnet != nil && d.config["ipv6.address"] != "none" && !dhcpalloc.DHCPValidIP(dhcpv6Subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
+			if dhcpv6Subnet != nil && !dhcpalloc.DHCPValidIP(dhcpv6Subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], n.Name())
 			}
 
@@ -422,10 +418,6 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 			ipAddr, _, err := net.ParseCIDR(parentAddress)
 			if err != nil {
 				return fmt.Errorf("Invalid network ipv6.address: %w", err)
-			}
-
-			if d.config["ipv6.address"] == "none" && util.IsFalseOrEmpty(d.config["security.ipv6_filtering"]) {
-				return errors.New("Cannot have ipv6.address as none unless using security.ipv6_filtering")
 			}
 
 			// IP should not be the same as the parent managed network address.
@@ -512,7 +504,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 				if d.config["ipv4.address"] == "" {
 					return errors.New("IPv4 filtering requires a manually specified ipv4.address when using an unmanaged parent bridge")
 				}
-			} else if d.config["ipv4.address"] != "" && !strings.Contains(d.config["ipv4.address"], "/") {
+			} else if !util.IsNoneOrEmpty(d.config["ipv4.address"]) && !strings.Contains(d.config["ipv4.address"], "/") {
 				// Static IP cannot be used with unmanaged parent.
 				return errors.New("Cannot use manually specified ipv4.address when using unmanaged parent bridge")
 			}
@@ -521,7 +513,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader, partialValid
 				if d.config["ipv6.address"] == "" {
 					return errors.New("IPv6 filtering requires a manually specified ipv6.address when using an unmanaged parent bridge")
 				}
-			} else if d.config["ipv6.address"] != "" && !strings.Contains(d.config["ipv6.address"], "/") {
+			} else if !util.IsNoneOrEmpty(d.config["ipv6.address"]) && !strings.Contains(d.config["ipv6.address"], "/") {
 				// Static IP cannot be used with unmanaged parent.
 				return errors.New("Cannot use manually specified ipv6.address when using unmanaged parent bridge")
 			}

--- a/internal/server/ip/addr.go
+++ b/internal/server/ip/addr.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 // Addr represents arguments for address protocol manipulation.
@@ -55,6 +56,32 @@ func (a *Addr) scopeNum() (int, error) {
 	}
 
 	return int(scope), nil
+}
+
+// FlushDynamic removes all non-permanent addresses from the device.
+func (a *Addr) FlushDynamic() error {
+	link, err := linkByName(a.DevName)
+	if err != nil {
+		return err
+	}
+
+	addrs, err := netlink.AddrList(link, int(a.Family))
+	if err != nil {
+		return fmt.Errorf("Failed to get addresses for device %s: %w", a.DevName, err)
+	}
+
+	for _, addr := range addrs {
+		if addr.Flags&unix.IFA_F_PERMANENT != 0 {
+			continue
+		}
+
+		err := netlink.AddrDel(link, &addr)
+		if err != nil {
+			return fmt.Errorf("Failed to delete address %v: %w", addr, err)
+		}
+	}
+
+	return nil
 }
 
 // Flush flushes protocol addresses.

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -664,7 +664,7 @@
 						"ipv4.address": {
 							"longdesc": "",
 							"managed": "no",
-							"shortdesc": "An IPv4 address to assign to the instance through DHCP (can be `none` to restrict all IPv4 traffic when `security.ipv4_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)",
+							"shortdesc": "An IPv4 address to assign to the instance through DHCP (can be `none` to disable DHCPv4 inside an OCI container and restrict all IPv4 traffic when `security.ipv4_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)",
 							"type": "string"
 						}
 					},
@@ -696,7 +696,7 @@
 						"ipv6.address": {
 							"longdesc": "",
 							"managed": "no",
-							"shortdesc": "An IPv6 address to assign to the instance through DHCP (can be `none` to restrict all IPv6 traffic when `security.ipv6_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)",
+							"shortdesc": "An IPv6 address to assign to the instance through DHCP (can be `none` to disable DHCPv6 and SLAAC inside an OCI container and restrict all IPv6 traffic when `security.ipv6_filtering` is set, or a CIDR value to statically configure the address inside an OCI container)",
 							"type": "string"
 						}
 					},


### PR DESCRIPTION
The validation logic already mostly allowed a `none` value for ipv4.address/ipv6.address with OCI containers, but the ipv4.address case was still hitting some validation errors further down the line depending on the network type and ipv6.address would skip DHCPv6 but not prevent SLAAC (also a problem with a static address).