### PR TITLE
incus: Remove url escape for spice socket path.

### DIFF
--- a/cmd/incus/console.go
+++ b/cmd/incus/console.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/fs"
 	"net"
-	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -341,12 +340,7 @@ func (c *cmdConsole) vga(d incus.InstanceServer, name string) error {
 			return err
 		}, "Failed to remove temporary file")
 
-		spiceURL := &url.URL{
-			Scheme: "spice+unix",
-			Path:   path.Name(),
-		}
-
-		socket = spiceURL.String()
+		socket = fmt.Sprintf("spice+unix://%s", path.Name())
 	} else {
 		listener, err = net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {


### PR DESCRIPTION
On macOS, the spice socket path is wrongly url escaped which leads to `%20` within the file path.
This PR addresses it.