### PR TITLE
Various migration/evacuation fixes

### DIFF
--- a/client/incus_events.go
+++ b/client/incus_events.go
@@ -108,14 +108,25 @@ func (r *ProtocolIncus) getEvents(allProjects bool, eventTypes []string) (*Event
 			case <-time.After(time.Minute):
 			case <-r.ctxConnected.Done():
 			case <-stopCh:
+				// The reader is gone, close our connection and clear it if still current.
+				r.eventConnsLock.Lock()
+				if r.eventConns[listener.projectName] == wsConn {
+					delete(r.eventConns, listener.projectName)
+				}
+
+				r.eventConnsLock.Unlock()
+
+				_ = wsConn.Close()
+
+				return
 			}
 
 			r.eventListenersLock.Lock()
 			r.eventConnsLock.Lock()
 			if r.ctxConnected.Err() != nil || len(r.eventListeners[listener.projectName]) == 0 {
 				// We don't need the connection anymore, disconnect and clear.
-				if r.eventListeners[listener.projectName] != nil {
-					_ = r.eventConns[listener.projectName].Close()
+				if r.eventConns[listener.projectName] == wsConn {
+					_ = wsConn.Close()
 					delete(r.eventConns, listener.projectName)
 				}
 

--- a/client/operations.go
+++ b/client/operations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"sync"
@@ -337,8 +338,9 @@ func (op *operation) setupListener() error {
 		op.handlerReady = false
 		op.handlerLock.Unlock()
 
-		// Attempt to reconnect and resume monitoring.
-		for range 5 {
+		// Attempt to reconnect, giving up after 30 seconds of continuous failure.
+		deadline := time.Now().Add(30 * time.Second)
+		for time.Now().Before(deadline) {
 			err := op.setupListener()
 			if err == nil {
 				return
@@ -354,13 +356,30 @@ func (op *operation) setupListener() error {
 				break
 			}
 
+			// Fall back to polling the operation in case events remain unavailable.
+			op.handlerLock.Lock()
+			err = op.Refresh()
+			if err == nil {
+				// The operation is still reachable, keep trying.
+				deadline = time.Now().Add(30 * time.Second)
+
+				if op.StatusCode.IsFinal() {
+					op.closeChActive()
+					op.handlerLock.Unlock()
+
+					return
+				}
+			}
+
+			op.handlerLock.Unlock()
+
 			time.Sleep(2 * time.Second)
 		}
 
 		// Reconnection failed, report the original error.
 		op.handlerLock.Lock()
 		if !op.handlerReady {
-			op.Err = listener.err.Error()
+			op.Err = fmt.Sprintf("Lost connection to the event listener and failed to reconnect: %v", listener.err)
 			op.closeChActive()
 		}
 

--- a/cmd/incusd/api_cluster_evacuation.go
+++ b/cmd/incusd/api_cluster_evacuation.go
@@ -189,10 +189,61 @@ func evacuateMigrateInstance(r *http.Request) evacuateMigrateFunc {
 	}
 }
 
+// evacuateWaitForCreations waits for local instance creation operations to complete.
+func evacuateWaitForCreations(ctx context.Context, op *operations.Operation) error {
+	lastCount := -1
+
+	for {
+		count := 0
+		for _, localOp := range operations.Clone() {
+			if localOp.Type() == operationtype.InstanceCreate && !localOp.Status().IsFinal() {
+				count++
+			}
+		}
+
+		if count == 0 {
+			return nil
+		}
+
+		if op != nil && count != lastCount {
+			lastCount = count
+			_ = op.ExtendMetadata(map[string]any{"evacuation_progress": fmt.Sprintf("Waiting for %d instance creation operations to complete", count)})
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+}
+
 func evacuateClusterMember(ctx context.Context, s *state.State, op *operations.Operation, name string, mode string, stopInstance evacuateStopFunc, migrateInstance evacuateMigrateFunc) error {
+	// Setup a reverter.
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	// Set cluster member status to EVACUATING to prevent any new instance from being placed on it.
+	err := evacuateClusterSetState(s, name, db.ClusterMemberStateEvacuating)
+	if err != nil {
+		return err
+	}
+
+	reverter.Add(func() {
+		_ = evacuateClusterSetState(s, name, db.ClusterMemberStateCreated)
+	})
+
+	// Wait for ongoing instance creations to complete (skipped when healing an offline member).
+	if mode != "heal" {
+		err = evacuateWaitForCreations(ctx, op)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Get the instance list for the server being evacuated.
 	var dbInstances []dbCluster.Instance
-	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		dbInstances, err = dbCluster.GetInstances(ctx, tx.Tx(), dbCluster.InstanceFilter{Node: &name})
@@ -216,20 +267,6 @@ func evacuateClusterMember(ctx context.Context, s *state.State, op *operations.O
 
 		instances[i] = inst
 	}
-
-	// Setup a reverter.
-	reverter := revert.New()
-	defer reverter.Fail()
-
-	// Set cluster member status to EVACUATING.
-	err = evacuateClusterSetState(s, name, db.ClusterMemberStateEvacuating)
-	if err != nil {
-		return err
-	}
-
-	reverter.Add(func() {
-		_ = evacuateClusterSetState(s, name, db.ClusterMemberStateCreated)
-	})
 
 	// Perform the evacuation.
 	opts := evacuateOpts{

--- a/cmd/incusd/api_cluster_evacuation.go
+++ b/cmd/incusd/api_cluster_evacuation.go
@@ -7,8 +7,10 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -304,29 +306,47 @@ func evacuateClusterMember(ctx context.Context, s *state.State, op *operations.O
 	return nil
 }
 
+// concurrentInstanceActions runs fn on every instance with bounded concurrency.
+// Each instance runs to completion regardless of other failures, all of which are reported at the end.
+func concurrentInstanceActions(instances []instance.Instance, prefix string, fn func(inst instance.Instance) error) error {
+	group := errgroup.Group{}
+	group.SetLimit(max(runtime.NumCPU()/16, 1))
+
+	var failuresLock sync.Mutex
+	failures := []string{}
+
+	for _, inst := range instances {
+		group.Go(func() error {
+			err := fn(inst)
+			if err != nil {
+				failuresLock.Lock()
+				failures = append(failures, fmt.Sprintf("%s/%s: %v", inst.Project().Name, inst.Name(), err))
+				failuresLock.Unlock()
+			}
+
+			return nil
+		})
+	}
+
+	_ = group.Wait()
+
+	if len(failures) > 0 {
+		sort.Strings(failures)
+
+		return fmt.Errorf("%s:\n - %s", prefix, strings.Join(failures, "\n - "))
+	}
+
+	return nil
+}
+
 func evacuateInstances(ctx context.Context, opts evacuateOpts) error {
 	if opts.migrateInstance == nil {
 		return errors.New("Missing migration callback function")
 	}
 
-	// Limit the number of concurrent evacuations to run at the same time
-	numParallelEvacs := max(runtime.NumCPU()/16, 1)
-
-	group, groupCtx := errgroup.WithContext(ctx)
-	group.SetLimit(numParallelEvacs)
-
-	for _, inst := range opts.instances {
-		group.Go(func() error {
-			return evacuateInstancesFunc(groupCtx, inst, opts)
-		})
-	}
-
-	err := group.Wait()
-	if err != nil {
-		return fmt.Errorf("Failed to evacuate instances: %w", err)
-	}
-
-	return nil
+	return concurrentInstanceActions(opts.instances, "Failed to evacuate instances", func(inst instance.Instance) error {
+		return evacuateInstancesFunc(ctx, inst, opts)
+	})
 }
 
 func evacuateInstancesFunc(ctx context.Context, inst instance.Instance, opts evacuateOpts) error {
@@ -531,22 +551,12 @@ func restoreClusterMember(d *Daemon, r *http.Request, skipInstances bool) respon
 			}
 		}
 
-		// Limit the number of concurrent migrations to run at the same time
-		numParallelMigrations := max(runtime.NumCPU()/16, 1)
-
-		group := &errgroup.Group{}
-		group.SetLimit(numParallelMigrations)
-
 		// Migrate back the remote instances.
-		for _, inst := range instances {
-			group.Go(func() error {
-				return restoreClusterMemberFunc(inst, op, originName, r, s)
-			})
-		}
-
-		err = group.Wait()
+		err = concurrentInstanceActions(instances, "Failed to restore instances", func(inst instance.Instance) error {
+			return restoreClusterMemberFunc(inst, op, originName, r, s)
+		})
 		if err != nil {
-			return fmt.Errorf("Failed to restore instances: %w", err)
+			return err
 		}
 
 		// Set node status to CREATED.

--- a/cmd/incusd/instance_post.go
+++ b/cmd/incusd/instance_post.go
@@ -1037,9 +1037,11 @@ func migrateInstance(ctx context.Context, s *state.State, inst instance.Instance
 			return fmt.Errorf("Instance move to destination failed on source: %w", err)
 		}
 
-		err = destOp.Wait()
-		if err != nil {
-			return fmt.Errorf("Instance move to destination failed: %w", err)
+		// A live migration on the same shared storage is handed over once the source succeeds,
+		// so the database record must follow the instance even if the destination reported an error.
+		destErr := destOp.Wait()
+		if destErr != nil && (!req.Live || !sourcePool.Driver().Info().Remote || req.Pool != "") {
+			return fmt.Errorf("Instance move to destination failed: %w", destErr)
 		}
 
 		// Update the database post-migration.
@@ -1160,6 +1162,10 @@ func migrateInstance(ctx context.Context, s *state.State, inst instance.Instance
 			if err != nil {
 				return fmt.Errorf("Failed starting instance on target member: %w", err)
 			}
+		}
+
+		if destErr != nil {
+			return fmt.Errorf("Instance moved to %q but destination reported an error: %w", targetMemberInfo.Name, destErr)
 		}
 	}
 

--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -804,6 +804,10 @@ func createFromCopy(ctx context.Context, s *state.State, r *http.Request, projec
 }
 
 func createFromBackup(s *state.State, r *http.Request, projectName string, data io.Reader, pool string, instanceName string, config string, device string) response.Response {
+	if s.ServerClustered && s.DB.Cluster.LocalNodeIsEvacuated() {
+		return response.Forbidden(errors.New("Cluster member is evacuated"))
+	}
+
 	reverter := revert.New()
 	defer reverter.Fail()
 

--- a/cmd/incusd/instances_put.go
+++ b/cmd/incusd/instances_put.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/incus/v7/internal/server/auth"
 	"github.com/lxc/incus/v7/internal/server/cluster"
 	"github.com/lxc/incus/v7/internal/server/db"
+	dbCluster "github.com/lxc/incus/v7/internal/server/db/cluster"
 	"github.com/lxc/incus/v7/internal/server/instance"
 	"github.com/lxc/incus/v7/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v7/internal/server/operations"
@@ -85,6 +86,16 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 	<-d.waitReady.Done()
 
 	s := d.State()
+
+	// Ensure the project exists.
+	err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+
+		return err
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
 
 	c, err := instance.LoadNodeAll(s, instancetype.Any)
 	if err != nil {

--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -28,6 +28,7 @@ import (
 	deviceConfig "github.com/lxc/incus/v7/internal/server/device/config"
 	"github.com/lxc/incus/v7/internal/server/device/nictype"
 	"github.com/lxc/incus/v7/internal/server/instance"
+	"github.com/lxc/incus/v7/internal/server/instance/drivers/qemudefault"
 	"github.com/lxc/incus/v7/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v7/internal/server/instance/operationlock"
 	"github.com/lxc/incus/v7/internal/server/lifecycle"
@@ -1657,19 +1658,43 @@ func (d *common) balanceNUMANodes() error {
 		}
 	}
 
+	numaNodesToUse := 1
 	if err == nil && limitsCPU > cpusPerNumaNode {
-		numaNodesToUse := int(math.Ceil(float64(limitsCPU) / float64(cpusPerNumaNode)))
-
-		selectedNumaNodes := make([]string, numaNodesToUse)
-		for i, node := range nodes[:numaNodesToUse] {
-			selectedNumaNodes[i] = strconv.FormatUint(node, 10)
-		}
-
-		joinedNumaNodes := strings.Join(selectedNumaNodes, ",")
-		return d.VolatileSet(map[string]string{"volatile.cpu.nodes": joinedNumaNodes})
+		numaNodesToUse = int(math.Ceil(float64(limitsCPU) / float64(cpusPerNumaNode)))
 	}
 
-	return d.VolatileSet(map[string]string{"volatile.cpu.nodes": fmt.Sprintf("%d", nodes[0])})
+	// Similarly, if the effective memory limit is greater than the amount of memory per NUMA node,
+	// use as many NUMA nodes as needed to fit it.
+	limitsMemoryStr := conf["limits.memory"]
+	if limitsMemoryStr == "" {
+		limitsMemoryStr = qemudefault.MemSize
+	}
+
+	limitsMemory, memoryErr := ParseMemoryStr(limitsMemoryStr)
+	defaultMemory, _ := ParseMemoryStr(qemudefault.MemSize)
+
+	// Never split anything at or below the default memory size.
+	if memoryErr == nil && limitsMemory > defaultMemory && len(nodes) > 0 {
+		memory, err := resources.GetMemory()
+		if err != nil {
+			return err
+		}
+
+		memoryPerNumaNode := int64(memory.Total) / int64(len(nodes))
+		if memoryPerNumaNode > 0 && limitsMemory > memoryPerNumaNode {
+			numaNodesToUse = max(numaNodesToUse, int(math.Ceil(float64(limitsMemory)/float64(memoryPerNumaNode))))
+		}
+	}
+
+	// Cap at the number of available NUMA nodes.
+	numaNodesToUse = min(numaNodesToUse, len(nodes))
+
+	selectedNumaNodes := make([]string, numaNodesToUse)
+	for i, node := range nodes[:numaNodesToUse] {
+		selectedNumaNodes[i] = strconv.FormatUint(node, 10)
+	}
+
+	return d.VolatileSet(map[string]string{"volatile.cpu.nodes": strings.Join(selectedNumaNodes, ",")})
 }
 
 // Gets the process starting time.

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -3425,8 +3425,11 @@ func (d *lxc) Stop(stateful bool) error {
 
 	err = cc.Stop()
 	if err != nil {
-		op.Done(err)
-		return err
+		// Only fail while the container is still running, it may have finished stopping on its own.
+		if d.IsRunning() {
+			op.Done(err)
+			return err
+		}
 	}
 
 	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1023,13 +1023,14 @@ func (d *qemu) restoreStateHandle(ctx context.Context, monitor *qmp.Monitor, f *
 
 	err = monitor.MigrateIncoming(ctx, "migration")
 	if err != nil {
-		if errors.Is(err, qmp.ErrMonitorDisconnect) && util.PathExists(d.LogFilePath()) {
-			qemuError, err := os.ReadFile(d.LogFilePath())
-			if err != nil {
-				return err
+		if errors.Is(err, qmp.ErrMonitorDisconnect) {
+			// Crash output goes to stderr (early log), -D only captures QEMU's internal logging.
+			qemuError, readErr := os.ReadFile(d.EarlyLogFilePath())
+			if readErr != nil || len(strings.TrimSpace(string(qemuError))) == 0 {
+				qemuError, _ = os.ReadFile(d.LogFilePath())
 			}
 
-			return fmt.Errorf("QEMU crashed on VM restore: %s", string(qemuError))
+			return fmt.Errorf("QEMU crashed on VM restore: %s", strings.TrimSpace(string(qemuError)))
 		}
 
 		return err

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -8313,6 +8313,9 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 
 	g, ctx := errgroup.WithContext(context.Background())
 
+	// Tracks whether a live cluster move completed the state hand-over to the target.
+	committed := false
+
 	// Start control connection monitor.
 	g.Go(func() error {
 		d.logger.Debug("Migrate send control monitor started")
@@ -8375,7 +8378,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 				defer instanceRefClear(d)
 			}
 
-			err = d.migrateSendLive(ctx, pool, args.ClusterMoveSourceName, args.StoragePool, blockSize, filesystemConn, stateConn, volSourceArgs)
+			err = d.migrateSendLive(ctx, pool, args.ClusterMoveSourceName, args.StoragePool, blockSize, filesystemConn, stateConn, volSourceArgs, &committed)
 			if err != nil {
 				return err
 			}
@@ -8401,8 +8404,13 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 	{
 		err := g.Wait()
 		if err != nil {
-			op.Done(err)
-			return err
+			if !committed {
+				op.Done(err)
+				return err
+			}
+
+			// Post hand-over errors can't undo the migration, rely on the target's own result instead.
+			d.logger.Warn("Ignoring migration error received after hand-over", logger.Ctx{"err": err})
 		}
 
 		op.Done(nil)
@@ -8718,7 +8726,7 @@ func (d *qemu) sendMigrationSnapshot(diskName string, filesystemConn io.ReadWrit
 }
 
 // migrateSendLive performs live migration send process.
-func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clusterMoveSourceName string, storagePool string, rootDiskSize int64, filesystemConn io.ReadWriteCloser, stateConn io.ReadWriteCloser, volSourceArgs *localMigration.VolumeSourceArgs) error {
+func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clusterMoveSourceName string, storagePool string, rootDiskSize int64, filesystemConn io.ReadWriteCloser, stateConn io.ReadWriteCloser, volSourceArgs *localMigration.VolumeSourceArgs, committed *bool) error {
 	monitor, err := d.qmpConnect()
 	if err != nil {
 		return err
@@ -8740,6 +8748,7 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 	dependentVolumeMove := clusterMoveSourceName != "" && disksToMigrate
 
 	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Non-shared storage snapshot setup.
 	if !sameSharedStorage || dependentVolumeMove {
@@ -8908,6 +8917,12 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 		return fmt.Errorf("Failed starting state transfer to target: %w", err)
 	}
 
+	// On failure, cancel the migration and resume the guest.
+	reverter.Add(func() {
+		_ = monitor.MigrateCancel()
+		_ = monitor.Start()
+	})
+
 	// Start monitoring the migration progress.
 	chMonitor := make(chan bool, 1)
 
@@ -9002,12 +9017,24 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 
 	d.logger.Debug("Stateful migration checkpoint send finished")
 
+	// The state hand-over is complete, past this point the migration can no longer be reverted.
+	if clusterMoveSourceName != "" {
+		*committed = true
+	}
+
+	reverter.Success()
+
 	if clusterMoveSourceName != "" {
 		// If doing an intra-cluster member move then we will be deleting the instance on the source,
 		// so lets just stop it after migration is completed.
 		err = d.Stop(false)
 		if err != nil {
-			return fmt.Errorf("Failed stopping instance: %w", err)
+			d.logger.Warn("Failed stopping instance after hand-over, forcing stop", logger.Ctx{"err": err})
+
+			err = d.forceStop()
+			if err != nil {
+				return fmt.Errorf("Failed stopping instance: %w", err)
+			}
 		}
 	} else {
 		// Resume guest.
@@ -9018,8 +9045,6 @@ func (d *qemu) migrateSendLive(ctx context.Context, pool storagePools.Pool, clus
 
 		d.logger.Debug("Resumed instance")
 	}
-
-	reverter.Success()
 
 	return nil
 }

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -572,6 +572,11 @@ func (m *Monitor) MigrateWait(ctx context.Context, state string) error {
 	}
 }
 
+// MigrateCancel cancels an ongoing migration.
+func (m *Monitor) MigrateCancel() error {
+	return m.Run("migrate_cancel", nil, nil)
+}
+
 // MigrateContinue continues a migration stream.
 func (m *Monitor) MigrateContinue(fromState string) error {
 	var args struct {


### PR DESCRIPTION
This is a collection of fixes from a recent set of tests auto-evacuating a very busy lab environment. The fixes basically cover:
 - Harden the client reconnection as it occasionally still disconnected
 - Handle a race where a clean shutdown completes before the forced shutdown fully runs
 - Make sure no instance creation can occur while evacuating/evacuated
 - Drain all ongoing instance creations prior to evacuating a server
 - Improve migration received errors (QEMU)
 - Improve NUMA placement when nodes are short on memory
 - Cleanup error on missing project during bulk instance state operations
 - Don't cancel ongoing evacuations at the first sign of failure, let the ongoing ones complete, then fail
 - Correctly record instance location once QEMU has resumed on target