### PR TITLE
incus/device: Set NVIDIA device UUIDs for physical GPUs

### DIFF
--- a/internal/server/device/gpu_physical.go
+++ b/internal/server/device/gpu_physical.go
@@ -226,6 +226,17 @@ func (d *gpuPhysical) startContainer() (*deviceConfig.RunConfig, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			if util.IsTrue(d.inst.ExpandedConfig()["nvidia.runtime"]) {
+				if gpu.Nvidia.UUID == "" {
+					return nil, fmt.Errorf("NVIDIA GPU %q is missing its UUID", gpu.PCIAddress)
+				}
+
+				runConf.GPUDevice = append(runConf.GPUDevice, deviceConfig.RunConfigItem{
+					Key:   GPUNvidiaDeviceKey,
+					Value: gpu.Nvidia.UUID,
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

When `nvidia.runtime=true` is used with a physical NVIDIA GPU device, Incus passes the `/dev/nvidia*` devices through but doesn't add the selected GPU UUID to `runConf.GPUDevice`.

As a result, the NVIDIA LXC hook keeps its initial `NVIDIA_VISIBLE_DEVICES=none` value and doesn't expose GPU-specific `/proc/driver/nvidia/gpus/*` entries.

This patch makes physical NVIDIA GPU devices emit the selected GPU UUID using the existing `GPUNvidiaDeviceKey`, matching the mechanism already used for MIG devices.

The UUID is only required/emitted when `nvidia.runtime=true`, so ordinary physical GPU passthrough without the NVIDIA runtime remains unchanged.

I believe this change will fix issues faced by users in for example this thread: https://discuss.linuxcontainers.org/t/nvidia-gpu-seems-not-complete/19012

## Testing

Tested with a Quadro P400 on an Incus system using a physical GPU device and `nvidia.runtime=true`.

Before this change:
- `/dev/nvidia0` was present
- `/proc/driver/nvidia/gpus` was empty
- the NVIDIA hook received `NVIDIA_VISIBLE_DEVICES=none`

After this change:
- the hook receives the selected `GPU-...` UUID
- `/proc/driver/nvidia/gpus/0000:05:00.0` is present