### PR TITLE
Fix discard alignment issue in VM due to QCOW2 bitmap layer

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -5588,6 +5588,16 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 					blockDevFile["driver"] = "file"
 				}
 
+				// Advertise the cluster size as discard granularity as qcow2 drops partial cluster discards.
+				imgInfo, err := storageDrivers.Qcow2Info(srcDevPath)
+				if err != nil {
+					return fmt.Errorf("Failed getting qcow2 info for disk device %q: %w", driveConf.DevName, err)
+				}
+
+				if imgInfo.ClusterSize > 0 {
+					qemuDev["discard_granularity"] = imgInfo.ClusterSize
+				}
+
 				blockDev = map[string]any{
 					"driver":    "qcow2",
 					"discard":   "unmap", // Forward as an unmap request. This is the same as `discard=on` in the qemu config file.

--- a/internal/server/storage/drivers/utils_qcow2.go
+++ b/internal/server/storage/drivers/utils_qcow2.go
@@ -48,6 +48,7 @@ type ImageInfo struct {
 	BackingFilename string         `json:"backing-filename"`
 	Format          string         `json:"format"`
 	VirtualSize     int            `json:"virtual-size"`
+	ClusterSize     int            `json:"cluster-size"`
 	FormatSpecific  FormatSpecific `json:"format-specific"`
 }
 


### PR DESCRIPTION
Our use of a QCOW2 layer for bitmap tracking causes QEMU to use 64k aligned chunks for discard. We weren't communicating that to the guest leading to misaligned requests that QEMU would then just drop.

In the worst case this was causing IncusOS to fallback to a full zeroing of the entire 50GiB+ drive rather than a single discard request.