### PR TITLE
internal/server/instance/drivers: Publish migration errors before completion

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -7001,9 +7001,9 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 	}()
 
 	// Start filesystem transfer routine and initialize a channel that is closed when the routine finishes.
-	fsTransferDone := make(chan struct{})
-	g.Go(func() error {
-		defer close(fsTransferDone)
+	fsTransfer := &migrationReceiveTransfer{done: make(chan struct{})}
+	g.Go(func() (retErr error) {
+		defer func() { fsTransfer.complete(retErr) }()
 
 		d.logger.Debug("Migrate receive filesystem transfer started")
 		defer d.logger.Debug("Migrate receive filesystem transfer finished")
@@ -7171,13 +7171,13 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 	// Start live state transfer routine (if required) and initialize a channel that is closed when the
 	// routine finishes. It is never closed if the routine is not started.
-	stateTransferDone := make(chan struct{})
+	stateTransfer := &migrationReceiveTransfer{done: make(chan struct{})}
 	if args.Live {
-		g.Go(func() error {
+		g.Go(func() (retErr error) {
 			d.logger.Debug("Migrate receive state transfer started")
 			defer d.logger.Debug("Migrate receive state transfer finished")
 
-			defer close(stateTransferDone)
+			defer func() { stateTransfer.complete(retErr) }()
 
 			imagesDir, err := os.MkdirTemp("", "incus_restore_")
 			if err != nil {
@@ -7249,10 +7249,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			}
 
 			// Wait until filesystem transfer is done before starting final state sync and restore.
-			<-fsTransferDone
-
-			// But only proceed if no errors have occurred thus far.
-			err = ctx.Err()
+			err = fsTransfer.wait(ctx)
 			if err != nil {
 				return err
 			}
@@ -7281,14 +7278,14 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 	{
 		// Wait until the filesystem transfer and state transfer routines have finished.
-		<-fsTransferDone
+		fsTransferErr := fsTransfer.wait(ctx)
+		var stateTransferErr error
 		if args.Live {
-			<-stateTransferDone
+			stateTransferErr = stateTransfer.wait(ctx)
 		}
 
-		// If context is cancelled by this stage, then an error has occurred.
-		// Wait for all routines to finish and collect the first error that occurred.
-		if ctx.Err() != nil {
+		// Completion can precede errgroup cancellation, so also check the published results.
+		if fsTransferErr != nil || stateTransferErr != nil || ctx.Err() != nil {
 			err := g.Wait()
 
 			// Send failure response to source.

--- a/internal/server/instance/drivers/migration_receive.go
+++ b/internal/server/instance/drivers/migration_receive.go
@@ -1,0 +1,27 @@
+//go:build linux && cgo && !agent
+
+package drivers
+
+import (
+	"context"
+)
+
+// migrationReceiveTransfer publishes the result before notifying all waiting receivers.
+type migrationReceiveTransfer struct {
+	done chan struct{}
+	err  error
+}
+
+func (t *migrationReceiveTransfer) complete(err error) {
+	t.err = err
+	close(t.done)
+}
+
+func (t *migrationReceiveTransfer) wait(ctx context.Context) error {
+	<-t.done
+	if t.err != nil {
+		return t.err
+	}
+
+	return ctx.Err()
+}

--- a/internal/server/instance/drivers/migration_receive_test.go
+++ b/internal/server/instance/drivers/migration_receive_test.go
@@ -1,0 +1,49 @@
+//go:build linux && cgo && !agent
+
+package drivers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestMigrationReceiveTransferErrorBeforeCancellation(t *testing.T) {
+	want := errors.New("transfer failed")
+	transfer := &migrationReceiveTransfer{done: make(chan struct{})}
+	group, ctx := errgroup.WithContext(context.Background())
+	allowReturn := make(chan struct{})
+	defer func() {
+		close(allowReturn)
+		require.ErrorIs(t, group.Wait(), want)
+	}()
+	results := make(chan error, 2)
+	for range 2 {
+		go func() { results <- transfer.wait(ctx) }()
+	}
+
+	group.Go(func() (retErr error) {
+		defer func() { <-allowReturn }()
+		defer func() { transfer.complete(retErr) }()
+		return want
+	})
+
+	// Both the restore worker and the final response must see errors before errgroup does.
+	for range 2 {
+		require.ErrorIs(t, <-results, want)
+		require.NoError(t, ctx.Err())
+	}
+}
+
+func TestMigrationReceiveTransferSuccess(t *testing.T) {
+	transfer := &migrationReceiveTransfer{done: make(chan struct{})}
+	transfer.complete(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, transfer.wait(ctx))
+	cancel()
+	require.ErrorIs(t, transfer.wait(ctx), context.Canceled)
+}


### PR DESCRIPTION
The filesystem/state workers close their completion channels in a defer, before `errgroup` sees their returned error and cancels its context. A waiter can therefore observe completion and an uncancelled context after a failed transfer, start CRIU restore, or send a successful migration response.

Publish each transfer result before closing its completion channel. Check that result both before restore and before the final response; retain the context check for control-monitor errors. The regression test holds the worker between publishing completion and returning to `errgroup`, with two concurrent waiters, so the failure window is deterministic and needs no timing assumptions.

Validation: focused tests with the race detector, `go test -v ./...`, and `make static-analysis`.
