### PR TITLE
Set PKCE challenge and verifier values

### DIFF
--- a/client/incus_oidc.go
+++ b/client/incus_oidc.go
@@ -3,6 +3,7 @@ package incus
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -63,6 +64,7 @@ type oidcTransport struct {
 	deviceAuthorizationEndpoint string
 	tokenEndpoint               string
 	audience                    string
+	codeVerifier                string
 }
 
 // Transport returns the underlying *http.Transport used for the Incus server.
@@ -99,6 +101,10 @@ func (o *oidcTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	if isDeviceAuthorization && o.audience != "" {
 		r.Form.Add("audience", o.audience)
+	}
+
+	if isToken && o.codeVerifier != "" {
+		r.Form.Set("code_verifier", o.codeVerifier)
 	}
 
 	// Drop empty parameters as some providers reject an empty client_secret.
@@ -333,7 +339,24 @@ func (o *oidcClient) authenticate(issuer string, clientID string, audience strin
 	o.oidcTransport.deviceAuthorizationEndpoint = provider.GetDeviceAuthorizationEndpoint()
 	o.oidcTransport.tokenEndpoint = provider.OAuthConfig().Endpoint.TokenURL
 
-	resp, err := rp.DeviceAuthorization(context.TODO(), strings.Split(scopes, ","), provider, nil)
+	var authFn httphelper.FormAuthorization
+
+	if provider.IsPKCE() {
+		codeVerifierBytes := make([]byte, 32)
+		_, err = rand.Read(codeVerifierBytes)
+		if err != nil {
+			return err
+		}
+
+		o.oidcTransport.codeVerifier = base64.RawURLEncoding.EncodeToString(codeVerifierBytes)
+
+		authFn = func(form url.Values) {
+			form.Set("code_challenge", oidc.NewSHACodeChallenge(o.oidcTransport.codeVerifier))
+			form.Set("code_challenge_method", "S256")
+		}
+	}
+
+	resp, err := rp.DeviceAuthorization(context.TODO(), strings.Split(scopes, ","), provider, authFn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds the required `code_challenge` and `code_verifier` values for clients that are set to require PKCE.

The `zitadel/oidc` package does not have built-in support as its potentially not providing any additional security for the device flow, more details here:
- https://github.com/zitadel/oidc/issues/784

I've tested on:
- `Keycloak 26.6.1` with `Require PKCE` both enabled and disabled and `Method` set to `S256`.
- `Rauthy v0.36.2` with `PKCE` set to `S256`.

I assume we don't want to support the `plain` method type.

Also note, `provider.IsPKCE()` only identifies if PKCE is supported, not necessarily required, so it should be safe to send the values in that case.
