### PR TITLE
Manipulate NVRAM through initial keys

### DIFF
--- a/cmd/incus/low_level.go
+++ b/cmd/incus/low_level.go
@@ -1131,24 +1131,6 @@ func (c *cmdLowLevelSecureBoot) command() *cobra.Command {
 	return cmd
 }
 
-// eslGUIDVar gets the GUID and variable name associated to the given ESL.
-func eslGUIDVar(esl string) (string, string) {
-	var guid, varName string
-	switch esl {
-	case "pk", "kek":
-		guid = uefi.EfiGlobalVariableGuid
-		varName = strings.ToUpper(esl)
-	case "db", "dbx", "dbt":
-		guid = uefi.EfiImageSecurityDatabaseGuid
-		varName = esl
-	case "mok":
-		guid = uefi.ShimLockGuid
-		varName = "MokList"
-	}
-
-	return guid, varName
-}
-
 // Add.
 type cmdLowLevelSecureBootAdd struct {
 	global *cmdGlobal
@@ -1192,7 +1174,7 @@ func (c *cmdLowLevelSecureBootAdd) run(cmd *cobra.Command, args []string) error 
 
 	d := parsed[0].RemoteServer
 	instanceName := parsed[0].RemoteObject.String
-	guid, varName := eslGUIDVar(parsed[1].String)
+	guid, varName := util.ESLGUIDVar(parsed[1].String)
 	fileName := parsed[2].String
 	var input []byte
 	if fileName == "-" && !termios.IsTerminal(getStdinFd()) {
@@ -1505,7 +1487,7 @@ func (c *cmdLowLevelSecureBootList) run(cmd *cobra.Command, args []string) error
 
 	d := parsed[0].RemoteServer
 	instanceName := parsed[0].RemoteObject.String
-	guid, varName := eslGUIDVar(parsed[1].String)
+	guid, varName := util.ESLGUIDVar(parsed[1].String)
 
 	v, _, err := d.GetInstanceNVRAMGUIDVar(instanceName, guid, varName)
 	if err != nil {
@@ -1603,7 +1585,7 @@ func (c *cmdLowLevelSecureBootRemove) run(cmd *cobra.Command, args []string) err
 
 	d := parsed[0].RemoteServer
 	instanceName := parsed[0].RemoteObject.String
-	guid, varName := eslGUIDVar(parsed[1].String)
+	guid, varName := util.ESLGUIDVar(parsed[1].String)
 	hasFingerprint := parsed[2].BranchID == 0
 	var fingerprint string
 	if hasFingerprint {

--- a/cmd/incus/low_level.go
+++ b/cmd/incus/low_level.go
@@ -1166,7 +1166,7 @@ func (c *cmdLowLevelSecureBootAdd) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(color.DescriptionPrefix, i18n.G(`Add Secure Boot signatures`))
 
 	cmd.RunE = c.run
-	cli.AddStringFlag(cmd.Flags(), &c.flagOwner, "owner", "OVMF", "", i18n.G("Set the signature owner"))
+	cli.AddStringFlag(cmd.Flags(), &c.flagOwner, "owner", "Incus", "", i18n.G("Set the signature owner"))
 	cli.AddStringFlag(cmd.Flags(), &c.flagType, "type", "", "", i18n.G("Don’t import the file as a certificate but rather compute and import its digest (sha256|sha384|sha512)"))
 
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -3428,3 +3428,9 @@ Adds a new `ceph.rbd.backend` configuration key to the Ceph RBD storage driver.
 When set to `librbd`, volumes are accessed through `librbd` rather than the
 RBD kernel driver, with `qemu-nbd` being used whenever a block device is
 needed on the host.
+
+## `instance_nvram_config`
+
+This adds three categories of initial configuration options, `initial.nvram.*`,
+`initial.nvram-binary.*` and `initial.secureboot`, which allow defining default
+NVRAM variables and Secure Boot certificates and keys when rebuilding the NVRAM.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -2552,6 +2552,22 @@ Override the UID of the process run in an OCI container.
 
 <!-- config group instance-oci end -->
 <!-- config group instance-raw start -->
+```{config:option} initial.nvram-binary.<GUID>.<name> instance-raw
+:condition: "virtual machine"
+:liveupdate: "yes"
+:shortdesc: "Base64-encoded NVRAM variable value to set when generating the NVRAM, optionally prefixed by its attributes"
+:type: "blob"
+Base64-encoded variable value to set when generating the NVRAM, optionally prefixed by `<attributes>:`, with `<attributes>` an integer.
+```
+
+```{config:option} initial.nvram.<GUID>.<name> instance-raw
+:condition: "virtual machine"
+:liveupdate: "yes"
+:shortdesc: "Dissected NVRAM variable value to set when generating the NVRAM"
+:type: "blob"
+
+```
+
 ```{config:option} raw.apparmor instance-raw
 :liveupdate: "yes"
 :shortdesc: "AppArmor profile entries"
@@ -2820,6 +2836,54 @@ If left empty, no limit is set.
 
 <!-- config group instance-resource-limits end -->
 <!-- config group instance-security start -->
+```{config:option} initial.secureboot.db instance-security
+:condition: "virtual machine"
+:liveupdate: "yes"
+:shortdesc: "Initial authorized signature database entries to enroll when generating the NVRAM (PEM certificate and signature bundle)"
+:type: "string"
+This option accepts signatures armored with `SIGNATURE` in addition to certificates.
+```
+
+```{config:option} initial.secureboot.dbt instance-security
+:condition: "virtual machine"
+:liveupdate: "yes"
+:shortdesc: "Initial authorized timestamp signature database certificates to enroll when generating the NVRAM (PEM certificate bundle)"
+:type: "string"
+
+```
+
+```{config:option} initial.secureboot.dbx instance-security
+:condition: "virtual machine"
+:liveupdate: "yes"
+:shortdesc: "Initial forbidden signature database entries to enroll when generating the NVRAM (PEM certificate and signature bundle)"
+:type: "string"
+This option accepts signatures armored with `SIGNATURE` in addition to certificates.
+```
+
+```{config:option} initial.secureboot.kek instance-security
+:condition: "virtual machine"
+:liveupdate: "yes"
+:shortdesc: "Initial key exchange keys to enroll when generating the NVRAM (PEM certificate bundle)"
+:type: "string"
+
+```
+
+```{config:option} initial.secureboot.mok instance-security
+:condition: "virtual machine"
+:liveupdate: "yes"
+:shortdesc: "Initial machine owner key entries to enroll when generating the NVRAM (PEM certificate and signature bundle)"
+:type: "string"
+This option accepts signatures armored with `SIGNATURE` in addition to certificates.
+```
+
+```{config:option} initial.secureboot.pk instance-security
+:condition: "virtual machine"
+:liveupdate: "yes"
+:shortdesc: "Initial platform key to enroll when generating the NVRAM (PEM certificate)"
+:type: "string"
+
+```
+
 ```{config:option} security.agent.metrics instance-security
 :condition: "virtual machine"
 :defaultdesc: "`true`"

--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -1187,6 +1187,60 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 
 // InstanceConfigKeysVM is a map of config key to validator. (keys applying to VM only).
 var InstanceConfigKeysVM = map[string]func(value string) error{
+	// gendoc:generate(entity=instance, group=security, key=initial.secureboot.pk)
+	//
+	// ---
+	//  type: string
+	//  liveupdate: yes
+	//  condition: virtual machine
+	//  shortdesc: Initial platform key to enroll when generating the NVRAM (PEM certificate)
+	"initial.secureboot.pk": validate.IsPEM(false),
+
+	// gendoc:generate(entity=instance, group=security, key=initial.secureboot.kek)
+	//
+	// ---
+	//  type: string
+	//  liveupdate: yes
+	//  condition: virtual machine
+	//  shortdesc: Initial key exchange keys to enroll when generating the NVRAM (PEM certificate bundle)
+	"initial.secureboot.kek": validate.IsPEM(true),
+
+	// gendoc:generate(entity=instance, group=security, key=initial.secureboot.db)
+	// This option accepts signatures armored with `SIGNATURE` in addition to certificates.
+	// ---
+	//  type: string
+	//  liveupdate: yes
+	//  condition: virtual machine
+	//  shortdesc: Initial authorized signature database entries to enroll when generating the NVRAM (PEM certificate and signature bundle)
+	"initial.secureboot.db": validate.IsPEM(true, "CERTIFICATE", "SIGNATURE"),
+
+	// gendoc:generate(entity=instance, group=security, key=initial.secureboot.dbx)
+	// This option accepts signatures armored with `SIGNATURE` in addition to certificates.
+	// ---
+	//  type: string
+	//  liveupdate: yes
+	//  condition: virtual machine
+	//  shortdesc: Initial forbidden signature database entries to enroll when generating the NVRAM (PEM certificate and signature bundle)
+	"initial.secureboot.dbx": validate.IsPEM(true, "CERTIFICATE", "SIGNATURE"),
+
+	// gendoc:generate(entity=instance, group=security, key=initial.secureboot.dbt)
+	//
+	// ---
+	//  type: string
+	//  liveupdate: yes
+	//  condition: virtual machine
+	//  shortdesc: Initial authorized timestamp signature database certificates to enroll when generating the NVRAM (PEM certificate bundle)
+	"initial.secureboot.dbt": validate.IsPEM(true),
+
+	// gendoc:generate(entity=instance, group=security, key=initial.secureboot.mok)
+	// This option accepts signatures armored with `SIGNATURE` in addition to certificates.
+	// ---
+	//  type: string
+	//  liveupdate: yes
+	//  condition: virtual machine
+	//  shortdesc: Initial machine owner key entries to enroll when generating the NVRAM (PEM certificate and signature bundle)
+	"initial.secureboot.mok": validate.IsPEM(true, "CERTIFICATE", "SIGNATURE"),
+
 	// gendoc:generate(entity=instance, group=resource-limits, key=limits.memory.hotplug)
 	// If this option is set to `false`, disable memory hotplug entirely.
 	// Alternatively, it can be set to a bytes value which will define an upper limit for hotplugged memory.
@@ -1426,6 +1480,61 @@ func ConfigKeyChecker(key string, instanceType api.InstanceType) (func(value str
 		f, ok := InstanceConfigKeysVM[key]
 		if ok {
 			return f, nil
+		}
+
+		parts := strings.SplitN(key, ".", 4)
+		if len(parts) == 4 && (strings.HasPrefix(key, "initial.nvram.") || strings.HasPrefix(key, "initial.nvram-binary.")) {
+			// Reject GUIDs that don’t follow the strict lowercase 8-4-4-4-12 format, to avoid costly
+			// checks for duplicates.
+			validGUID := true
+			guid := parts[2]
+			if len(guid) != 36 {
+				validGUID = false
+			} else {
+			out:
+				for i := 0; i < len(guid); i++ {
+					switch i {
+					case 8, 13, 18, 23:
+						if guid[i] != '-' {
+							validGUID = false
+							break out
+						}
+
+					default:
+						c := guid[i]
+						if (c < '0' || c > '9') && (c < 'a' && c > 'f') {
+							validGUID = false
+							break out
+						}
+					}
+				}
+			}
+
+			if !validGUID {
+				return nil, fmt.Errorf("Invalid configuration key %s: invalid GUID", key)
+			}
+
+			if strings.HasPrefix(key, "initial.nvram.") {
+				// gendoc:generate(entity=instance, group=raw, key=initial.nvram.<GUID>.<name>)
+				//
+				// ---
+				//  type: blob
+				//  liveupdate: yes
+				//  condition: virtual machine
+				//  shortdesc: Dissected NVRAM variable value to set when generating the NVRAM
+				return validate.IsAny, nil
+			}
+
+			if strings.HasPrefix(key, "initial.nvram-binary.") {
+				// gendoc:generate(entity=instance, group=raw, key=initial.nvram-binary.<GUID>.<name>)
+				// Base64-encoded variable value to set when generating the NVRAM, optionally prefixed by `<attributes>:`, with `<attributes>` an integer.
+				// ---
+				//  type: blob
+				//  liveupdate: yes
+				//  condition: virtual machine
+				//  shortdesc: Base64-encoded NVRAM variable value to set when generating the NVRAM, optionally prefixed by its attributes
+				return validate.IsRawNVRAMVariable, nil
+			}
 		}
 	}
 

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -10,6 +10,7 @@ import (
 	"embed"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -2629,6 +2630,14 @@ func (d *qemu) setupNvram() error {
 		return err
 	}
 
+	// Get the configured NVRAM defaults.
+	nvramDefaults := map[string]string{}
+	for k, v := range d.expandedConfig {
+		if strings.HasPrefix(k, "initial.nvram.") || strings.HasPrefix(k, "initial.nvram-binary.") || strings.HasPrefix(k, "initial.secureboot.") {
+			nvramDefaults[k] = v
+		}
+	}
+
 	// Unified firmware images (e.g. AMD SEV) carry their own variable store and need no NVRAM.
 	needsNvram := false
 	for _, firmware := range firmwares {
@@ -2639,6 +2648,10 @@ func (d *qemu) setupNvram() error {
 	}
 
 	if !needsNvram {
+		if len(nvramDefaults) > 0 {
+			return errors.New("The selected firmware doesn’t include a NVRAM but NVRAM modifications are required")
+		}
+
 		return nil
 	}
 
@@ -2674,18 +2687,132 @@ func (d *qemu) setupNvram() error {
 
 	nvramPath := d.nvramPath()
 
-	// Handle the case where the firmware vars filename matches our internal one.
-	if efiVarsName == filepath.Base(nvramPath) {
-		return nil
+	if efiVarsName != filepath.Base(nvramPath) {
+		// Generate a symlink.
+		// This is so qemu.nvram can always be assumed to be the EDK2 vars file.
+		// The real file name is then used to determine what firmware must be selected.
+		_ = os.Remove(nvramPath)
+		err = os.Symlink(efiVarsName, nvramPath)
+		if err != nil {
+			return err
+		}
 	}
 
-	// Generate a symlink.
-	// This is so qemu.nvram can always be assumed to be the EDK2 vars file.
-	// The real file name is then used to determine what firmware must be selected.
-	_ = os.Remove(nvramPath)
-	err = os.Symlink(efiVarsName, nvramPath)
-	if err != nil {
-		return err
+	// Initialize the configured NVRAM defaults.
+	if len(nvramDefaults) > 0 {
+		nvram, err := d.getNVRAM()
+		if err != nil {
+			return err
+		}
+
+		for k, raw := range nvramDefaults {
+			var v api.InstanceNVRAMVariable
+			parts := strings.SplitN(k, ".", 4)
+			var guid, varName string
+			if strings.HasPrefix(k, "initial.nvram.") {
+				if len(parts) != 4 {
+					return fmt.Errorf("Unknown key %q", k)
+				}
+
+				guid = parts[2]
+				varName = parts[3]
+				var vPut api.InstanceNVRAMVariablePut
+				err = json.Unmarshal([]byte(raw), &vPut)
+				if err != nil {
+					return err
+				}
+
+				v.InstanceNVRAMVariablePut = vPut
+			} else if strings.HasPrefix(k, "initial.nvram-binary.") {
+				if len(parts) != 4 {
+					return fmt.Errorf("Unknown key %q", k)
+				}
+
+				guid = parts[2]
+				varName = parts[3]
+				varParts := strings.SplitN(raw, ":", 2)
+				if len(varParts) == 1 {
+					v.Attributes = []string{"NON_VOLATILE", "BOOTSERVICE_ACCESS", "RUNTIME_ACCESS"}
+				} else {
+					attributes, err := strconv.ParseUint(varParts[0], 0, 32)
+					if err != nil {
+						return fmt.Errorf("Invalid attribute value for %q: %q", k, varParts[0])
+					}
+
+					v.Attributes = uefi.ParseAttributes(uint32(attributes))
+				}
+
+				value := varParts[len(varParts)-1]
+				v.Binary, err = base64.RawStdEncoding.DecodeString(strings.TrimRight(value, "="))
+				if err != nil {
+					return fmt.Errorf("Invalid base64 value for %q: %q", k, value)
+				}
+			} else if strings.HasPrefix(k, "initial.secureboot.") {
+				guid, varName = util.ESLGUIDVar(parts[2])
+				var esl uefi.ESL
+				if varName == "MokList" {
+					v.Attributes = []string{"NON_VOLATILE", "BOOTSERVICE_ACCESS"}
+				} else {
+					now := time.Now().UTC()
+					v.Attributes = []string{"NON_VOLATILE", "BOOTSERVICE_ACCESS", "RUNTIME_ACCESS", "TIME_BASED_AUTHENTICATED_WRITE_ACCESS"}
+					v.Timestamp = &now
+				}
+
+				rest := []byte(raw)
+				ok := false
+				var block *pem.Block
+				for {
+					block, rest = pem.Decode(rest)
+					if block == nil {
+						break
+					}
+
+					switch block.Type {
+					case "CERTIFICATE":
+						cert, err := x509.ParseCertificate(block.Bytes)
+						if err != nil {
+							return fmt.Errorf("Invalid PEM certificate in %q: %w", k, err)
+						}
+
+						esl = append(esl, uefi.ESLNode{Entries: []uefi.ESLEntry{{Owner: uefi.IncusVendorGuid, Data: cert.Raw}}, Type: "x509"})
+					case "SIGNATURE":
+						eslNode := uefi.ESLNode{Entries: []uefi.ESLEntry{{Owner: uefi.IncusVendorGuid, Data: block.Bytes}}}
+						switch len(block.Bytes) {
+						case 32:
+							eslNode.Type = "sha256"
+						case 48:
+							eslNode.Type = "sha384"
+						case 64:
+							eslNode.Type = "sha512"
+						default:
+							return fmt.Errorf("Unexpected signature length %d in %q", len(block.Bytes), k)
+						}
+
+						esl = append(esl, eslNode)
+					default:
+						return fmt.Errorf("Unknown armor %s in %q", block.Type, k)
+					}
+
+					ok = true
+				}
+
+				if !ok {
+					return fmt.Errorf("Invalid PEM data in %q", k)
+				}
+
+				v.Data = esl
+			}
+
+			err = nvram.Set(guid, varName, v)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = d.setNVRAM(nvram)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -7071,6 +7198,8 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 			"cloud-init.",
 			"environment.",
 			"image.",
+			"initial.nvram.",
+			"initial.secureboot.",
 			"snapshots.",
 			"user.",
 			"volatile.",

--- a/internal/server/instance/instance_utils.go
+++ b/internal/server/instance/instance_utils.go
@@ -100,6 +100,11 @@ func ValidConfig(sysOS *sys.OS, config map[string]string, expanded bool, instanc
 		if ok && config["systemd.credential-binary."+after] != "" {
 			return fmt.Errorf("Mutually exclusive keys %s and systemd.credential-binary.%s are set", k, after)
 		}
+
+		after, ok = strings.CutPrefix(k, "initial.nvram.")
+		if ok && config["initial.nvram-binary."+after] != "" {
+			return fmt.Errorf("Mutually exclusive keys %s and initial.nvram-binary.%s are set", k, after)
+		}
 	}
 
 	_, rawSeccomp := config["raw.seccomp"]

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -2881,6 +2881,24 @@
 			"raw": {
 				"keys": [
 					{
+						"initial.nvram-binary.\u003cGUID\u003e.\u003cname\u003e": {
+							"condition": "virtual machine",
+							"liveupdate": "yes",
+							"longdesc": "Base64-encoded variable value to set when generating the NVRAM, optionally prefixed by `\u003cattributes\u003e:`, with `\u003cattributes\u003e` an integer.",
+							"shortdesc": "Base64-encoded NVRAM variable value to set when generating the NVRAM, optionally prefixed by its attributes",
+							"type": "blob"
+						}
+					},
+					{
+						"initial.nvram.\u003cGUID\u003e.\u003cname\u003e": {
+							"condition": "virtual machine",
+							"liveupdate": "yes",
+							"longdesc": "",
+							"shortdesc": "Dissected NVRAM variable value to set when generating the NVRAM",
+							"type": "blob"
+						}
+					},
+					{
 						"raw.apparmor": {
 							"liveupdate": "yes",
 							"longdesc": "The specified entries are appended to the generated profile.",
@@ -3137,6 +3155,60 @@
 			},
 			"security": {
 				"keys": [
+					{
+						"initial.secureboot.db": {
+							"condition": "virtual machine",
+							"liveupdate": "yes",
+							"longdesc": "This option accepts signatures armored with `SIGNATURE` in addition to certificates.",
+							"shortdesc": "Initial authorized signature database entries to enroll when generating the NVRAM (PEM certificate and signature bundle)",
+							"type": "string"
+						}
+					},
+					{
+						"initial.secureboot.dbt": {
+							"condition": "virtual machine",
+							"liveupdate": "yes",
+							"longdesc": "",
+							"shortdesc": "Initial authorized timestamp signature database certificates to enroll when generating the NVRAM (PEM certificate bundle)",
+							"type": "string"
+						}
+					},
+					{
+						"initial.secureboot.dbx": {
+							"condition": "virtual machine",
+							"liveupdate": "yes",
+							"longdesc": "This option accepts signatures armored with `SIGNATURE` in addition to certificates.",
+							"shortdesc": "Initial forbidden signature database entries to enroll when generating the NVRAM (PEM certificate and signature bundle)",
+							"type": "string"
+						}
+					},
+					{
+						"initial.secureboot.kek": {
+							"condition": "virtual machine",
+							"liveupdate": "yes",
+							"longdesc": "",
+							"shortdesc": "Initial key exchange keys to enroll when generating the NVRAM (PEM certificate bundle)",
+							"type": "string"
+						}
+					},
+					{
+						"initial.secureboot.mok": {
+							"condition": "virtual machine",
+							"liveupdate": "yes",
+							"longdesc": "This option accepts signatures armored with `SIGNATURE` in addition to certificates.",
+							"shortdesc": "Initial machine owner key entries to enroll when generating the NVRAM (PEM certificate and signature bundle)",
+							"type": "string"
+						}
+					},
+					{
+						"initial.secureboot.pk": {
+							"condition": "virtual machine",
+							"liveupdate": "yes",
+							"longdesc": "",
+							"shortdesc": "Initial platform key to enroll when generating the NVRAM (PEM certificate)",
+							"type": "string"
+						}
+					},
 					{
 						"security.agent.metrics": {
 							"condition": "virtual machine",

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -571,6 +571,7 @@ var APIExtensions = []string{
 	"network_ipv6_ra",
 	"qemu_scriptlet_nvram",
 	"storage_ceph_rbd_backend",
+	"instance_nvram_config",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:05+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 "
 "<nlincus@users.noreply.hosted.weblate.org>\n"
@@ -695,8 +695,8 @@ msgstr "Fehler: %v\n"
 msgid "(no timestamp)"
 msgstr "Zeitstempel:\n"
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Akzeptiere Zertifikat"
@@ -804,7 +804,7 @@ msgstr "--target kann nicht mit Instanzen verwendet werden"
 msgid "--override-boot only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -863,7 +863,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -953,7 +953,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Action %q isn't supported by this tool"
 msgstr "Aktion %q wird von diesem Programm nicht unterstützt"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1604,7 +1604,7 @@ msgstr "Kann --volume-only nicht setzen, wenn ein Snapshot kopiert wird"
 msgid "Cannot set key: %s"
 msgstr "Kann Schlüssel nicht setzen: %s"
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1785,7 +1785,7 @@ msgstr "Clustering aktiviert"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2744,7 +2744,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2938,7 +2938,7 @@ msgstr "Alternatives config Verzeichnis."
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3321,7 +3321,7 @@ msgstr "DATEINAME"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 #, fuzzy
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -3436,7 +3436,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed parsing validation response: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3644,7 +3644,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to open target file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3654,7 +3654,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to parse dump response: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3918,7 +3918,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4403,7 +4403,7 @@ msgstr "Profil %s erstellt\n"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -4587,7 +4587,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "Akzeptiere Zertifikat"
@@ -4917,11 +4917,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6860,7 +6860,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6900,11 +6900,11 @@ msgstr "Fingerabdruck: %s\n"
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6933,11 +6933,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -7396,7 +7396,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -7554,7 +7554,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 #, fuzzy
 msgid "Remove all signatures"
 msgstr "Entferntes Administrator Passwort"
@@ -7953,7 +7953,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -8420,7 +8420,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 #, fuzzy
 msgid "Set the signature owner"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -8454,7 +8454,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -9019,7 +9019,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -9130,12 +9130,12 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "Ein Client Zertifikat ist bereits erstellt worden"
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "Ein Client Zertifikat ist bereits erstellt worden"
@@ -9592,19 +9592,19 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Unable to parse %s as valid JSON"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -9638,7 +9638,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -9678,7 +9678,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, fuzzy, c-format
 msgid "Unknown signature type %s"
 msgstr "Unbekannter Befehl %s für Abbild"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:14+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/incus/cli/el/>\n"
@@ -435,8 +435,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 msgid "(not a certificate)"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "--override-boot only works with a single instance"
 msgstr ""
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1254,7 +1254,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2455,7 +2455,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -2766,7 +2766,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, c-format
 msgid "Failed reading input file: %w"
 msgstr ""
@@ -3087,7 +3087,7 @@ msgstr ""
 msgid "Failed to open target file %q: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr ""
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3360,7 +3360,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -3810,7 +3810,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -3986,7 +3986,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 msgid "Input file contains no certificate"
 msgstr ""
 
@@ -4301,11 +4301,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6148,7 +6148,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6187,11 +6187,11 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6220,11 +6220,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -6659,7 +6659,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -6811,7 +6811,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -6847,7 +6847,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7176,7 +7176,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -7598,7 +7598,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -7631,7 +7631,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8151,7 +8151,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8258,11 +8258,11 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 msgid "The given certificate is already present in this ESL"
 msgstr ""
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 msgid "The given signature is already present in this ESL"
 msgstr ""
 
@@ -8709,19 +8709,19 @@ msgstr ""
 msgid "Unable to parse %s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr ""
@@ -8753,7 +8753,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -8793,7 +8793,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:05+0000\n"
 "Last-Translator: Kazantsev Mikhail <kazan417@mail.ru>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/incus/cli/es/>\n"
@@ -693,8 +693,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Acepta certificado"
@@ -800,7 +800,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--override-boot only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -945,7 +945,7 @@ msgstr "condición"
 msgid "Action %q isn't supported by this tool"
 msgstr "El filtrado no está soportado aún"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1550,7 +1550,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1728,7 +1728,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2636,7 +2636,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2817,7 +2817,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3138,7 +3138,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
@@ -3251,7 +3251,7 @@ msgstr "Acepta certificado"
 msgid "Failed parsing validation response: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "No se peude leer desde stdin: %s"
@@ -3459,7 +3459,7 @@ msgstr "Acepta certificado"
 msgid "Failed to open target file %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Acepta certificado"
@@ -3469,7 +3469,7 @@ msgstr "Acepta certificado"
 msgid "Failed to parse dump response: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3733,7 +3733,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4210,7 +4210,7 @@ msgstr "Expira: %s"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -4392,7 +4392,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "Acepta certificado"
@@ -4716,11 +4716,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6618,7 +6618,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6658,11 +6658,11 @@ msgstr "Versión de CUDA: %v"
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6691,11 +6691,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -7144,7 +7144,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -7301,7 +7301,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -7340,7 +7340,7 @@ msgstr "Aliases:"
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7688,7 +7688,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -8131,7 +8131,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -8164,7 +8164,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8708,7 +8708,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8817,12 +8817,12 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "Certificado del cliente almacenado en el servidor: "
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -9275,19 +9275,19 @@ msgstr "Acepta certificado"
 msgid "Unable to parse %s as valid JSON"
 msgstr "Acepta certificado"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "Acepta certificado"
@@ -9320,7 +9320,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -9360,7 +9360,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:06+0000\n"
 "Last-Translator: Varlorg <varlorg@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -706,8 +706,8 @@ msgstr "erreur : %v"
 msgid "(no timestamp)"
 msgstr "Horodatage :"
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Certificat invalide"
@@ -811,7 +811,7 @@ msgstr "--target ne peut pas être utilisé avec des instances"
 msgid "--override-boot only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -869,7 +869,7 @@ msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 msgid "=> Query %d:"
 msgstr "=> Requête %d :"
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -954,7 +954,7 @@ msgstr "Action"
 msgid "Action %q isn't supported by this tool"
 msgstr "L'action '%q' n'est pas supporté par le serveur"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 msgid "Cannot set key: %s"
 msgstr "Impossible de définir cette clef : %s"
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1763,7 +1763,7 @@ msgstr "Clustering activé"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2687,7 +2687,7 @@ msgstr "Ne pas demander de confirmation de l’utilisateur pour utiliser --force
 msgid "Don't show progress information"
 msgstr "Ne pas afficher les informations sur l'état d'avancement"
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2868,7 +2868,7 @@ msgstr "Clé de configuration invalide"
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3256,7 +3256,7 @@ msgstr "FICHIER"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -3373,7 +3373,7 @@ msgstr "Échec de l’analyse de la clef d’hôte SSH : %w"
 msgid "Failed parsing validation response: %w"
 msgstr "Échec de l'analyse de la réponse de validation : %w"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "Échec de la lecture à partir de l'entrée standard : %w"
@@ -3585,7 +3585,7 @@ msgstr "Impossible d’ouvrir le fichier source %q : %v"
 msgid "Failed to open target file %q: %w"
 msgstr "Échec de la fermeture du fichier de certificat du serveur %q : %w"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Échec de la création du certificat : %w"
@@ -3595,7 +3595,7 @@ msgstr "Échec de la création du certificat : %w"
 msgid "Failed to parse dump response: %w"
 msgstr "Échec de l'analyse de la réponse du dump : %w"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3885,7 +3885,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4384,7 +4384,7 @@ msgstr "Adresses IPv6 d’uplink"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 #, fuzzy
 msgid "ISSUER"
 msgstr "DATE D'ÉMISSION"
@@ -4580,7 +4580,7 @@ msgstr "Données d'entrée"
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "Générer le certificat client"
@@ -4927,11 +4927,11 @@ msgstr ""
 " – t : type\n"
 " – L : localisation du bail DHCP (membre du cluster)"
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 #, fuzzy
 msgid ""
 "List Secure Boot signatures\n"
@@ -7403,7 +7403,7 @@ msgstr "Aucun port correspondant n’a été trouvé"
 msgid "No matching rule(s) found"
 msgstr "Aucune règle correspondante n’a été trouvée"
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -7444,11 +7444,11 @@ msgstr "Version de l’OS"
 msgid "OVN:"
 msgstr "OVN :"
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 #, fuzzy
 msgid "OWNER GUID NAME"
 msgstr "NOM"
@@ -7483,11 +7483,11 @@ msgstr ""
 "Seule l’une des options --storage-create-device et --storage-create-loop "
 "peut être spécifiée"
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -7940,7 +7940,7 @@ msgstr "Le chemin de la requête doit commencer par « / »"
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -8104,7 +8104,7 @@ msgstr ""
 "Supprimer %s et tout ce qu’il contient (instances, images, volumes, "
 "réseaux…) (oui/non) : "
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 #, fuzzy
 msgid "Remove Secure Boot signatures"
 msgstr "Supprimer un serveur distant"
@@ -8143,7 +8143,7 @@ msgstr "Création du conteneur"
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 #, fuzzy
 msgid "Remove all signatures"
 msgstr "Mot de passe de l'administrateur distant"
@@ -8496,7 +8496,7 @@ msgstr "VOLUMES DE STOCKAGE"
 msgid "STP"
 msgstr "STP"
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -8942,7 +8942,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 #, fuzzy
 msgid "Set the signature owner"
 msgstr "Copie de l'image : %s"
@@ -8976,7 +8976,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -9519,7 +9519,7 @@ msgstr "JETON"
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -9630,12 +9630,12 @@ msgstr "Les pools de stockage inconnus suivants ont été trouvés :"
 msgid "The following unknown volumes have been found:"
 msgstr "Les volumes inconnus suivants ont été trouvés :"
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "Un certificat client est déjà présent"
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "Un certificat client est déjà présent"
@@ -10119,19 +10119,19 @@ msgstr "Échec de l’analyse du preseed : %w"
 msgid "Unable to parse %s as valid JSON"
 msgstr "Échec de l’analyse du preseed : %w"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "Échec de l’analyse du preseed : %w"
@@ -10164,7 +10164,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -10204,7 +10204,7 @@ msgstr "Clef inconnue : %s"
 msgid "Unknown output type %q"
 msgstr "Type de sortie inconnu : %q"
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, fuzzy, c-format
 msgid "Unknown signature type %s"
 msgstr "Type de fichier inconnu : %s"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:12+0000\n"
 "Last-Translator: Kazantsev Mikhail <kazan417@mail.ru>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -436,8 +436,8 @@ msgstr "galat: %v"
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Terima sertifikat"
@@ -537,7 +537,7 @@ msgstr "--console tidak bisa dipakai saat memaksa mematikan instansi"
 msgid "--override-boot only works with a single instance"
 msgstr "--console hanya bekerja dengan satu instansi"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -594,7 +594,7 @@ msgstr "--console tidak bisa dipakai dengan --allx"
 msgid "=> Query %d:"
 msgstr "=> Query %d:"
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -681,7 +681,7 @@ msgstr "kondisi"
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1444,7 +1444,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2309,7 +2309,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2481,7 +2481,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -2795,7 +2795,7 @@ msgstr "NAMA_BERKAS"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "SIDIKJARI"
 
@@ -2908,7 +2908,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, c-format
 msgid "Failed reading input file: %w"
 msgstr ""
@@ -3116,7 +3116,7 @@ msgstr ""
 msgid "Failed to open target file %q: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr ""
@@ -3126,7 +3126,7 @@ msgstr ""
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -3840,7 +3840,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -4017,7 +4017,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 msgid "Input file contains no certificate"
 msgstr ""
 
@@ -4334,11 +4334,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6192,7 +6192,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6231,11 +6231,11 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6264,11 +6264,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -6713,7 +6713,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -6867,7 +6867,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -6903,7 +6903,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7233,7 +7233,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -7657,7 +7657,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -7690,7 +7690,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8214,7 +8214,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8321,11 +8321,11 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 msgid "The given certificate is already present in this ESL"
 msgstr ""
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 msgid "The given signature is already present in this ESL"
 msgstr ""
 
@@ -8772,19 +8772,19 @@ msgstr ""
 msgid "Unable to parse %s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr ""
@@ -8816,7 +8816,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -8856,7 +8856,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2026-08-23 18:19-0400\n"
+        "POT-Creation-Date: 2026-08-24 00:06+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -407,7 +407,7 @@ msgstr  ""
 msgid   "(no timestamp)"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462 cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444 cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 msgid   "(not a certificate)"
 msgstr  ""
 
@@ -500,7 +500,7 @@ msgstr  ""
 msgid   "--override-boot only works with a single instance"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid   "--owner and --type require --all to be set"
 msgstr  ""
 
@@ -554,7 +554,7 @@ msgstr  ""
 msgid   "=> Query %d:"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid   "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr  ""
 
@@ -636,7 +636,7 @@ msgstr  ""
 msgid   "Action %q isn't supported by this tool"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid   "Add Secure Boot signatures"
 msgstr  ""
 
@@ -1200,7 +1200,7 @@ msgstr  ""
 msgid   "Cannot set key: %s"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid   "Cannot store a signature in PK, KEK or dbt"
 msgstr  ""
 
@@ -1328,7 +1328,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:172 cmd/incus/cluster.go:1130 cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:595 cmd/incus/image.go:1083 cmd/incus/image_alias.go:211 cmd/incus/list.go:154 cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376 cmd/incus/network.go:1054 cmd/incus/network.go:1253 cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122 cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129 cmd/incus/network_peer.go:118 cmd/incus/network_zone.go:123 cmd/incus/operation.go:152 cmd/incus/profile.go:708 cmd/incus/project.go:522 cmd/incus/remote.go:1166 cmd/incus/snapshot.go:344 cmd/incus/storage.go:666 cmd/incus/storage_bucket.go:467 cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume_bitmap.go:232 cmd/incus/storage_volume_snapshot.go:327 cmd/incus/top.go:68 cmd/incus/warning.go:98
+#: cmd/incus/cluster.go:172 cmd/incus/cluster.go:1130 cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:595 cmd/incus/image.go:1083 cmd/incus/image_alias.go:211 cmd/incus/list.go:154 cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358 cmd/incus/network.go:1054 cmd/incus/network.go:1253 cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122 cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129 cmd/incus/network_peer.go:118 cmd/incus/network_zone.go:123 cmd/incus/operation.go:152 cmd/incus/profile.go:708 cmd/incus/project.go:522 cmd/incus/remote.go:1166 cmd/incus/snapshot.go:344 cmd/incus/storage.go:666 cmd/incus/storage_bucket.go:467 cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume_bitmap.go:232 cmd/incus/storage_volume_snapshot.go:327 cmd/incus/top.go:68 cmd/incus/warning.go:98
 msgid   "Columns"
 msgstr  ""
 
@@ -2122,7 +2122,7 @@ msgstr  ""
 msgid   "Don't show progress information"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid   "Don’t import the file as a certificate but rather compute and import its digest (sha256|sha384|sha512)"
 msgstr  ""
 
@@ -2280,7 +2280,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:213 cmd/incus/cluster.go:1159 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:620 cmd/incus/image.go:1130 cmd/incus/image_alias.go:260 cmd/incus/list.go:598 cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414 cmd/incus/network.go:1101 cmd/incus/network.go:1291 cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158 cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:151 cmd/incus/network_zone.go:159 cmd/incus/operation.go:184 cmd/incus/profile.go:752 cmd/incus/project.go:563 cmd/incus/remote.go:1193 cmd/incus/snapshot.go:378 cmd/incus/storage.go:704 cmd/incus/storage_bucket.go:501 cmd/incus/storage_bucket.go:888 cmd/incus/storage_volume.go:1659 cmd/incus/storage_volume_bitmap.go:286 cmd/incus/storage_volume_snapshot.go:431 cmd/incus/top.go:96 cmd/incus/warning.go:236
+#: cmd/incus/cluster.go:213 cmd/incus/cluster.go:1159 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:620 cmd/incus/image.go:1130 cmd/incus/image_alias.go:260 cmd/incus/list.go:598 cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396 cmd/incus/network.go:1101 cmd/incus/network.go:1291 cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158 cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:151 cmd/incus/network_zone.go:159 cmd/incus/operation.go:184 cmd/incus/profile.go:752 cmd/incus/project.go:563 cmd/incus/remote.go:1193 cmd/incus/snapshot.go:378 cmd/incus/storage.go:704 cmd/incus/storage_bucket.go:501 cmd/incus/storage_bucket.go:888 cmd/incus/storage_volume.go:1659 cmd/incus/storage_volume_bitmap.go:286 cmd/incus/storage_volume_snapshot.go:431 cmd/incus/top.go:96 cmd/incus/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2544,7 +2544,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421 cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249 cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421 cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249 cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2656,7 +2656,7 @@ msgstr  ""
 msgid   "Failed parsing validation response: %w"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, c-format
 msgid   "Failed reading input file: %w"
 msgstr  ""
@@ -2860,7 +2860,7 @@ msgstr  ""
 msgid   "Failed to open target file %q: %w"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, c-format
 msgid   "Failed to parse PEM certificate: %w"
 msgstr  ""
@@ -2870,7 +2870,7 @@ msgstr  ""
 msgid   "Failed to parse dump response: %w"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid   "Failed to parse input file as either PEM or DER certificate"
 msgstr  ""
 
@@ -3114,7 +3114,7 @@ msgstr  ""
 msgid   "Format (csv|json|table|yaml|compact|markdown), use suffix \",noheader\" to disable headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:58 cmd/incus/alias.go:118 cmd/incus/cluster.go:173 cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272 cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594 cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155 cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375 cmd/incus/network.go:1055 cmd/incus/network.go:1252 cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71 cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416 cmd/incus/network_load_balancer.go:128 cmd/incus/network_peer.go:117 cmd/incus/network_zone.go:121 cmd/incus/network_zone.go:822 cmd/incus/operation.go:150 cmd/incus/profile.go:709 cmd/incus/project.go:523 cmd/incus/project.go:1000 cmd/incus/remote.go:1165 cmd/incus/snapshot.go:343 cmd/incus/storage.go:667 cmd/incus/storage_bucket.go:465 cmd/incus/storage_bucket.go:861 cmd/incus/storage_volume.go:1528 cmd/incus/storage_volume_bitmap.go:233 cmd/incus/storage_volume_snapshot.go:341 cmd/incus/warning.go:99
+#: cmd/incus/admin_sql.go:58 cmd/incus/alias.go:118 cmd/incus/cluster.go:173 cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272 cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594 cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155 cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357 cmd/incus/network.go:1055 cmd/incus/network.go:1252 cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71 cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416 cmd/incus/network_load_balancer.go:128 cmd/incus/network_peer.go:117 cmd/incus/network_zone.go:121 cmd/incus/network_zone.go:822 cmd/incus/operation.go:150 cmd/incus/profile.go:709 cmd/incus/project.go:523 cmd/incus/project.go:1000 cmd/incus/remote.go:1165 cmd/incus/snapshot.go:343 cmd/incus/storage.go:667 cmd/incus/storage_bucket.go:465 cmd/incus/storage_bucket.go:861 cmd/incus/storage_volume.go:1528 cmd/incus/storage_volume_bitmap.go:233 cmd/incus/storage_volume_snapshot.go:341 cmd/incus/warning.go:99
 msgid   "Format (csv|json|table|yaml|compact|markdown), use suffix \",noheader\" to disable headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr  ""
 
@@ -3538,7 +3538,7 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid   "ISSUER"
 msgstr  ""
 
@@ -3710,7 +3710,7 @@ msgstr  ""
 msgid   "Input data file (\"-\" for stdin)"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 msgid   "Input file contains no certificate"
 msgstr  ""
 
@@ -4017,11 +4017,11 @@ msgid   "List DHCP leases\n"
         "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid   "List Secure Boot signatures"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid   "List Secure Boot signatures\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -5776,7 +5776,7 @@ msgstr  ""
 msgid   "No matching rule(s) found"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid   "No signature matches"
 msgstr  ""
 
@@ -5813,11 +5813,11 @@ msgstr  ""
 msgid   "OVN:"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid   "OWNER GUID"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid   "OWNER GUID NAME"
 msgstr  ""
 
@@ -5845,11 +5845,11 @@ msgstr  ""
 msgid   "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid   "Only remove signatures of the given type"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid   "Only remove signatures owned by the given owner"
 msgstr  ""
 
@@ -6264,7 +6264,7 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid   "RAW VALUE"
 msgstr  ""
 
@@ -6406,7 +6406,7 @@ msgstr  ""
 msgid   "Remove %s and everything it contains (instances, images, volumes, networks, ...) (yes/no): "
 msgstr  ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid   "Remove Secure Boot signatures"
 msgstr  ""
 
@@ -6442,7 +6442,7 @@ msgstr  ""
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid   "Remove all signatures"
 msgstr  ""
 
@@ -6759,7 +6759,7 @@ msgstr  ""
 msgid   "STP"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid   "SUBJECT"
 msgstr  ""
 
@@ -7145,7 +7145,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid   "Set the signature owner"
 msgstr  ""
 
@@ -7177,7 +7177,7 @@ msgstr  ""
 msgid   "Setup loop based storage with SIZE in GiB"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid   "Several signatures match the given fingerprint"
 msgstr  ""
 
@@ -7682,7 +7682,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120 cmd/incus/image_alias.go:250 cmd/incus/list.go:555 cmd/incus/low_level.go:1406 cmd/incus/network.go:1082 cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89 cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142 cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629 cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120 cmd/incus/image_alias.go:250 cmd/incus/list.go:555 cmd/incus/low_level.go:1388 cmd/incus/network.go:1082 cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89 cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142 cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629 cmd/incus/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -7774,11 +7774,11 @@ msgstr  ""
 msgid   "The following unknown volumes have been found:"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 msgid   "The given certificate is already present in this ESL"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 msgid   "The given signature is already present in this ESL"
 msgstr  ""
 
@@ -8193,17 +8193,17 @@ msgstr  ""
 msgid   "Unable to parse %s as valid JSON"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527 cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509 cmd/incus/low_level.go:1621
 #, c-format
 msgid   "Unable to parse %s:%s as an EFI Signature List"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520 cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502 cmd/incus/low_level.go:1614
 #, c-format
 msgid   "Unable to parse %s:%s as valid JSON"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, c-format
 msgid   "Unable to parse owner %s: %w"
 msgstr  ""
@@ -8231,7 +8231,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:219 cmd/incus/cluster.go:1165 cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440 cmd/incus/config_trust.go:626 cmd/incus/image.go:1152 cmd/incus/image_alias.go:266 cmd/incus/list.go:616 cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420 cmd/incus/network.go:1107 cmd/incus/network.go:1297 cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164 cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170 cmd/incus/network_peer.go:157 cmd/incus/network_zone.go:165 cmd/incus/operation.go:190 cmd/incus/profile.go:758 cmd/incus/project.go:569 cmd/incus/remote.go:1199 cmd/incus/snapshot.go:384 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:507 cmd/incus/storage_bucket.go:894 cmd/incus/storage_volume.go:1665 cmd/incus/storage_volume_bitmap.go:292 cmd/incus/storage_volume_snapshot.go:437 cmd/incus/top.go:102 cmd/incus/warning.go:242
+#: cmd/incus/cluster.go:219 cmd/incus/cluster.go:1165 cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440 cmd/incus/config_trust.go:626 cmd/incus/image.go:1152 cmd/incus/image_alias.go:266 cmd/incus/list.go:616 cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402 cmd/incus/network.go:1107 cmd/incus/network.go:1297 cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164 cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170 cmd/incus/network_peer.go:157 cmd/incus/network_zone.go:165 cmd/incus/operation.go:190 cmd/incus/profile.go:758 cmd/incus/project.go:569 cmd/incus/remote.go:1199 cmd/incus/snapshot.go:384 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:507 cmd/incus/storage_bucket.go:894 cmd/incus/storage_volume.go:1665 cmd/incus/storage_volume_bitmap.go:292 cmd/incus/storage_volume_snapshot.go:437 cmd/incus/top.go:102 cmd/incus/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -8261,7 +8261,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid   "Unknown signature type %s"
 msgstr  ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:07+0000\n"
 "Last-Translator: Alberto Donato <ack@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -708,8 +708,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Accetta certificato"
@@ -806,7 +806,7 @@ msgstr ""
 msgid "--override-boot only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -861,7 +861,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -947,7 +947,7 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1543,7 +1543,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1720,7 +1720,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2628,7 +2628,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2809,7 +2809,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3128,7 +3128,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -3241,7 +3241,7 @@ msgstr "Accetta certificato"
 msgid "Failed parsing validation response: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "Impossible leggere da stdin: %s"
@@ -3449,7 +3449,7 @@ msgstr "Accetta certificato"
 msgid "Failed to open target file %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Accetta certificato"
@@ -3459,7 +3459,7 @@ msgstr "Accetta certificato"
 msgid "Failed to parse dump response: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3723,7 +3723,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4193,7 +4193,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "Accetta certificato"
@@ -4698,11 +4698,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6602,7 +6602,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6641,11 +6641,11 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6674,11 +6674,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -7126,7 +7126,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -7321,7 +7321,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -8108,7 +8108,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -8141,7 +8141,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8685,7 +8685,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8794,12 +8794,12 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "Certificato del client salvato dal server: "
@@ -9254,19 +9254,19 @@ msgstr "Accetta certificato"
 msgid "Unable to parse %s as valid JSON"
 msgstr "Accetta certificato"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "Accetta certificato"
@@ -9300,7 +9300,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -9340,7 +9340,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:07+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -694,8 +694,8 @@ msgstr "エラー: %v"
 msgid "(no timestamp)"
 msgstr "タイムスタンプ:"
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "不正な証明書です"
@@ -798,7 +798,7 @@ msgstr "--target はインスタンスでは使えません"
 msgid "--override-boot only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr "--stateless と --storage は同時に指定できません"
 msgid "=> Query %d:"
 msgstr "=> クエリ %d:"
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -944,7 +944,7 @@ msgstr "説明"
 msgid "Action %q isn't supported by this tool"
 msgstr "%q はこのツールではサポートされていません"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1564,7 +1564,7 @@ msgstr "スナップショットをコピーするときに --volume-only は指
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1742,7 +1742,7 @@ msgstr "クラスタリングが有効になりました"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2662,7 +2662,7 @@ msgstr "--force を使う際にユーザーの確認を必要としない"
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2843,7 +2843,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3222,7 +3222,7 @@ msgstr "FILENAME"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
@@ -3335,7 +3335,7 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed parsing validation response: %w"
 msgstr "バリデーションレスポンスの読み取りに失敗しました: %w"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "ファイルから読み込めません: %w"
@@ -3543,7 +3543,7 @@ msgstr "ソース側ファイルのオープンに失敗しました %q: %v"
 msgid "Failed to open target file %q: %w"
 msgstr "ターゲットファイルのオープンに失敗しました %q: %w"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
@@ -3553,7 +3553,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to parse dump response: %w"
 msgstr "ダンプレスポンスの読み取りに失敗しました: %w"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3840,7 +3840,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4324,7 +4324,7 @@ msgstr "IP アドレス"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 #, fuzzy
 msgid "ISSUER"
 msgstr "ISSUE DATE"
@@ -4525,7 +4525,7 @@ msgstr "入力するデータ"
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "クライアント証明書を生成します"
@@ -4878,11 +4878,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 #, fuzzy
 msgid ""
 "List Secure Boot signatures\n"
@@ -7555,7 +7555,7 @@ msgstr "マッチするポートが見つかりません"
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -7599,11 +7599,11 @@ msgstr "CUDA バージョン: %v"
 msgid "OVN:"
 msgstr "OVN:"
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 #, fuzzy
 msgid "OWNER GUID NAME"
 msgstr "NAME"
@@ -7637,11 +7637,11 @@ msgstr ""
 "指定できるのは、--storage-create-device もしくは --storage-create-loop のいず"
 "れか一方のみです"
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -8095,7 +8095,7 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -8264,7 +8264,7 @@ msgstr ""
 "%s とそれに含まれるすべて（インスタンス、イメージ、ボリューム、ネットワー"
 "ク、…）を削除します (yes/no): "
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 #, fuzzy
 msgid "Remove Secure Boot signatures"
 msgstr "リモートサーバを削除します"
@@ -8303,7 +8303,7 @@ msgstr "インスタンスからプロファイルを削除します"
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 #, fuzzy
 msgid "Remove all signatures"
 msgstr "エイリアスを削除します"
@@ -8656,7 +8656,7 @@ msgstr "STORAGE VOLUMES"
 msgid "STP"
 msgstr "STP"
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -9185,7 +9185,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr "インスタンスプロパティとして設定します"
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 #, fuzzy
 msgid "Set the signature owner"
 msgstr "ストレージバケットに対する鍵を作成します"
@@ -9220,7 +9220,7 @@ msgstr "DEVICE を使ってストレージベースのデバイスをセット�
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr "サイズ GiB で loop ベースのストレージをセットアップします"
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -9769,7 +9769,7 @@ msgstr "TOKEN"
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -9907,12 +9907,12 @@ msgstr "次の未知のストレージプールが見つかりました:"
 msgid "The following unknown volumes have been found:"
 msgstr "次の未知のボリュームが見つかりました:"
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "クライアント証明書はすでに存在しています"
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "クライアント証明書はすでに存在しています"
@@ -10408,19 +10408,19 @@ msgstr "事前に与える構成ファイルのパースに失敗しました: %
 msgid "Unable to parse %s as valid JSON"
 msgstr "事前に与える構成ファイルのパースに失敗しました: %w"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "事前に与える構成ファイルのパースに失敗しました: %w"
@@ -10453,7 +10453,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -10493,7 +10493,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, fuzzy, c-format
 msgid "Unknown signature type %s"
 msgstr "未知のファイルタイプ '%s'"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:14+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Georgian <https://hosted.weblate.org/projects/incus/cli/ka/>\n"
@@ -457,8 +457,8 @@ msgstr "შეცდომა: %v"
 msgid "(no timestamp)"
 msgstr "დროის შტამპები:"
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "არასწორი სერტიფიკატი"
@@ -558,7 +558,7 @@ msgstr "--target გაშვებულ ასლებთან ერთა�
 msgid "--override-boot only works with a single instance"
 msgstr "--console მხოლოდ ერთ გაშვებულ ასლთან მუშაობს"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgstr "--no-profiles -ის და --refresh -ის ერთად გამ
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -701,7 +701,7 @@ msgstr "მდგომარეობა"
 msgid "Action %q isn't supported by this tool"
 msgstr "ქმედება %q ამ პროგრამის მიერ მხარდაჭერილი არაა"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1285,7 +1285,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr "პარამეტრის დაყენების შეცდომა: %s"
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1460,7 +1460,7 @@ msgstr "კლასტერი ჩართულია"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2494,7 +2494,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -2805,7 +2805,7 @@ msgstr "ფაილის სახელი"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "თითის ანაბეჭდი"
 
@@ -2918,7 +2918,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "sshfs-ის გაშვების შეცდომა: %w"
@@ -3126,7 +3126,7 @@ msgstr ""
 msgid "Failed to open target file %q: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "sshfs-ის გაშვების შეცდომა: %w"
@@ -3136,7 +3136,7 @@ msgstr "sshfs-ის გაშვების შეცდომა: %w"
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3399,7 +3399,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -3850,7 +3850,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr "პრობლეების თარიღი"
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 #, fuzzy
 msgid "ISSUER"
 msgstr "პრობლეების თარიღი"
@@ -4027,7 +4027,7 @@ msgstr "შეყვანილი მონაცემები"
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "არასწორი სერტიფიკატი"
@@ -4343,11 +4343,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6200,7 +6200,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6239,11 +6239,11 @@ msgstr "ოს-ის ვერსია"
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 #, fuzzy
 msgid "OWNER GUID NAME"
 msgstr "სახელი"
@@ -6273,11 +6273,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -6712,7 +6712,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -6866,7 +6866,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 #, fuzzy
 msgid "Remove Secure Boot signatures"
 msgstr "დაშორებულების წაშლა"
@@ -6903,7 +6903,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr "ყველა წესის წაშლა, რომელიც ემთხვევა"
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 #, fuzzy
 msgid "Remove all signatures"
 msgstr "ფსევდონიმების წაშლა"
@@ -7233,7 +7233,7 @@ msgstr ""
 msgid "STP"
 msgstr "STP"
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -7656,7 +7656,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -7689,7 +7689,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8211,7 +8211,7 @@ msgstr "კოდი"
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8319,11 +8319,11 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 msgid "The given certificate is already present in this ESL"
 msgstr ""
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 msgid "The given signature is already present in this ESL"
 msgstr ""
 
@@ -8771,19 +8771,19 @@ msgstr "sshfs-ის გაშვების შეცდომა: %w"
 msgid "Unable to parse %s as valid JSON"
 msgstr "sshfs-ის გაშვების შეცდომა: %w"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "sshfs-ის გაშვების შეცდომა: %w"
@@ -8815,7 +8815,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -8855,7 +8855,7 @@ msgstr "უცნობი გასაღები: %s"
 msgid "Unknown output type %q"
 msgstr "უცნობი გამოტანის ტიპი %q"
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, fuzzy, c-format
 msgid "Unknown signature type %s"
 msgstr "უცნობი ფაილის ტიპი '%s'"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:11+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -455,8 +455,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 msgid "(not a certificate)"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "--override-boot only works with a single instance"
 msgstr ""
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -605,7 +605,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -690,7 +690,7 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1449,7 +1449,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2475,7 +2475,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -2786,7 +2786,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2899,7 +2899,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, c-format
 msgid "Failed reading input file: %w"
 msgstr ""
@@ -3107,7 +3107,7 @@ msgstr ""
 msgid "Failed to open target file %q: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr ""
@@ -3117,7 +3117,7 @@ msgstr ""
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -3831,7 +3831,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -4007,7 +4007,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 msgid "Input file contains no certificate"
 msgstr ""
 
@@ -4322,11 +4322,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6169,7 +6169,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6208,11 +6208,11 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6241,11 +6241,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -6680,7 +6680,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -6832,7 +6832,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -6868,7 +6868,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7197,7 +7197,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -7619,7 +7619,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -7652,7 +7652,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8172,7 +8172,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8279,11 +8279,11 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 msgid "The given certificate is already present in this ESL"
 msgstr ""
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 msgid "The given signature is already present in this ESL"
 msgstr ""
 
@@ -8730,19 +8730,19 @@ msgstr ""
 msgid "Unable to parse %s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr ""
@@ -8774,7 +8774,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -8814,7 +8814,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:08+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 "
 "<nlincus@users.noreply.hosted.weblate.org>\n"
@@ -711,8 +711,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Accepteer certificaat"
@@ -818,7 +818,7 @@ msgid "--override-boot only works with a single instance"
 msgstr ""
 "--console werkt alleen als het een enkele instantiatie (instance) betreft"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr "--no-profiles kan niet gebruikt worden met --refresh"
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "Actie %q is niet ondersteund door dit programma"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgstr "Clustering aan"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2629,7 +2629,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr "Toon geen voortgang indicator/informatie"
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2802,7 +2802,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3115,7 +3115,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -3228,7 +3228,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "Backup aan het maken van instantiatie (instance): %s"
@@ -3436,7 +3436,7 @@ msgstr ""
 msgid "Failed to open target file %q: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Backup aan het maken van instantiatie (instance): %s"
@@ -3446,7 +3446,7 @@ msgstr "Backup aan het maken van instantiatie (instance): %s"
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3709,7 +3709,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4160,7 +4160,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -4336,7 +4336,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "Genereer het client certificaat"
@@ -4653,11 +4653,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6509,7 +6509,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6548,11 +6548,11 @@ msgstr "OS Versie"
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6581,11 +6581,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -7025,7 +7025,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -7179,7 +7179,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -7216,7 +7216,7 @@ msgstr "Voeg profielen (profiles) toe aan instantiaties (instances)"
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7546,7 +7546,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -7975,7 +7975,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -8008,7 +8008,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8530,7 +8530,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8639,12 +8639,12 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "Een client certificaat is al aanwezig"
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "Een client certificaat is al aanwezig"
@@ -9092,19 +9092,19 @@ msgstr ""
 msgid "Unable to parse %s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr ""
@@ -9136,7 +9136,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -9176,7 +9176,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-23 12:17+0000\n"
 "Last-Translator: Américo Monteiro <a_monteiro@gmx.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/incus/cli/pt/"
@@ -699,8 +699,8 @@ msgstr "(erro: %w)"
 msgid "(no timestamp)"
 msgstr "(sem marca temporal)"
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 msgid "(not a certificate)"
 msgstr "(não é um certificado)"
 
@@ -798,7 +798,7 @@ msgstr "--override-boot não pode ser usado com instâncias congeladas"
 msgid "--override-boot only works with a single instance"
 msgstr "--override-boot só funciona com uma única instância"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr "--owner e-type requer --all para ser definido"
 
@@ -853,7 +853,7 @@ msgstr "--tls-p12 não pode ser usado com --tls-cert ou --tls-key"
 msgid "=> Query %d:"
 msgstr "=> Consultar %d:"
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -941,7 +941,7 @@ msgstr "Ação"
 msgid "Action %q isn't supported by this tool"
 msgstr "Acção %q não é suportada por esta ferramenta"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr "Adicionar assinaturas de Arranque Seguro"
 
@@ -1571,7 +1571,7 @@ msgstr "Não pode definir --volume-only quando copia um instantâneo"
 msgid "Cannot set key: %s"
 msgstr "Não pode definir a chave: %s"
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr "Incapaz de armazenar uma assinatura em PK, KEK ou dbt"
 
@@ -1750,7 +1750,7 @@ msgstr "Ativado o agrupamento"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2675,7 +2675,7 @@ msgstr "Não requer confirmação do utilizador para usar --force"
 msgid "Don't show progress information"
 msgstr "Não mostra informações de progresso"
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2857,7 +2857,7 @@ msgstr "Edita configurações de confiança como YAML"
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3247,7 +3247,7 @@ msgstr "NOME DE FICHEIRO"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "IMPRESSÃO DIGITAL"
 
@@ -3363,7 +3363,7 @@ msgstr "Falhou ao analisar chave SSH de máquina: %w"
 msgid "Failed parsing validation response: %w"
 msgstr "Falhou ao analisar resposta de validação: %w"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, c-format
 msgid "Failed reading input file: %w"
 msgstr "Falhou ao ler o ficheiro de entrada: %w"
@@ -3572,7 +3572,7 @@ msgstr "Falhou ao abrir ficheiro fonte %q: %v"
 msgid "Failed to open target file %q: %w"
 msgstr "Falhou ao abrir ficheiro alvo %q: %w"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Falhou ao analisar certificado PEM: %w"
@@ -3582,7 +3582,7 @@ msgstr "Falhou ao analisar certificado PEM: %w"
 msgid "Failed to parse dump response: %w"
 msgstr "Falhou ao analisar resposta de despejo: %w"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 "Falhou ao analisar ficheiro de entrada seja como certificado PEM ou DER"
@@ -3869,7 +3869,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4359,7 +4359,7 @@ msgstr "Endereço uplink IPv6"
 msgid "ISSUE DATE"
 msgstr "DATA DO PROBLEMA"
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr "EMISSOR"
 
@@ -4545,7 +4545,7 @@ msgstr "Dados de entrada"
 msgid "Input data file (\"-\" for stdin)"
 msgstr "Ficheiro de dados de entrada (\"-\" para stdin)"
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 msgid "Input file contains no certificate"
 msgstr "O ficheiro de entrada não contém nenhum certificado"
 
@@ -4886,11 +4886,11 @@ msgstr ""
 "  t - Tipo\n"
 "  L - Localização do Aluguer DHCP (ex. é membro de agrupamento)"
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr "Lista assinaturas de Arranque Seguro"
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -7482,7 +7482,7 @@ msgstr "Nenhuns porto(s) correspondente encontrados"
 msgid "No matching rule(s) found"
 msgstr "Nenhuma regra(s) correspondente encontrada"
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr "Nenhuma assinatura corresponde"
 
@@ -7525,11 +7525,11 @@ msgstr "Versão do OS"
 msgid "OVN:"
 msgstr "OVN:"
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr "GUID DO DONO"
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr "NOME de GUID do DONO"
 
@@ -7560,11 +7560,11 @@ msgstr ""
 "Apenas um de --storage-create-device ou ---storage-create-loop pode ser "
 "especificado"
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr "Apenas remove assinaturas do tipo fornecido"
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr "Apenas remove assinaturas que são propriedade do dono fornecido"
 
@@ -8004,7 +8004,7 @@ msgstr "Caminho de consulta tem de começar com /"
 msgid "Query virtual machine images"
 msgstr "Consulta imagens de máquinas virtuais"
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr "VALOR CRU"
 
@@ -8170,7 +8170,7 @@ msgstr ""
 "Remover %s e tudo o que contém (instâncias, imagens, volumes, redes, ...) "
 "(sim/não): "
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr "Remove assinaturas de Arranque Seguro"
 
@@ -8206,7 +8206,7 @@ msgstr "Remove todos os perfis da instância"
 msgid "Remove all rules that match"
 msgstr "Remove todas as regras que correspondem"
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr "Remove todas as assinaturas"
 
@@ -8553,7 +8553,7 @@ msgstr "VOLUMES DE ARMAZENAMENTO"
 msgid "STP"
 msgstr "STP"
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr "SUJEITO"
 
@@ -9059,7 +9059,7 @@ msgstr "Define a chave como uma propriedade de volume de armazenamento"
 msgid "Set the key as an instance property"
 msgstr "Define a chave como uma propriedade de instância"
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr "Define o dono da assinatura"
 
@@ -9094,7 +9094,7 @@ msgstr "Configura armazenamento baseado em dispositivo usando DEVICE"
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr "Configura armazenamento baseado em loop com TAMANHO em GiB"
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr "Várias assinaturas correspondem à impressão digital dada"
 
@@ -9635,7 +9635,7 @@ msgstr "TESTEMUNHO"
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -9772,11 +9772,11 @@ msgstr "Foram encontradas as seguintes pools de armazenamento desconhecidas:"
 msgid "The following unknown volumes have been found:"
 msgstr "Os seguintes volumes desconhecidos foram encontrados:"
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 msgid "The given certificate is already present in this ESL"
 msgstr "O certificado fornecido já está presente neste ESL"
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 msgid "The given signature is already present in this ESL"
 msgstr "A assinatura fornecida já está presente neste ESL"
 
@@ -10257,19 +10257,19 @@ msgstr "Incapaz de analisar %s como uma entrada de arranque"
 msgid "Unable to parse %s as valid JSON"
 msgstr "Incapaz de analisar %s como um JSON válido"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr "Incapaz de analisar %s:%s como uma Lista de Assinatura EFI"
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr "Incapaz de analisar %s:%s como um JSON válido"
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "Incapaz de analisar dono %s: %w"
@@ -10301,7 +10301,7 @@ msgstr "Tipo de canal desconhecido para cliente %q: %s"
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -10341,7 +10341,7 @@ msgstr "Chave desconhecida: %s"
 msgid "Unknown output type %q"
 msgstr "Tipo de saída desconhecido %q"
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr "Tipo de assinatura desconhecido %s"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:09+0000\n"
 "Last-Translator: Kazantsev Mikhail <kazan417@mail.ru>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -685,8 +685,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Aceitar certificado"
@@ -794,7 +794,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--override-boot only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -944,7 +944,7 @@ msgstr "condição"
 msgid "Action %q isn't supported by this tool"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1733,7 +1733,7 @@ msgstr "Clustering ativado"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2667,7 +2667,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2857,7 +2857,7 @@ msgstr "Editar configurações de perfil como YAML"
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3175,7 +3175,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr "Aceitar certificado"
 msgid "Failed parsing validation response: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "Não é possível ler stdin: %s"
@@ -3496,7 +3496,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to open target file %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Aceitar certificado"
@@ -3506,7 +3506,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to parse dump response: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3770,7 +3770,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4247,7 +4247,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -4430,7 +4430,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "Adicionar novos clientes confiáveis"
@@ -4753,11 +4753,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6663,7 +6663,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6703,11 +6703,11 @@ msgstr "Versão CUDA: %v"
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6736,11 +6736,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -7193,7 +7193,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -7351,7 +7351,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -7391,7 +7391,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7750,7 +7750,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -8199,7 +8199,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -8232,7 +8232,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8787,7 +8787,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8897,12 +8897,12 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "Certificado do cliente armazenado no servidor: "
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -9356,19 +9356,19 @@ msgstr "Aceitar certificado"
 msgid "Unable to parse %s as valid JSON"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "Aceitar certificado"
@@ -9402,7 +9402,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -9442,7 +9442,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/incus/cli/ru/>\n"
@@ -695,8 +695,8 @@ msgstr "(ошибка: %w)"
 msgid "(no timestamp)"
 msgstr "(нет отметки времени)"
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Недопустимый сертификат"
@@ -802,7 +802,7 @@ msgstr "--target не может использоваться с экземпл�
 msgid "--override-boot only works with a single instance"
 msgstr "--console работает только с одним экземпляром"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr "--timestamp нельзя использовать вместе с --form
 msgid "=> Query %d:"
 msgstr "=> Query %d:"
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -946,7 +946,7 @@ msgstr "Действие"
 msgid "Action %q isn't supported by this tool"
 msgstr "Действие %q не поддерживается этим инструментом"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1580,7 +1580,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr "Невозможно задать параметр: %s"
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgstr "Кластеризация включена"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2691,7 +2691,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr "Не показывать информацию о прогрессе"
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2873,7 +2873,7 @@ msgstr "Редактировать конфигураций доверия се�
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3260,7 +3260,7 @@ msgstr "ИМЯ ФАЙЛА"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "ОТПЕЧАТОК"
 
@@ -3375,7 +3375,7 @@ msgstr "Не удалось распознать формат SSH-ключа х�
 msgid "Failed parsing validation response: %w"
 msgstr "Не удалось распознать ответ проверки: %w"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "Не удалось прочитать из файла: %w"
@@ -3585,7 +3585,7 @@ msgstr "Не удалось открыть исходный файл %q: %v"
 msgid "Failed to open target file %q: %w"
 msgstr "Не удалось открыть целевой файл %q: %w"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Не удалось создать сертификат: %w"
@@ -3595,7 +3595,7 @@ msgstr "Не удалось создать сертификат: %w"
 msgid "Failed to parse dump response: %w"
 msgstr "Не удалось разобрать ответ дампа: %w"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3884,7 +3884,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4383,7 +4383,7 @@ msgstr "IPv6-адрес восходящего канала"
 msgid "ISSUE DATE"
 msgstr "ДАТА ВЫПУСКА"
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 #, fuzzy
 msgid "ISSUER"
 msgstr "ДАТА ВЫПУСКА"
@@ -4574,7 +4574,7 @@ msgstr "Входные данные"
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "Сгенерировать клиентский сертификат"
@@ -4920,11 +4920,11 @@ msgstr ""
 "  t - Тип\n"
 "  L - Местоположение DHCP-аренды (например, участник кластера)"
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 #, fuzzy
 msgid ""
 "List Secure Boot signatures\n"
@@ -7478,7 +7478,7 @@ msgstr "Соответствующие порты не найдены"
 msgid "No matching rule(s) found"
 msgstr "Соответствующих правил не найдено"
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -7520,11 +7520,11 @@ msgstr "Версия ОС"
 msgid "OVN:"
 msgstr "OVN:"
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 #, fuzzy
 msgid "OWNER GUID NAME"
 msgstr "НАЗВАНИЕ GUID ИДЕНТИФИКАТОРА"
@@ -7559,11 +7559,11 @@ msgstr ""
 "Можно указать только один из параметров --storage-create-device или --"
 "storage-create-loop"
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -8011,7 +8011,7 @@ msgstr "Путь запроса должен начаться с /"
 msgid "Query virtual machine images"
 msgstr "Запрос образов виртуальных машин"
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr "СЫРОЕ ЗНАЧЕНИЕ"
 
@@ -8180,7 +8180,7 @@ msgstr ""
 "Удалить %s и все, что в нем содержится (экземпляры, образы, тома, сети, ...) "
 "да(yes)/нет(no): "
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 #, fuzzy
 msgid "Remove Secure Boot signatures"
 msgstr "Удалить дистанционные сервера"
@@ -8217,7 +8217,7 @@ msgstr "Убрать все профили из экземпляра"
 msgid "Remove all rules that match"
 msgstr "Удалить все правила, которые удовлетворяют условию"
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 #, fuzzy
 msgid "Remove all signatures"
 msgstr "Удалить псевдонимы"
@@ -8566,7 +8566,7 @@ msgstr "ТОМА ХРАНЕНИЯ"
 msgid "STP"
 msgstr "SPANNING TREE PROTOCOL"
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -9078,7 +9078,7 @@ msgstr "Задать параметр тома хранения"
 msgid "Set the key as an instance property"
 msgstr "Задать параметр экземпляра"
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 #, fuzzy
 msgid "Set the signature owner"
 msgstr "Задать параметр хранилища"
@@ -9115,7 +9115,7 @@ msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 "Настроить хранилища на основе loop устройства с указанием размера в ГиБ"
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -9657,7 +9657,7 @@ msgstr "ТОКЕН"
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -9792,12 +9792,12 @@ msgstr "Найдены следующие неизвестные пулы хра
 msgid "The following unknown volumes have been found:"
 msgstr "Были найдены следующие неизвестные тома:"
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "Сертификат клиента хранится на сервере"
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "Сертификат клиента хранится на сервере"
@@ -10279,19 +10279,19 @@ msgstr "Не удалось разобрать файл предваритель
 msgid "Unable to parse %s as valid JSON"
 msgstr "Не удалось разобрать файл предварительной настройки (preseed): %w"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "Не удалось разобрать файл предварительной настройки (preseed): %w"
@@ -10323,7 +10323,7 @@ msgstr "Неизвестный тип канала связи для клиен�
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -10363,7 +10363,7 @@ msgstr "Неизвестный параметр: %s"
 msgid "Unknown output type %q"
 msgstr "Неизвестный тип вывода %q"
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, fuzzy, c-format
 msgid "Unknown signature type %s"
 msgstr "Неизвестный тип файла '%s"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:13+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/incus/cli/sv/>\n"
@@ -696,8 +696,8 @@ msgstr "(fel: %w)"
 msgid "(no timestamp)"
 msgstr "(ingen tidsstämpel)"
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "Ogiltigt certifikat"
@@ -796,7 +796,7 @@ msgstr "--target kan inte användas med instanser"
 msgid "--override-boot only works with a single instance"
 msgstr "--console fungerar endast med en enda instans"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -854,7 +854,7 @@ msgstr "--no-profiles kan inte användas tillsammans med --refresh"
 msgid "=> Query %d:"
 msgstr "=> Fråga %d:"
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -941,7 +941,7 @@ msgstr "Åtgärden"
 msgid "Action %q isn't supported by this tool"
 msgstr "Åtgärden %q stöds inte av detta verktyg"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1565,7 +1565,7 @@ msgstr "Kan inte ställa in --volume-only när du kopierar en ögonblicksbild"
 msgid "Cannot set key: %s"
 msgstr "Kan inte ställa in nyckel: %s"
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1744,7 +1744,7 @@ msgstr "Klustering aktiverad"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2664,7 +2664,7 @@ msgstr "Kräv inte användarens bekräftelse för att använda --force"
 msgid "Don't show progress information"
 msgstr "Visa inte information om framsteg"
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2845,7 +2845,7 @@ msgstr "Redigera förtroendekonfigurationer som YAML"
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3229,7 +3229,7 @@ msgstr "FILNAMN"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "FINGERAVTRYCK"
 
@@ -3342,7 +3342,7 @@ msgstr "Misslyckades med att analysera SSH-värdnyckel: %w"
 msgid "Failed parsing validation response: %w"
 msgstr "Misslyckad analys av valideringssvar: %w"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "Det gick inte att läsa från filen: %w"
@@ -3552,7 +3552,7 @@ msgstr "Misslyckades med att öppna källfilen %q: %v"
 msgid "Failed to open target file %q: %w"
 msgstr "Misslyckades att öppna målfil %q: %w"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "Det gick inte att skapa certifikatet: %w"
@@ -3562,7 +3562,7 @@ msgstr "Det gick inte att skapa certifikatet: %w"
 msgid "Failed to parse dump response: %w"
 msgstr "Det gick inte att analysera dumpningssvaret: %w"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3853,7 +3853,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4341,7 +4341,7 @@ msgstr "IPv6-upplänksadress"
 msgid "ISSUE DATE"
 msgstr "UTGIVNINGSDATUM"
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 #, fuzzy
 msgid "ISSUER"
 msgstr "UTGIVNINGSDATUM"
@@ -4531,7 +4531,7 @@ msgstr "Inmatningsdata"
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "Skapa klientcertifikatet"
@@ -4870,11 +4870,11 @@ msgstr ""
 "  t - Typ\n"
 "   L - Plats för DHCP-lån (t.ex. dess klustermedlem)"
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 #, fuzzy
 msgid ""
 "List Secure Boot signatures\n"
@@ -7407,7 +7407,7 @@ msgstr "Inga matchande portar hittades"
 msgid "No matching rule(s) found"
 msgstr "Inga matchande regler hittades"
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -7448,11 +7448,11 @@ msgstr "OS-version"
 msgid "OVN:"
 msgstr "OVN:"
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 #, fuzzy
 msgid "OWNER GUID NAME"
 msgstr "GUID-NAMN"
@@ -7484,11 +7484,11 @@ msgid ""
 msgstr ""
 "Endast ett av --storage-create-device eller --storage-create-loop kan anges"
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -7932,7 +7932,7 @@ msgstr "Sökvägen måste börja med /"
 msgid "Query virtual machine images"
 msgstr "Fråga virtuella maskinavbildningar"
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr "RÅVÄRDE"
 
@@ -8098,7 +8098,7 @@ msgstr ""
 "Ta bort %s och allt som den innehåller (instanser, avbildningar, volymer, "
 "nätverk, ...) (ja/nej): "
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 #, fuzzy
 msgid "Remove Secure Boot signatures"
 msgstr "Ta bort fjärrkontroller"
@@ -8135,7 +8135,7 @@ msgstr "Ta bort alla profiler från instansen"
 msgid "Remove all rules that match"
 msgstr "Ta bort alla regler som matchar"
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 #, fuzzy
 msgid "Remove all signatures"
 msgstr "Ta bort alias"
@@ -8476,7 +8476,7 @@ msgstr "LAGRINGSVOLYMER"
 msgid "STP"
 msgstr "STP"
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -8980,7 +8980,7 @@ msgstr "Ställ in nyckeln som en lagringsvolymegenskap"
 msgid "Set the key as an instance property"
 msgstr "Ställ in nyckeln som en instansegenskap"
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 #, fuzzy
 msgid "Set the signature owner"
 msgstr "Ställ in nyckeln som en lagringsegenskap"
@@ -9016,7 +9016,7 @@ msgstr "Konfigurera enhetsbaserad lagring med DEVICE"
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr "Konfigurera loopbaserad lagring med STORLEK i GiB"
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -9557,7 +9557,7 @@ msgstr "TOKEN"
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -9691,12 +9691,12 @@ msgstr "Följande okända lagringspooler har hittats:"
 msgid "The following unknown volumes have been found:"
 msgstr "Följande okända volymer har hittats:"
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "Ett klientcertifikat finns redan"
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "Ett klientcertifikat finns redan"
@@ -10170,19 +10170,19 @@ msgstr "Det gick inte att analysera förinställningen: %w"
 msgid "Unable to parse %s as valid JSON"
 msgstr "Det gick inte att analysera förinställningen: %w"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "Det gick inte att analysera förinställningen: %w"
@@ -10215,7 +10215,7 @@ msgstr "Okänd kanaltyp för klient %q: %s"
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -10255,7 +10255,7 @@ msgstr "Okänd nyckel: %s"
 msgid "Unknown output type %q"
 msgstr "Okänd utdatatyp %q"
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, fuzzy, c-format
 msgid "Unknown signature type %s"
 msgstr "Okänd filtyp '%s'"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:13+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/incus/cli/ta/>\n"
@@ -435,8 +435,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 msgid "(not a certificate)"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "--override-boot only works with a single instance"
 msgstr ""
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgstr ""
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1254,7 +1254,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2455,7 +2455,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -2766,7 +2766,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, c-format
 msgid "Failed reading input file: %w"
 msgstr ""
@@ -3087,7 +3087,7 @@ msgstr ""
 msgid "Failed to open target file %q: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr ""
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3360,7 +3360,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -3810,7 +3810,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -3986,7 +3986,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 msgid "Input file contains no certificate"
 msgstr ""
 
@@ -4301,11 +4301,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6148,7 +6148,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6187,11 +6187,11 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6220,11 +6220,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -6659,7 +6659,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -6811,7 +6811,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -6847,7 +6847,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7176,7 +7176,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -7598,7 +7598,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -7631,7 +7631,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8151,7 +8151,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8258,11 +8258,11 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 msgid "The given certificate is already present in this ESL"
 msgstr ""
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 msgid "The given signature is already present in this ESL"
 msgstr ""
 
@@ -8709,19 +8709,19 @@ msgstr ""
 msgid "Unable to parse %s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr ""
@@ -8753,7 +8753,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -8793,7 +8793,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:10+0000\n"
 "Last-Translator: meipeter <meipeter114514@outlook.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -693,8 +693,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 #, fuzzy
 msgid "(not a certificate)"
 msgstr "无效的证书"
@@ -795,7 +795,7 @@ msgstr "--target 不能与实例一起使用"
 msgid "--override-boot only works with a single instance"
 msgstr "--console 只适用于单个实例"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -853,7 +853,7 @@ msgstr "--no-profiles 不能与 --refresh 一起使用"
 msgid "=> Query %d:"
 msgstr "=> 查询 %d："
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -940,7 +940,7 @@ msgstr "描述"
 msgid "Action %q isn't supported by this tool"
 msgstr "此工具不支持操作 %q"
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1547,7 +1547,7 @@ msgstr "复制快照时无法设置 --volume-only"
 msgid "Cannot set key: %s"
 msgstr "无法设置键：%s"
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1722,7 +1722,7 @@ msgstr "已启用集群"
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2639,7 +2639,7 @@ msgstr "使用 --force 不需要用户确认"
 msgid "Don't show progress information"
 msgstr "不显示进度信息"
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2816,7 +2816,7 @@ msgstr "将信任配置编辑为 YAML"
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -3174,7 +3174,7 @@ msgstr "文件名"
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr "指纹"
 
@@ -3287,7 +3287,7 @@ msgstr "解析 SSH 主机密钥失败：%w"
 msgid "Failed parsing validation response: %w"
 msgstr "解析验证响应失败：%w"
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, fuzzy, c-format
 msgid "Failed reading input file: %w"
 msgstr "无法从标准输入读取：%w"
@@ -3495,7 +3495,7 @@ msgstr "关闭服务器证书文件 %q 失败：%w"
 msgid "Failed to open target file %q: %w"
 msgstr "关闭服务器证书文件 %q 失败：%w"
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, fuzzy, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr "创建证书失败：%w"
@@ -3505,7 +3505,7 @@ msgstr "创建证书失败：%w"
 msgid "Failed to parse dump response: %w"
 msgstr "解析转储响应失败：%w"
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3784,7 +3784,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -4250,7 +4250,7 @@ msgstr "IPv6上行地址"
 msgid "ISSUE DATE"
 msgstr "发行日期"
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 #, fuzzy
 msgid "ISSUER"
 msgstr "发行日期"
@@ -4432,7 +4432,7 @@ msgstr "输入数据"
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 #, fuzzy
 msgid "Input file contains no certificate"
 msgstr "生成客户端证书"
@@ -4768,11 +4768,11 @@ msgstr ""
 "  t - 类型\n"
 "  L - DHCP 租约位置（例如其集群成员）"
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6921,7 +6921,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6960,11 +6960,11 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6993,11 +6993,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -7438,7 +7438,7 @@ msgstr "查询路径必须以 / 开头"
 msgid "Query virtual machine images"
 msgstr "查询虚拟机镜像"
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -7598,7 +7598,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr "移除项目 %s 及其所有内容 (实例, 镜像, 存储卷, 网络, ...) (yes/no): "
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -7638,7 +7638,7 @@ msgstr "从实例拉取文件"
 msgid "Remove all rules that match"
 msgstr "移除所有匹配的规则"
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 #, fuzzy
 msgid "Remove all signatures"
 msgstr "移除别名"
@@ -7970,7 +7970,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -8394,7 +8394,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -8427,7 +8427,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8950,7 +8950,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -9060,12 +9060,12 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 #, fuzzy
 msgid "The given certificate is already present in this ESL"
 msgstr "客户端证书已存在"
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 #, fuzzy
 msgid "The given signature is already present in this ESL"
 msgstr "客户端证书已存在"
@@ -9513,19 +9513,19 @@ msgstr "解析 preseed 失败：%w"
 msgid "Unable to parse %s as valid JSON"
 msgstr "解析 preseed 失败：%w"
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, fuzzy, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr "解析 preseed 失败：%w"
@@ -9557,7 +9557,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -9597,7 +9597,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2026-08-23 18:19-0400\n"
+"POT-Creation-Date: 2026-08-24 00:06+0000\n"
 "PO-Revision-Date: 2026-08-22 19:12+0000\n"
 "Last-Translator: pesder <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
@@ -436,8 +436,8 @@ msgstr ""
 msgid "(no timestamp)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1454 cmd/incus/low_level.go:1462
-#: cmd/incus/low_level.go:1482 cmd/incus/low_level.go:1490
+#: cmd/incus/low_level.go:1436 cmd/incus/low_level.go:1444
+#: cmd/incus/low_level.go:1464 cmd/incus/low_level.go:1472
 msgid "(not a certificate)"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr "--target 不能與實體一起使用"
 msgid "--override-boot only works with a single instance"
 msgstr "--console 僅適用於單個實體"
 
-#: cmd/incus/low_level.go:1613
+#: cmd/incus/low_level.go:1595
 msgid "--owner and --type require --all to be set"
 msgstr ""
 
@@ -594,7 +594,7 @@ msgstr "--no-profiles 不能與 --refresh 一起使用"
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1322
+#: cmd/incus/low_level.go:1304
 msgid ""
 "A PK certificate is already enrolled; remove it first to enroll a new one"
 msgstr ""
@@ -679,7 +679,7 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/low_level.go:1165 cmd/incus/low_level.go:1166
+#: cmd/incus/low_level.go:1147 cmd/incus/low_level.go:1148
 msgid "Add Secure Boot signatures"
 msgstr ""
 
@@ -1263,7 +1263,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/low_level.go:1217
+#: cmd/incus/low_level.go:1199
 msgid "Cannot store a signature in PK, KEK or dbt"
 msgstr ""
 
@@ -1438,7 +1438,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:443 cmd/incus/config_trust.go:403
 #: cmd/incus/config_trust.go:595 cmd/incus/image.go:1083
 #: cmd/incus/image_alias.go:211 cmd/incus/list.go:154
-#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1376
+#: cmd/incus/low_level.go:720 cmd/incus/low_level.go:1358
 #: cmd/incus/network.go:1054 cmd/incus/network.go:1253
 #: cmd/incus/network_allocations.go:73 cmd/incus/network_forward.go:122
 #: cmd/incus/network_integration.go:417 cmd/incus/network_load_balancer.go:129
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/low_level.go:1170
+#: cmd/incus/low_level.go:1152
 msgid ""
 "Don’t import the file as a certificate but rather compute and import its "
 "digest (sha256|sha384|sha512)"
@@ -2464,7 +2464,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:434
 #: cmd/incus/config_trust.go:620 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:260 cmd/incus/list.go:598
-#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1414
+#: cmd/incus/low_level.go:752 cmd/incus/low_level.go:1396
 #: cmd/incus/network.go:1101 cmd/incus/network.go:1291
 #: cmd/incus/network_allocations.go:99 cmd/incus/network_forward.go:158
 #: cmd/incus/network_integration.go:443 cmd/incus/network_load_balancer.go:164
@@ -2775,7 +2775,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:420 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1114 cmd/incus/image.go:1115 cmd/incus/image_alias.go:249
-#: cmd/incus/low_level.go:1397 cmd/incus/low_level.go:1398
+#: cmd/incus/low_level.go:1379 cmd/incus/low_level.go:1380
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2888,7 +2888,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1205
+#: cmd/incus/low_level.go:1187
 #, c-format
 msgid "Failed reading input file: %w"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgstr ""
 msgid "Failed to open target file %q: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1250
+#: cmd/incus/low_level.go:1232
 #, c-format
 msgid "Failed to parse PEM certificate: %w"
 msgstr ""
@@ -3106,7 +3106,7 @@ msgstr ""
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/low_level.go:1262
+#: cmd/incus/low_level.go:1244
 msgid "Failed to parse input file as either PEM or DER certificate"
 msgstr ""
 
@@ -3369,7 +3369,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:444 cmd/incus/config_template.go:272
 #: cmd/incus/config_trust.go:404 cmd/incus/config_trust.go:594
 #: cmd/incus/image.go:1084 cmd/incus/image_alias.go:210 cmd/incus/list.go:155
-#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1375
+#: cmd/incus/low_level.go:719 cmd/incus/low_level.go:1357
 #: cmd/incus/network.go:1055 cmd/incus/network.go:1252
 #: cmd/incus/network_acl.go:104 cmd/incus/network_allocations.go:71
 #: cmd/incus/network_forward.go:121 cmd/incus/network_integration.go:416
@@ -3819,7 +3819,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/low_level.go:1399 cmd/incus/low_level.go:1400
+#: cmd/incus/low_level.go:1381 cmd/incus/low_level.go:1382
 msgid "ISSUER"
 msgstr ""
 
@@ -3995,7 +3995,7 @@ msgstr ""
 msgid "Input data file (\"-\" for stdin)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1266
+#: cmd/incus/low_level.go:1248
 msgid "Input file contains no certificate"
 msgstr ""
 
@@ -4310,11 +4310,11 @@ msgid ""
 "  L - Location of the DHCP Lease (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/low_level.go:1353
+#: cmd/incus/low_level.go:1335
 msgid "List Secure Boot signatures"
 msgstr ""
 
-#: cmd/incus/low_level.go:1354
+#: cmd/incus/low_level.go:1336
 msgid ""
 "List Secure Boot signatures\n"
 "\n"
@@ -6157,7 +6157,7 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/low_level.go:1679
+#: cmd/incus/low_level.go:1661
 msgid "No signature matches"
 msgstr ""
 
@@ -6196,11 +6196,11 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1401
+#: cmd/incus/low_level.go:1383
 msgid "OWNER GUID"
 msgstr ""
 
-#: cmd/incus/low_level.go:1402
+#: cmd/incus/low_level.go:1384
 msgid "OWNER GUID NAME"
 msgstr ""
 
@@ -6229,11 +6229,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
-#: cmd/incus/low_level.go:1581
+#: cmd/incus/low_level.go:1563
 msgid "Only remove signatures of the given type"
 msgstr ""
 
-#: cmd/incus/low_level.go:1580
+#: cmd/incus/low_level.go:1562
 msgid "Only remove signatures owned by the given owner"
 msgstr ""
 
@@ -6668,7 +6668,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1403
+#: cmd/incus/low_level.go:742 cmd/incus/low_level.go:1385
 msgid "RAW VALUE"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/low_level.go:1575 cmd/incus/low_level.go:1576
+#: cmd/incus/low_level.go:1557 cmd/incus/low_level.go:1558
 msgid "Remove Secure Boot signatures"
 msgstr ""
 
@@ -6856,7 +6856,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/low_level.go:1579
+#: cmd/incus/low_level.go:1561
 msgid "Remove all signatures"
 msgstr ""
 
@@ -7185,7 +7185,7 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/low_level.go:1404 cmd/incus/low_level.go:1405
+#: cmd/incus/low_level.go:1386 cmd/incus/low_level.go:1387
 msgid "SUBJECT"
 msgstr ""
 
@@ -7607,7 +7607,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/low_level.go:1169
+#: cmd/incus/low_level.go:1151
 msgid "Set the signature owner"
 msgstr ""
 
@@ -7640,7 +7640,7 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/low_level.go:1683
+#: cmd/incus/low_level.go:1665
 msgid "Several signatures match the given fingerprint"
 msgstr ""
 
@@ -8161,7 +8161,7 @@ msgstr ""
 
 #: cmd/incus/config_trust.go:418 cmd/incus/image.go:1120
 #: cmd/incus/image_alias.go:250 cmd/incus/list.go:555
-#: cmd/incus/low_level.go:1406 cmd/incus/network.go:1082
+#: cmd/incus/low_level.go:1388 cmd/incus/network.go:1082
 #: cmd/incus/network.go:1279 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_integration.go:434 cmd/incus/network_peer.go:142
 #: cmd/incus/operation.go:168 cmd/incus/storage_volume.go:1629
@@ -8269,11 +8269,11 @@ msgstr ""
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/low_level.go:1316
+#: cmd/incus/low_level.go:1298
 msgid "The given certificate is already present in this ESL"
 msgstr ""
 
-#: cmd/incus/low_level.go:1313
+#: cmd/incus/low_level.go:1295
 msgid "The given signature is already present in this ESL"
 msgstr ""
 
@@ -8720,19 +8720,19 @@ msgstr ""
 msgid "Unable to parse %s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1302 cmd/incus/low_level.go:1527
-#: cmd/incus/low_level.go:1639
+#: cmd/incus/low_level.go:1284 cmd/incus/low_level.go:1509
+#: cmd/incus/low_level.go:1621
 #, c-format
 msgid "Unable to parse %s:%s as an EFI Signature List"
 msgstr ""
 
-#: cmd/incus/low_level.go:1295 cmd/incus/low_level.go:1520
-#: cmd/incus/low_level.go:1632
+#: cmd/incus/low_level.go:1277 cmd/incus/low_level.go:1502
+#: cmd/incus/low_level.go:1614
 #, c-format
 msgid "Unable to parse %s:%s as valid JSON"
 msgstr ""
 
-#: cmd/incus/low_level.go:1210 cmd/incus/low_level.go:1646
+#: cmd/incus/low_level.go:1192 cmd/incus/low_level.go:1628
 #, c-format
 msgid "Unable to parse owner %s: %w"
 msgstr ""
@@ -8764,7 +8764,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:483 cmd/incus/config_trust.go:440
 #: cmd/incus/config_trust.go:626 cmd/incus/image.go:1152
 #: cmd/incus/image_alias.go:266 cmd/incus/list.go:616
-#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1420
+#: cmd/incus/low_level.go:758 cmd/incus/low_level.go:1402
 #: cmd/incus/network.go:1107 cmd/incus/network.go:1297
 #: cmd/incus/network_allocations.go:105 cmd/incus/network_forward.go:164
 #: cmd/incus/network_integration.go:449 cmd/incus/network_load_balancer.go:170
@@ -8804,7 +8804,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/low_level.go:1231
+#: cmd/incus/low_level.go:1213
 #, c-format
 msgid "Unknown signature type %s"
 msgstr ""

--- a/shared/uefi/guid.go
+++ b/shared/uefi/guid.go
@@ -60,9 +60,10 @@ const (
 
 	// Vendors.
 
+	IncusVendorGuid     = "7b3743d8-4c1f-420a-b4d7-3654fa4792cc"
 	MicrosoftVendorGuid = "77fa9abd-0359-4d32-bd60-28f4e78f784b"
 	MtcVendorGuid       = "eb704011-1402-11d3-8e77-00a0c969723b"
-	OVMFVendorGuid      = "a0baa8a3-041d-48a8-bc87-c36d121b5e3d" // Non-standard.
+	OvmfVendorGuid      = "a0baa8a3-041d-48a8-bc87-c36d121b5e3d" // Non-standard.
 
 	// External.
 
@@ -123,9 +124,10 @@ var guidNames = map[string]string{
 
 	// Vendors.
 
+	IncusVendorGuid:     "INCUS_VENDOR_GUID",
 	MicrosoftVendorGuid: "MICROSOFT_VENDOR_GUID",
 	MtcVendorGuid:       "MTC_VENDOR_GUID",
-	OVMFVendorGuid:      "OVMF_VENDOR_GUID", // Non-standard.
+	OvmfVendorGuid:      "OVMF_VENDOR_GUID", // Non-standard.
 
 	// External.
 

--- a/shared/util/uefi.go
+++ b/shared/util/uefi.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/lxc/incus/v7/shared/uefi"
+)
+
+// ESLGUIDVar gets the GUID and variable name associated to the given ESL.
+func ESLGUIDVar(esl string) (string, string) {
+	var guid, varName string
+	switch esl {
+	case "pk", "kek":
+		guid = uefi.EfiGlobalVariableGuid
+		varName = strings.ToUpper(esl)
+	case "db", "dbx", "dbt":
+		guid = uefi.EfiImageSecurityDatabaseGuid
+		varName = esl
+	case "mok":
+		guid = uefi.ShimLockGuid
+		varName = "MokList"
+	}
+
+	return guid, varName
+}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net"
@@ -1063,4 +1064,64 @@ func IsSELinuxLevel(value string) error {
 	}
 
 	return nil
+}
+
+// IsRawNVRAMVariable validates whether the string is Base64 encoded, with an optional integer+colon
+// prefix.
+func IsRawNVRAMVariable(value string) error {
+	parts := strings.SplitN(value, ":", 2)
+	value = parts[len(parts)-1]
+	err := IsBase64(value)
+	if err != nil {
+		return fmt.Errorf("Invalid value for NVRAM variable %q: %w", value, err)
+	}
+
+	if len(parts) == 2 {
+		_, err = strconv.ParseUint(parts[0], 0, 32)
+		if err != nil {
+			return fmt.Errorf("Invalid value for NVRAM variable attribute %q: %w", parts[0], err)
+		}
+	}
+
+	return nil
+}
+
+// IsPEM validates whether the string is a valid PEM bundle. This doesn’t validate the content
+// of the individual blocks.
+func IsPEM(bundle bool, armors ...string) func(value string) error {
+	return func(value string) error {
+		if len(armors) == 0 {
+			armors = []string{"CERTIFICATE"}
+		}
+
+		rest := []byte(value)
+		ok := false
+		var block *pem.Block
+		for {
+			block, rest = pem.Decode(rest)
+			if block == nil {
+				break
+			}
+
+			if !slices.Contains(armors, block.Type) {
+				return fmt.Errorf("Unknown armor %s; expected one of %v", block.Type, armors)
+			}
+
+			if ok && !bundle {
+				return errors.New("More than one block found; expected only one")
+			}
+
+			ok = true
+		}
+
+		if !ok {
+			if bundle {
+				return errors.New("Invalid value; must be a PEM bundle")
+			}
+
+			return errors.New("Invalid value; must be a single PEM block")
+		}
+
+		return nil
+	}
 }

--- a/test/suites/nvram_vm.sh
+++ b/test/suites/nvram_vm.sh
@@ -124,6 +124,56 @@ EOF
     incus config unset v1 raw.qemu.scriptlet
     [ "$(incus low-level nvram get v1 00112233-4455-6677-8899-aabbccddeeff:abc --format=binary)" = "def" ]
 
+    # Use configuration overrides.
+    incus config set v1 initial.nvram-binary.00112233-4455-6677-8899-aabbccddeeff.Foo=QmFy
+    incus config set v1 initial.nvram-binary.00112233-4455-6677-8899-aabbccddeeff.Baz=3:UXV4
+    echo '{"data":{"width": 800,"height":600},"attributes":["NON_VOLATILE","BOOTSERVICE_ACCESS","RUNTIME_ACCESS"]}' | incus config set v1 initial.nvram.7235c51c-0c80-4cab-87ac-3b084a6304b1.PlatformConfig=-
+    incus config set v1 initial.secureboot.db=- <<EOF
+-----BEGIN CERTIFICATE-----
+MIIFpDCCA4ygAwIBAgITMwAAABY2vzaJnxV1zAAAAAAAFjANBgkqhkiG9w0BAQsF
+ADBaMQswCQYDVQQGEwJVUzEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9u
+MSswKQYDVQQDEyJNaWNyb3NvZnQgUlNBIERldmljZXMgUm9vdCBDQSAyMDIxMB4X
+DTIzMDYxMzE5MjE0N1oXDTM4MDYxMzE5MzE0N1owTjELMAkGA1UEBhMCVVMxHjAc
+BgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEfMB0GA1UEAxMWTWljcm9zb2Z0
+IFVFRkkgQ0EgMjAyMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL0i
+Kq7vGjGFE3hRp5v9/HjRY7gam2P1EgbbS0E1am+r9WoEzJfPu9QICRphOg3ms6BG
+/wmt3oAk3BKA8l/ZFu3iQp3NL01hAmGKHEsdGGI5hpdxrT5/XXETS+kqAMG+1bcA
+n15lsiwa/3Tt6oPSOYkzNXN9oKL6QORmUFiq/IfoXCCDNOyr4gvFXz7/SCsRkSbv
+GG5XxZ8Yc5nv4Wp0K7svf1COHdo9drYE5cwuEMeDG4Oj5KUTE3FuM3ijqDzsSCZe
+x8ZeDYeaqsxVNIGtnZD15pZjpugHIBfIkx7SrqTcrn1Zv4heYgyuW/IpQFYdJkDe
+haatVtHPVUd2X5w52wMCAwEAAaOCAW0wggFpMA4GA1UdDwEB/wQEAwIBhjAQBgkr
+BgEEAYI3FQEEAwIBADAdBgNVHQ4EFgQUgaprMkTJNbzg1mKK85gnQh4ySX0wGQYJ
+KwYBBAGCNxQCBAweCgBTAHUAYgBDAEEwDwYDVR0TAQH/BAUwAwEB/zAfBgNVHSME
+GDAWgBSERIYGAJg/LKqzxYnzrC7J5p0JAzBlBgNVHR8EXjBcMFqgWKBWhlRodHRw
+Oi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NybC9NaWNyb3NvZnQlMjBSU0El
+MjBEZXZpY2VzJTIwUm9vdCUyMENBJTIwMjAyMS5jcmwwcgYIKwYBBQUHAQEEZjBk
+MGIGCCsGAQUFBzAChlZodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2Nl
+cnRzL01pY3Jvc29mdCUyMFJTQSUyMERldmljZXMlMjBSb290JTIwQ0ElMjAyMDIx
+LmNydDANBgkqhkiG9w0BAQsFAAOCAgEAB2ATKlOHEg8a81oUlRfl2NeVVJuLDt2R
+pe3HXUdQk0W3lYhfFxlBY3a1grCoxZ2ZFTaJSb4Swmb7gwywgc7lpKvCoJrr9Qc8
+/iH4mtwZIQyeJCzRXKIWCkvr7EicsVt02wFkwuOAaqsazXcbajmat7pwRP9nlMWB
+BvDLgQSTJyGZvYeIFJwicQ4LL1y+uJBUfMAevCubo1YXS5fn438TNPqwNGub9rIt
+99h72CDTXKeVTE8q+eceaK/8bI/Ihj2fyNHvTRrI0fb9LXzj6EHB6ifB+44lhlqJ
+phC+zuOPpXvEGqDodZD9IbDBo8UWI148zi/+jJi/CFz2ucWyPLbMyOx/0nd0y+3z
+lsmLjRwqiQ+jj73OKoVGmiOij0LAmdbqhR9hGb4WNbd1oJWAZQaH1As1yMSqDs6i
+CmNgyksrXCcEgq8+WIN6WthnPxBT9QwW9yZLioC5xR+g3tjTYUQURaf1q5qIF/23
+lFQCi+S3U6E+jZ5QgqgA4HiUG76zxDAfsg7b8EaQweZX/nzBcLIcS2TZEAMbNPtm
+z4JunkCoETfyZYshCa88k2I987yD3T9VkBXSMa8R5/jKoILhuc+zV5PHVTesf0G/
+H5Y88yaU+djSVSSKirZB8OAWwCOSjHEKTGoNGVX3OpySIZah1fgKjJ2/yevKiEL8
+S7Tv/ycwIWE=
+-----END CERTIFICATE-----
+-----BEGIN SIGNATURE-----
+AAARESIiMzNERFVVZmZ3d4iImZmqqru7zMzd3e7u//8=
+-----END SIGNATURE-----
+EOF
+    incus config set v1 volatile.apply_nvram=true
+    incus start v1
+    incus wait v1 agent
+    [ "$(incus low-level nvram get v1 00112233-4455-6677-8899-aabbccddeeff:Foo --format=json)" = '{"attributes":["NON_VOLATILE","BOOTSERVICE_ACCESS","RUNTIME_ACCESS"],"binary":"QmFy"}' ]
+    [ "$(incus low-level nvram get v1 00112233-4455-6677-8899-aabbccddeeff:Baz --format=json)" = '{"attributes":["NON_VOLATILE","BOOTSERVICE_ACCESS"],"binary":"UXV4"}' ]
+    [ "$(incus low-level nvram get v1 OVMF_PLATFORM_CONFIG_GUID:PlatformConfig --format=json)" = '{"data":{"height":600,"width":800},"attributes":["NON_VOLATILE","BOOTSERVICE_ACCESS","RUNTIME_ACCESS"],"binary":"IAMAAFgCAAA="}' ]
+    [ "$(incus low-level secureboot list v1 db --format=csv --columns=tf | tr '\n' :)" = "sha256,000011112222:x509,f6124e34125b:" ]
+
     echo "==> Deleting VM"
     incus rm -f v1
 


### PR DESCRIPTION
The initial keys are deliberately not frozen after the first boot, as i) it makes sense to force rebuilding the NVRAM with new defaults and ii) you can’t block profile modification anyway, so new profile-defined defaults would still be applied.

Closes: #2627