### PR TITLE
shared/cmd: Fix progress rendering on non-terminals

### DIFF
--- a/shared/cmd/progress.go
+++ b/shared/cmd/progress.go
@@ -106,9 +106,9 @@ func (p *ProgressRenderer) Update(status string) {
 	if p.terminal == 0 {
 		if !termios.IsTerminal(int(os.Stdout.Fd())) {
 			p.terminal = -1
+		} else {
+			p.terminal = 1
 		}
-
-		p.terminal = 1
 	}
 
 	if p.terminal != 1 {


### PR DESCRIPTION
`p.terminal = 1` sat outside the `!IsTerminal` branch and overwrote the `-1` it had just set, so `if p.terminal != 1` never fired and progress repaints were written to pipes and log files.